### PR TITLE
Update DefaultFieldFactory.java

### DIFF
--- a/server/src/main/java/com/vaadin/ui/DefaultFieldFactory.java
+++ b/server/src/main/java/com/vaadin/ui/DefaultFieldFactory.java
@@ -75,7 +75,7 @@ public class DefaultFieldFactory implements FormFieldFactory, TableFieldFactory 
      * @param propertyId
      * @return the formatted caption string
      */
-    public static String createCaptionByPropertyId(Object propertyId) {
+    public String createCaptionByPropertyId(Object propertyId) {
         return SharedUtil.propertyIdToHumanFriendly(propertyId);
     }
 
@@ -95,7 +95,7 @@ public class DefaultFieldFactory implements FormFieldFactory, TableFieldFactory 
      *            the type of the property
      * @return the most suitable generic {@link Field} for given type
      */
-    public static Field<?> createFieldByPropertyType(Class<?> type) {
+    public Field<?> createFieldByPropertyType(Class<?> type) {
         // Null typed properties can not be edited
         if (type == null) {
             return null;


### PR DESCRIPTION
In the Vaadin book there is a suggestion to extend from this class to implement an own factory. There is absolutely no reason why the two methods are static. If you remove the two static modifiers, it's a lot easier to extend from this class.
