### PR TITLE
Typo in the Profiler log

### DIFF
--- a/client/src/com/vaadin/client/LayoutManager.java
+++ b/client/src/com/vaadin/client/LayoutManager.java
@@ -443,7 +443,7 @@ public class LayoutManager {
                         try {
                             String key = null;
                             if (Profiler.isEnabled()) {
-                                key = "layoutHorizontally() for "
+                                key = "layoutVertically() for "
                                         + Util.getSimpleName(cl);
                                 Profiler.enter(key);
                             }


### PR DESCRIPTION
Horizontally is done in the block before this one. Vertically is done here.
