### PR TITLE
Minor MenuBar and TabSheet enhancement...

### DIFF
--- a/server/src/com/vaadin/server/VaadinPortlet.java
+++ b/server/src/com/vaadin/server/VaadinPortlet.java
@@ -263,6 +263,18 @@ public class VaadinPortlet extends GenericPortlet implements Constants,
 
     }
 
+    @Override
+    public void destroy() {
+    	// perform vaadin portlet-specific destroy actions...
+    	
+    	// allow subclass to get into the destroy...
+    	portletDestroyed();
+    }
+    
+    protected void portletDestroyed() {
+    	
+    }
+    
     protected DeploymentConfiguration createDeploymentConfiguration(
             Properties initParameters) {
         return new DefaultDeploymentConfiguration(getClass(), initParameters);

--- a/server/src/com/vaadin/ui/MenuBar.java
+++ b/server/src/com/vaadin/ui/MenuBar.java
@@ -220,7 +220,7 @@ public class MenuBar extends AbstractComponent implements LegacyComponent {
         if (caption == null) {
             throw new IllegalArgumentException("caption cannot be null");
         }
-        MenuItem newItem = new MenuItem(caption, icon, command);
+        MenuItem newItem = createMenuItem(caption, icon, command);
         menuItems.add(newItem);
         markAsDirty();
 
@@ -228,6 +228,20 @@ public class MenuBar extends AbstractComponent implements LegacyComponent {
 
     }
 
+    /**
+     * createMenuItem: Override point to allow subclasses to instantiate the MenuItem instance.
+     * @param caption
+     *            the text for the menu item
+     * @param icon
+     *            the icon for the menu item
+     * @param command
+     *            the command for the menu item
+     * @return MenuItem The new menu item instance.
+     */
+    protected MenuBar.MenuItem createMenuItem(final String caption, final Resource icon, final MenuBar.Command command) {
+    	return new MenuItem(caption, icon, command);
+    }
+    
     /**
      * Add an item before some item. If the given item does not exist the item
      * is added at the end of the menu. Icon and command can be null, but a
@@ -249,7 +263,7 @@ public class MenuBar extends AbstractComponent implements LegacyComponent {
             throw new IllegalArgumentException("caption cannot be null");
         }
 
-        MenuItem newItem = new MenuItem(caption, icon, command);
+        MenuItem newItem = createMenuItem(caption, icon, command);
         if (menuItems.contains(itemToAddBefore)) {
             int index = menuItems.indexOf(itemToAddBefore);
             menuItems.add(index, newItem);
@@ -315,7 +329,7 @@ public class MenuBar extends AbstractComponent implements LegacyComponent {
         if (item != null) {
             moreItem = item;
         } else {
-            moreItem = new MenuItem("", null, null);
+            moreItem = createMenuItem("", null, null);
         }
         markAsDirty();
     }
@@ -514,7 +528,7 @@ public class MenuBar extends AbstractComponent implements LegacyComponent {
                 itsChildren = new ArrayList<MenuItem>();
             }
 
-            MenuItem newItem = new MenuItem(caption, icon, command);
+            MenuItem newItem = createMenuItem(caption, icon, command);
 
             // The only place where the parent is set
             newItem.setParent(this);
@@ -525,6 +539,20 @@ public class MenuBar extends AbstractComponent implements LegacyComponent {
             return newItem;
         }
 
+        /**
+         * createMenuItem: Override point for subclasses to handle the creation of the menu item.
+         * @param caption
+         *            the text for the menu item
+         * @param icon
+         *            the icon for the menu item
+         * @param command
+         *            the command for the menu item
+         * @return MenuItem The new MenuItem instance.
+         */
+        protected MenuBar.MenuItem createMenuItem(final String caption, final Resource icon, final MenuBar.Command command) {
+        	return new MenuItem(caption, icon, command);
+        }
+        
         /**
          * Add an item before some item. If the given item does not exist the
          * item is added at the end of the menu. Icon and command can be null,
@@ -552,7 +580,7 @@ public class MenuBar extends AbstractComponent implements LegacyComponent {
 
             if (hasChildren() && itsChildren.contains(itemToAddBefore)) {
                 int index = itsChildren.indexOf(itemToAddBefore);
-                newItem = new MenuItem(caption, icon, command);
+                newItem = createMenuItem(caption, icon, command);
                 newItem.setParent(this);
                 itsChildren.add(index, newItem);
             } else {

--- a/server/src/com/vaadin/ui/TabSheet.java
+++ b/server/src/com/vaadin/ui/TabSheet.java
@@ -304,7 +304,7 @@ public class TabSheet extends AbstractComponentContainer implements Focusable,
         } else {
             components.add(position, c);
 
-            Tab tab = new TabSheetTabImpl(caption, icon);
+            Tab tab = createTab(caption, icon);
 
             tabs.put(c, tab);
             if (selected == null) {
@@ -317,6 +317,20 @@ public class TabSheet extends AbstractComponentContainer implements Focusable,
         }
     }
 
+    /**
+     * createTab: Override point to allow subclasses to create the tab implementation.
+     * @param caption
+     *            the caption to be set for the component and used rendered in
+     *            tab bar
+     * @param icon
+     *            the icon to be set for the component and used rendered in tab
+     *            bar
+     * @return Tab The new tab instance.
+     */
+    protected Tab createTab(final String caption, final Resource icon) {
+    	return new TabSheetTabImpl(caption, icon);
+    }
+    
     /**
      * Adds a new tab into TabSheet. Component caption and icon are copied to
      * the tab metadata at creation time.
@@ -715,7 +729,7 @@ public class TabSheet extends AbstractComponentContainer implements Focusable,
             // Tab associations are not changed, but metadata is swapped between
             // the instances
             // TODO Should reassociate the instances instead?
-            Tab tmp = new TabSheetTabImpl(null, null);
+            Tab tmp = createTab(null, null);
             copyTabMetadata(newTab, tmp);
             copyTabMetadata(oldTab, newTab);
             copyTabMetadata(tmp, oldTab);
@@ -1307,7 +1321,7 @@ public class TabSheet extends AbstractComponentContainer implements Focusable,
      * @param to
      *            The tab to which copy the data.
      */
-    private static void copyTabMetadata(Tab from, Tab to) {
+    protected void copyTabMetadata(Tab from, Tab to) {
         to.setCaption(from.getCaption());
         to.setIcon(from.getIcon());
         to.setDescription(from.getDescription());


### PR DESCRIPTION
I have been working on i18n support in Vaadin widgets by extending the Vaadin classes and using the incoming captions as resource bundle keys.

In most respects this works like a charm.

The exception is the MenuBar and TabSheet classes.  In their addXxx() methods, they internally instantiate instances of internal classes.  In order to subclass these objects, I must replace the body of the addXxx() methods completely, thus risking compatibility with future Vaadin releases.

By moving the instantiation to separate createMenuItem() and createTab() methods, I could easily subclass MenuBar and TabSheet without having to replicate a large chunk of Vaadin code.
