### PR TITLE
vaadin-client changed to 'provided' scope

### DIFF
--- a/bom/vaadin-bom.pom
+++ b/bom/vaadin-bom.pom
@@ -82,6 +82,7 @@
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-client</artifactId>
                 <version>@vaadin.version@</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Since vaadin-client is not needed at runtime, its default scope could be provided, couldn't be? Thanks to that, it will not get to the war file by accident.
