### PR TITLE
Fix Mockito/Hamcrest build classpath conflict

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -41,6 +41,11 @@
             <groupId>com.google.gwt</groupId>
             <artifactId>gwt-elemental</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,12 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
+                <exclusions>
+                   <exclusion>
+                       <artifactId>hamcrest-core</artifactId>
+                       <groupId>org.hamcrest</groupId>
+                   </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.easymock</groupId>
@@ -209,8 +215,14 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
+                <artifactId>mockito-core</artifactId>
                 <version>1.9.5</version>
+                <exclusions>
+                   <exclusion>
+                      <artifactId>hamcrest-core</artifactId>
+                      <groupId>org.hamcrest</groupId>
+                  </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -279,7 +291,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Fixes issue with Mockito classes not found on the vaadin-client test classpath
- Fixes Mockito/Hamcrest dependency conflict described in
     https://tedvinke.wordpress.com/2013/12/17/mixing-junit-hamcrest-and-mockito-explaining-nosuchmethoderror/
