### PR TITLE
No Field instance created by factory if property is readonly

### DIFF
--- a/server/src/com/vaadin/ui/Table.java
+++ b/server/src/com/vaadin/ui/Table.java
@@ -3942,7 +3942,7 @@ public class Table extends AbstractSelect implements Action.Container,
      */
     protected Object getPropertyValue(Object rowId, Object colId,
             Property property) {
-        if (isEditable() && fieldFactory != null) {
+        if (isEditable() && fieldFactory != null && !property.isReadOnly()) {
             final Field<?> f = fieldFactory.createField(
                     getContainerDataSource(), rowId, colId, this);
             if (f != null) {


### PR DESCRIPTION
Table#getPropertyValue() creates Field instances for read-only properties.
In some use cases (with large tables and/or mostly read only cells) this is very inefficient.
