### PR TITLE
Add null-check to setCellFocus Method

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -2526,6 +2526,9 @@ public class Grid<T> extends ResizeComposite implements
          */
         private void setCellFocus(int rowIndex, int columnIndexDOM,
                 RowContainer container) {
+            if (container == null){
+                return;
+            }
             if (rowIndex == rowWithFocus
                     && cellFocusRange.contains(columnIndexDOM)
                     && container == this.containerWithFocus) {


### PR DESCRIPTION
Added if conditional in setCellFocus method to short circuit in the case that container is null, full reason available on ticket #20031

Change-Id: I646dd92dd3440440a0de39b1d7d3a66c543c31b4
