### PR TITLE
PageUp/Down, Home/End key in Table(#12879)

### DIFF
--- a/client/src/com/vaadin/client/ui/VScrollTable.java
+++ b/client/src/com/vaadin/client/ui/VScrollTable.java
@@ -1167,7 +1167,9 @@ public class VScrollTable extends FlowPanel implements HasWidgets,
         @Override
         public void execute() {
             if (firstvisible > 0) {
-                firstRowInViewPort = firstvisible;
+                // http://dev.vaadin.com/ticket/12879 anybody have good idea?
+                // firstRowInViewPort = firstvisible;
+                firstvisible = firstRowInViewPort;
                 if (firstvisibleOnLastPage > -1) {
                     scrollBodyPanel
                             .setScrollPosition(measureRowHeightOffset(firstvisibleOnLastPage));


### PR DESCRIPTION
Hi.

At first, my english is not good.

This is just workaround about #12879.

Refer to http://dev.vaadin.com/ticket/12879

Follow is a testproject about this with comparing between original and modification.
https://github.com/imcharsi/vaadin_test_table20140429

There is still something strange behavior about PageUp/Down key even though with this workaround.

So I think it would be required more precise fix.

Thanks.
