### PR TITLE
Add ability to read Compass directory and filenames

### DIFF
--- a/theme-compiler/src/com/vaadin/sass/internal/ScssStylesheet.java
+++ b/theme-compiler/src/com/vaadin/sass/internal/ScssStylesheet.java
@@ -62,6 +62,7 @@ public class ScssStylesheet extends Node {
     private String fileName;
 
     private String charset;
+    private static ArrayList<String> importPaths = new ArrayList<String>();
 
     /**
      * Read in a file SCSS and parse it into a ScssStylesheet
@@ -377,5 +378,40 @@ public class ScssStylesheet extends Node {
 
     public void setCharset(String charset) {
         this.charset = charset;
+    }
+
+    public static void setImportPaths(ArrayList<String> paths) {
+        if (paths == null) {
+            importPaths = new ArrayList<String>();
+        }
+        else {
+            importPaths = paths;
+        }
+    } 
+
+    public static ArrayList<String> getImportPaths() {
+        return (ArrayList<String>) importPaths.clone();
+    }
+
+    public static void setImportPath(String path) {
+        if (!importPaths.contains(path)) {
+            if (path != null) {
+                importPaths.add(path);
+            }
+        }
+    }
+
+    public static String getImportPath(int i) {
+        if ((i >= 0 ) && (i < importPaths.size())) {
+            return importPaths.get(i);
+        }
+        return null;
+    }
+
+    public static boolean removeImportPath(String path) {
+        if (importPaths.contains(path)) {
+            return importPaths.remove(path);
+        }
+        return false;
     }
 }

--- a/theme-compiler/src/com/vaadin/sass/internal/visitor/ImportNodeHandler.java
+++ b/theme-compiler/src/com/vaadin/sass/internal/visitor/ImportNodeHandler.java
@@ -58,23 +58,27 @@ public class ImportNodeHandler {
                 if (!importNode.isPureCssImport()) {
                     try {
                         StringBuilder filePathBuilder = new StringBuilder(
-                                stylesheet.getFileName());
+                                styleSheet.getFileName());
                         StringBuilder filePathBuilder2 = new StringBuilder(
-                                stylesheet.getFileName());
+                                styleSheet.getFileName());
                         filePathBuilder.append(File.separatorChar).append(
                                 importNode.getUri());
                         if (!filePathBuilder.toString().endsWith(".scss")) {
                             filePathBuilder.append(".scss");
                         }
 
-                        if (importNode.getUri().contains(String.valueOf(File.separatorChar))) {
+                        if (importNode.getUri().contains(
+                                String.valueOf(File.separatorChar))) {
                             filePathBuilder2.append(File.separatorChar);
-                            int index = importNode.getUri().lastIndexOf(File.separatorChar);
-                            filePathBuilder2.append(importNode.getUri().substring(0, index + 1));
+                            int index = importNode.getUri().lastIndexOf(
+                                    File.separatorChar);
+                            filePathBuilder2.append(importNode.getUri()
+                                    .substring(0, index + 1));
                             filePathBuilder2.append(new String("_"));
-                            filePathBuilder2.append(importNode.getUri().substring((index + 1), importNode.getUri().length()));
-                        }
-                        else {
+                            filePathBuilder2.append(importNode.getUri()
+                                    .substring((index + 1),
+                                            importNode.getUri().length()));
+                        } else {
                             filePathBuilder2.append(File.separatorChar);
                             filePathBuilder2.append(new String("_"));
                             filePathBuilder2.append(importNode.getUri());
@@ -85,52 +89,66 @@ public class ImportNodeHandler {
 
                         // set parent's charset to imported node.
                         ScssStylesheet imported = ScssStylesheet.get(
-                                filePathBuilder.toString(), styleSheet.getCharset());
+                                filePathBuilder.toString(),
+                                styleSheet.getCharset());
                         if (imported == null) {
                             imported = ScssStylesheet.get(
-                                    filePathBuilder2.toString(), styleSheet.getCharset());
+                                    filePathBuilder2.toString(),
+                                    styleSheet.getCharset());
                         }
                         if (imported == null) {
                             imported = ScssStylesheet.get(importNode.getUri());
                         }
                         if (imported == null) {
-                            ArrayList<String> importPaths = styleSheet.getImportPaths();
+                            ArrayList<String> importPaths = styleSheet
+                                    .getImportPaths();
                             int i = 0;
-                            while (i < importPaths.size() && (imported == null) ) {
+                            while (i < importPaths.size() && (imported == null)) {
                                 String item = importPaths.get(i).concat(
-                                        String.valueOf((File.separatorChar)).concat(
-                                        importNode.getUri()));
+                                        String.valueOf((File.separatorChar))
+                                                .concat(importNode.getUri()));
                                 String item2 = null;
-                                if (importNode.getUri().contains(String.valueOf(File.separatorChar))) {
+                                if (importNode.getUri().contains(
+                                        String.valueOf(File.separatorChar))) {
                                     StringBuilder filePath = new StringBuilder();
                                     filePath.append(importPaths.get(i));
                                     filePath.append(File.separatorChar);
-                                    int index = importNode.getUri().lastIndexOf(File.separatorChar);
-                                    filePath.append(importNode.getUri().substring(0, index + 1));
+                                    int index = importNode.getUri()
+                                            .lastIndexOf(File.separatorChar);
+                                    filePath.append(importNode.getUri()
+                                            .substring(0, index + 1));
                                     filePath.append(new String("_"));
-                                    filePath.append(importNode.getUri().substring((index + 1), importNode.getUri().length()));
+                                    filePath.append(importNode.getUri()
+                                            .substring(
+                                                    (index + 1),
+                                                    importNode.getUri()
+                                                            .length()));
                                     item2 = filePath.toString();
-                                }
-                                else {
-                                    item2 = importPaths.get(i).concat(
-                                            String.valueOf(File.separatorChar).concat(
-                                            (new String("_")).concat(
-                                            importNode.getUri())));
+                                } else {
+                                    item2 = importPaths
+                                            .get(i)
+                                            .concat(String.valueOf(
+                                                    File.separatorChar).concat(
+                                                    (new String("_"))
+                                                            .concat(importNode
+                                                                    .getUri())));
                                 }
 
-                                imported = ScssStylesheet.get(
-                                        item, styleSheet.getCharset());
+                                imported = ScssStylesheet.get(item,
+                                        styleSheet.getCharset());
                                 if (imported == null) {
                                     imported = ScssStylesheet.get(
-                                            item.concat(".scss"), styleSheet.getCharset());
+                                            item.concat(".scss"),
+                                            styleSheet.getCharset());
+                                }
+                                if (imported == null) {
+                                    imported = ScssStylesheet.get(item2,
+                                            styleSheet.getCharset());
                                 }
                                 if (imported == null) {
                                     imported = ScssStylesheet.get(
-                                            item2, styleSheet.getCharset());
-                                }
-                                if (imported == null) {
-                                    imported = ScssStylesheet.get(
-                                            item2.concat(".scss"), styleSheet.getCharset());
+                                            item2.concat(".scss"),
+                                            styleSheet.getCharset());
                                 }
                                 i++;
                             }

--- a/theme-compiler/src/com/vaadin/sass/internal/visitor/ImportNodeHandler.java
+++ b/theme-compiler/src/com/vaadin/sass/internal/visitor/ImportNodeHandler.java
@@ -58,19 +58,82 @@ public class ImportNodeHandler {
                 if (!importNode.isPureCssImport()) {
                     try {
                         StringBuilder filePathBuilder = new StringBuilder(
-                                styleSheet.getFileName());
+                                stylesheet.getFileName());
+                        StringBuilder filePathBuilder2 = new StringBuilder(
+                                stylesheet.getFileName());
                         filePathBuilder.append(File.separatorChar).append(
                                 importNode.getUri());
                         if (!filePathBuilder.toString().endsWith(".scss")) {
                             filePathBuilder.append(".scss");
                         }
 
+                        if (importNode.getUri().contains(String.valueOf(File.separatorChar))) {
+                            filePathBuilder2.append(File.separatorChar);
+                            int index = importNode.getUri().lastIndexOf(File.separatorChar);
+                            filePathBuilder2.append(importNode.getUri().substring(0, index + 1));
+                            filePathBuilder2.append(new String("_"));
+                            filePathBuilder2.append(importNode.getUri().substring((index + 1), importNode.getUri().length()));
+                        }
+                        else {
+                            filePathBuilder2.append(File.separatorChar);
+                            filePathBuilder2.append(new String("_"));
+                            filePathBuilder2.append(importNode.getUri());
+                        }
+                        if (!filePathBuilder2.toString().endsWith(".scss")) {
+                            filePathBuilder2.append(".scss");
+                        }
+
                         // set parent's charset to imported node.
                         ScssStylesheet imported = ScssStylesheet.get(
-                                filePathBuilder.toString(),
-                                styleSheet.getCharset());
+                                filePathBuilder.toString(), styleSheet.getCharset());
+                        if (imported == null) {
+                            imported = ScssStylesheet.get(
+                                    filePathBuilder2.toString(), styleSheet.getCharset());
+                        }
                         if (imported == null) {
                             imported = ScssStylesheet.get(importNode.getUri());
+                        }
+                        if (imported == null) {
+                            ArrayList<String> importPaths = styleSheet.getImportPaths();
+                            int i = 0;
+                            while (i < importPaths.size() && (imported == null) ) {
+                                String item = importPaths.get(i).concat(
+                                        String.valueOf((File.separatorChar)).concat(
+                                        importNode.getUri()));
+                                String item2 = null;
+                                if (importNode.getUri().contains(String.valueOf(File.separatorChar))) {
+                                    StringBuilder filePath = new StringBuilder();
+                                    filePath.append(importPaths.get(i));
+                                    filePath.append(File.separatorChar);
+                                    int index = importNode.getUri().lastIndexOf(File.separatorChar);
+                                    filePath.append(importNode.getUri().substring(0, index + 1));
+                                    filePath.append(new String("_"));
+                                    filePath.append(importNode.getUri().substring((index + 1), importNode.getUri().length()));
+                                    item2 = filePath.toString();
+                                }
+                                else {
+                                    item2 = importPaths.get(i).concat(
+                                            String.valueOf(File.separatorChar).concat(
+                                            (new String("_")).concat(
+                                            importNode.getUri())));
+                                }
+
+                                imported = ScssStylesheet.get(
+                                        item, styleSheet.getCharset());
+                                if (imported == null) {
+                                    imported = ScssStylesheet.get(
+                                            item.concat(".scss"), styleSheet.getCharset());
+                                }
+                                if (imported == null) {
+                                    imported = ScssStylesheet.get(
+                                            item2, styleSheet.getCharset());
+                                }
+                                if (imported == null) {
+                                    imported = ScssStylesheet.get(
+                                            item2.concat(".scss"), styleSheet.getCharset());
+                                }
+                                i++;
+                            }
                         }
                         if (imported == null) {
                             throw new FileNotFoundException(importNode.getUri()


### PR DESCRIPTION
I'm working for Liferay.com and our lead engineer, Ray Auge, spoke with Joonas Lehtinen about this feature. As Liferay needs this functionality for its Portal CE project, Joonas Lehtinen mentioned that we could contribute to the VAADIN project. 

My design was to use the stylesheets here:  https://github.com/chriseppstein/compass/tree/stable/frameworks/compass/stylesheets and modify the VAADIN code to be able to read them in such that our existing Ruby implementation can be replaced with VAADIN without any changes to our *.scss and *.css files.

As this is a bit of effort, it may take several pull requests to complete. 
This, then, is the first of several commits toward this effort.
