### PR TITLE
ComboBox styles added to the suggestbox popup too

### DIFF
--- a/client/src/com/vaadin/client/ui/VFilterSelect.java
+++ b/client/src/com/vaadin/client/ui/VFilterSelect.java
@@ -678,6 +678,7 @@ public class VFilterSelect extends Composite implements Field, KeyDownHandler,
                 for (String style : componentState.styles) {
                     if (!"".equals(style)) {
                         addStyleDependentName(style);
+                        suggestionPopup.addStyleName(style);
                     }
                 }
             }

--- a/uitest/src/com/vaadin/tests/components/combobox/Comboboxes.java
+++ b/uitest/src/com/vaadin/tests/components/combobox/Comboboxes.java
@@ -73,6 +73,11 @@ public class Comboboxes extends ComponentTestCase<ComboBox> {
         s.setCaption("Pagelength 0");
         populate(s, 15);
         addTestComponent(s);
+
+        s = createSelect("Styled suggest box");
+        populate(s, 5);
+        s.addStyleName("styled-suggest");
+        addTestComponent(s);
     }
 
     public class PageLength0ComboBox extends ComboBox {


### PR DESCRIPTION
Style names are now propagated to the GWT suggest box popup.
Fixes:
http://dev.vaadin.com/ticket/13251
