### PR TITLE
Allow any type of property id in Like

### DIFF
--- a/server/src/com/vaadin/data/util/filter/Like.java
+++ b/server/src/com/vaadin/data/util/filter/Like.java
@@ -23,11 +23,11 @@ public class Like implements Filter {
     private final String value;
     private boolean caseSensitive;
 
-    public Like(String propertyId, String value) {
+    public Like(Object propertyId, String value) {
         this(propertyId, value, true);
     }
 
-    public Like(String propertyId, String value, boolean caseSensitive) {
+    public Like(Object propertyId, String value, boolean caseSensitive) {
         this.propertyId = propertyId;
         this.value = value;
         setCaseSensitive(caseSensitive);


### PR DESCRIPTION
In contrast to all other Filters, the Like filter does only allow String property ids. This looks like an oversight and should be corrected.
