### PR TITLE
Update VFilterSelect.filterOptions(int, String, boolean) access modifier...

### DIFF
--- a/client/src/com/vaadin/client/ui/VFilterSelect.java
+++ b/client/src/com/vaadin/client/ui/VFilterSelect.java
@@ -1201,7 +1201,7 @@ public class VFilterSelect extends Composite implements Field, KeyDownHandler,
      * @param immediate
      *            Whether to send the options request immediately
      */
-    private void filterOptions(int page, String filter, boolean immediate) {
+    protected void filterOptions(int page, String filter, boolean immediate) {
         if (enableDebug) {
             debug("VFS: filterOptions(" + page + ", " + filter + ", "
                     + immediate + ")");


### PR DESCRIPTION
... from private to protected.

As the JavaDoc at the top of the class suggests, VFilterSelect needs to be more "extensible." This will help.
