### PR TITLE
Table header-drag element hidden if scss theme used

### DIFF
--- a/client/src/com/vaadin/client/ui/VScrollTable.java
+++ b/client/src/com/vaadin/client/ui/VScrollTable.java
@@ -2433,6 +2433,8 @@ public class VScrollTable extends FlowPanel implements HasWidgets,
         Element colResizeWidget = DOM.createDiv();
 
         Element floatingCopyOfHeaderCell;
+        
+        Element floatingThemeDiv;
 
         private boolean sortable = false;
         private final String cid;
@@ -2729,6 +2731,8 @@ public class VScrollTable extends FlowPanel implements HasWidgets,
         }
 
         private void createFloatingCopy() {
+            floatingThemeDiv = DOM.createDiv();
+            floatingThemeDiv.setClassName(client.getConfiguration().getThemeName());
             floatingCopyOfHeaderCell = DOM.createDiv();
             DOM.setInnerHTML(floatingCopyOfHeaderCell, DOM.getInnerHTML(td));
             floatingCopyOfHeaderCell = DOM
@@ -2739,8 +2743,9 @@ public class VScrollTable extends FlowPanel implements HasWidgets,
             DOM.setStyleAttribute(floatingCopyOfHeaderCell, "width", "auto");
             updateFloatingCopysPosition(DOM.getAbsoluteLeft(td),
                     DOM.getAbsoluteTop(td));
+            DOM.appendChild(floatingThemeDiv, floatingCopyOfHeaderCell);
             DOM.appendChild(RootPanel.get().getElement(),
-                    floatingCopyOfHeaderCell);
+                    floatingThemeDiv);
         }
 
         private void updateFloatingCopysPosition(int x, int y) {
@@ -2755,8 +2760,9 @@ public class VScrollTable extends FlowPanel implements HasWidgets,
 
         private void hideFloatingCopy() {
             DOM.removeChild(RootPanel.get().getElement(),
-                    floatingCopyOfHeaderCell);
+                    floatingThemeDiv);
             floatingCopyOfHeaderCell = null;
+            floatingThemeDiv = null;
         }
 
         /**


### PR DESCRIPTION
If I use SCSS theme based on reindeer then header-drag element does not appear.
Сause: header-drag element does not have parent element with classname equals theme name.
