### PR TITLE
Fix issue #16499: UI.getPushConfiguration().getTransport() *always* returns null

### DIFF
--- a/server/src/com/vaadin/ui/PushConfiguration.java
+++ b/server/src/com/vaadin/ui/PushConfiguration.java
@@ -208,7 +208,7 @@ class PushConfigurationImpl implements PushConfiguration {
     public Transport getTransport() {
         try {
             return Transport
-                    .valueOf(getParameter(PushConfigurationState.TRANSPORT_PARAM));
+                    .getByIdentifier(getParameter(PushConfigurationState.TRANSPORT_PARAM));
         } catch (IllegalArgumentException e) {
             return null;
         }

--- a/shared/src/com/vaadin/shared/ui/ui/Transport.java
+++ b/shared/src/com/vaadin/shared/ui/ui/Transport.java
@@ -45,5 +45,13 @@ public enum Transport {
     public String getIdentifier() {
         return identifier;
     }
-
+    
+    public static Transport getByIdentifier(String identifier) {
+        for (Transport t : values()) {
+            if (t.getIdentifier().equals(identifier)) {
+                return t;
+            }
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
Hello Vaadin team,

I stumbled upon this in the lastest Vaadin 7.3.9, Tomcat 8 and 7, etc.

UI.getPushConfiguration().getTransport() will always return null.

The problem has to do with using "Transport.valueOf" in the getTransport() method that is trying to look up the Transport enum based on it's identifier "websocket" rather than it's string equivalent name "WEBSOCKET". This applies to all of the transports.

Here is the relevant Vaadin ticket created in response to this issue: http://dev.vaadin.com/ticket/16499

Please try in your own project with Vaadin, any version, call UI.getPushConfiguration().getTransport() and see for yourself that it is always null.

The problem is caused by PushConfigurationImpl.getTransport() falling into the catch (IllegalArgumentException) that is then swallowed silently, and null is returned.
