### PR TITLE
Fix for trac-14802 : Correct style name for ValoTheme.PANEL_SCROLL_INDICATOR

### DIFF
--- a/server/src/com/vaadin/ui/themes/ValoTheme.java
+++ b/server/src/com/vaadin/ui/themes/ValoTheme.java
@@ -709,7 +709,7 @@ public class ValoTheme {
      * area is scrolled. Suitable with the {@link #PANEL_BORDERLESS} style. Can
      * be combined with any other Panel style.
      */
-    public static final String PANEL_SCROLL_INDICATOR = "scroll-indicator";
+    public static final String PANEL_SCROLL_INDICATOR = "scroll-divider";
 
     /**
      * Inset panel style. Can be combined with any other Panel style.


### PR DESCRIPTION
The correct style name for ValoTheme.PANEL_SCROLL_INDICATOR should be "scroll-divider".

https://dev.vaadin.com/ticket/14802
