### PR TITLE
NullPointerException in DateToSqlDateConverter and TableQuery

### DIFF
--- a/server/src/com/vaadin/data/util/converter/DateToSqlDateConverter.java
+++ b/server/src/com/vaadin/data/util/converter/DateToSqlDateConverter.java
@@ -43,7 +43,7 @@ public class DateToSqlDateConverter implements Converter<Date, java.sql.Date> {
                     + getModelType().getName() + " (targetType was "
                     + targetType.getName() + ")");
         }
-
+	if (value == null) return null;
         return new java.sql.Date(value.getTime());
     }
 

--- a/server/src/com/vaadin/data/util/sqlcontainer/query/TableQuery.java
+++ b/server/src/com/vaadin/data/util/sqlcontainer/query/TableQuery.java
@@ -663,7 +663,8 @@ public class TableQuery extends AbstractTransactionalQuery implements
             } catch (SQLException ignore) {
             } finally {
                 try {
-                    tables.close();
+                    if (tables != null) 
+			tables.close();
                 } catch (SQLException ignore) {
                 }
             }


### PR DESCRIPTION
DateToSqlConverter: Conversion fails if value is `null`. Trivial fix for the issue.
TableQuery: attempts to close() tables even if the variable is null
