### PR TITLE
Fixed event name to match example code

### DIFF
--- a/documentation/datamodel/datamodel-fields.asciidoc
+++ b/documentation/datamodel/datamodel-fields.asciidoc
@@ -35,7 +35,7 @@ By listening to the event, we can find out the new value of the field and whethe
 [source,java]
 ----
 TextField nameField = new TextField("Enter your name");
-nameField.addValueChangeListener(clickEvent -> {
+nameField.addValueChangeListener(event -> {
   String origin = event.isUserOriginated()
     ? "by the user"
     : "from code";


### PR DESCRIPTION
Value change event was called clickEvent, fixed to match code below.
