### PR TITLE
Provide a way to obtain Container Item from CalendarEvent

### DIFF
--- a/server/src/com/vaadin/ui/components/calendar/ContainerEventProvider.java
+++ b/server/src/com/vaadin/ui/components/calendar/ContainerEventProvider.java
@@ -532,6 +532,25 @@ public class ContainerEventProvider implements CalendarEditableEventProvider,
     public void detachContainerDataSource() {
         ignoreContainerEvents();
     }
+    
+    /**
+     * ContainerEventProvider operates on an inner ContainerCalendarEvent. This is the
+     * way to obtain the Container Item instance (eg from MoveEvent, EventResize, EventClickEvent).
+     */
+    public Item getItem(CalendarEvent ce) {
+        if (eventCache.contains(ce)) {
+            int index;
+            if (ce instanceof ContainerCalendarEvent) {
+                index = ((ContainerCalendarEvent) ce).getContainerIndex();
+            } else {
+                index = container.indexOfId(ce);
+            }
+            Item item = container.getItem(container.getIdByIndex(index));
+            return item;
+        } else {
+            return null;
+        }
+    }
 
     /*
      * (non-Javadoc)


### PR DESCRIPTION
When overriding methods such as moveEvent or resizeEvent, or implementing EventClickHandler, EventRangeSelectHandler, one gets an instance of appropriate CalendarComponentEvent, which holds a reference to an instance of ContainerCalendarEvent, which is a private inner class (so one can't cast the event object to it). When using this provider combined with (for exapmle) JPAContainer, there is no way to obtain an instance of the real event (which can be an entity, managed by the container). This severely limits the possibilities of extending ContainerEventProvider.
