### PR TITLE
Refresh in debug mode if servlet context is reinitialized

### DIFF
--- a/client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -420,6 +420,9 @@ public class ApplicationConnection implements HasHandlers {
                 getUIConnector().getState().overlayContainerLabel);
         Roles.getAlertRole().setAriaRelevantProperty(overlayContainer,
                 RelevantValue.ADDITIONS);
+        if (ApplicationConfiguration.isDebugMode()) {
+            new RefreshRequestHandler(this).startRefreshRequest();
+        }
     }
 
     /**

--- a/client/src/main/java/com/vaadin/client/RefreshRequestHandler.java
+++ b/client/src/main/java/com/vaadin/client/RefreshRequestHandler.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.client;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.gwt.http.client.Request;
+import com.google.gwt.http.client.RequestBuilder;
+import com.google.gwt.http.client.RequestCallback;
+import com.google.gwt.http.client.RequestException;
+import com.google.gwt.http.client.Response;
+import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.Window;
+import com.vaadin.shared.ApplicationConstants;
+
+/**
+ * Handles automatic reloading after a server restart or redeploy when not
+ * running in production mode.
+ *
+ * @author Vaadin Ltd
+ */
+public class RefreshRequestHandler {
+    private ApplicationConnection connection;
+
+    private class RequestRefreshCallback implements RequestCallback {
+        private int refreshRetryCount = 0;
+
+        @Override
+        public void onResponseReceived(Request request, Response response) {
+            int code = response.getStatusCode();
+            if (code == 0) {
+                retryRefreshRequest();
+                return;
+            }
+            if (code == 410
+                    && !"Session expired".equals(response.getStatusText())) {
+                // Pretend it's a generic server error
+                code = 400;
+            }
+
+            if (code != 200 && code != 410) {
+                getLogger().log(Level.INFO,
+                        "Got status code " + code + " for refresh request");
+                return;
+            }
+            String token = response.getHeader("X-VAADIN-REFRESH");
+            if (token == null && code != 410) {
+                // token is null, we need to
+                // refresh
+                retryRefreshRequest();
+            } else if (refreshToken == null) {
+                /*
+                 * we don't have a refreshtoken yet, let's set it to match the
+                 * serverside token
+                 */
+                refreshToken = token;
+
+                startRefreshRequest();
+            } else if (!refreshToken.equals(token) || code == 410) {
+
+                /*
+                 * The token we have doesn't match the token the server has.
+                 * This means that the servlet has been reloaded and we need to
+                 * refresh the page.
+                 */
+
+                refreshRetryCount = 0;
+
+                refreshToken = token;
+
+                /*
+                 * Reload or do repaint all depending on whether server still
+                 * has an UI with our id
+                 */
+                String uiIds = response.getText();
+                String uiId = connection.getUIConnector().getConnectorId();
+                if (uiIds.contains('|' + uiId + '|')) {
+                    getLogger().log(Level.INFO,
+                            "Got refresh token " + token + " containing UI id "
+                                    + uiId + " . Repainting all.");
+                    connection.getMessageSender().resynchronize();
+                } else {
+                    getLogger().log(Level.INFO, "Got refresh token " + token
+                            + " without UI id " + uiId + " . Refreshing.");
+                    Window.Location.reload();
+                }
+            } else {
+                /*
+                 * Expected connection cycling, just request again
+                 */
+                startRefreshRequest();
+            }
+        }
+
+        @Override
+        public void onError(Request request, Throwable exception) {
+            getLogger().log(Level.INFO, "Refresh request error", exception);
+            retryRefreshRequest();
+        }
+
+        private void retryRefreshRequest() {
+            if (refreshRetryCount++ < 10) {
+                new Timer() {
+                    @Override
+                    public void run() {
+                        startRefreshRequest();
+                    }
+                }.schedule(500 * refreshRetryCount);
+            } else {
+                getLogger().log(Level.INFO,
+                        "Refresh request retry limit reached");
+            }
+        }
+    }
+
+    public RefreshRequestHandler(ApplicationConnection connection) {
+        this.connection = connection;
+    }
+
+    // Token to recognize a redeployed application, initialized based on the
+    // first response we get
+    private String refreshToken = null;
+
+    public void startRefreshRequest() {
+        /*
+         * This is a hanging request; if nothing changes (i.e. the server and
+         * client both agree on the value of the refresh token, it will cycle
+         * (default duration five minutes). However, if the servlet is closing
+         * down we will receive a response.
+         *
+         * If the servlet and client disagree on the value of the refresh token,
+         * we will try again until they do agree.
+         */
+        try {
+            getLogger().log(Level.INFO,
+                    "Sending refresh request with token " + refreshToken);
+            String uri = connection
+                    .translateVaadinUri(ApplicationConstants.APP_PROTOCOL_PREFIX
+                            + ApplicationConstants.REFRESH_PATH
+                            + "?refresh-token=" + refreshToken);
+            new RequestBuilder(RequestBuilder.GET, uri).sendRequest(null,
+                    new RequestRefreshCallback());
+        } catch (RequestException e) {
+            getLogger().log(Level.WARNING, "Refresh request failed", e);
+        }
+    }
+
+    private static Logger getLogger() {
+        return Logger.getLogger(RefreshRequestHandler.class.getName());
+    }
+
+}

--- a/server/src/main/java/com/vaadin/server/RefreshHandler.java
+++ b/server/src/main/java/com/vaadin/server/RefreshHandler.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.server;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.vaadin.ui.UI;
+
+/**
+ * Maintains a hanging request and writes a response either when a predetermined
+ * time is up (default 5 minutes) or when the servlet closes down. When the
+ * client issues a new request, it can detect that the server has been restarted
+ * and thus reload the application.
+ * <p>
+ * Only requests from localhost are handled - this is a tool mainly used for
+ * making local development more convenient.
+ *
+ * @since
+ * @author Vaadin Ltd
+ */
+public class RefreshHandler implements RequestHandler {
+
+    /*
+     * The token changes every time the refreshhandler is reloaded. This should
+     * only happen during servlet context reload, i.e. when the servlet is shut
+     * down and restarted.
+     */
+    private final String token = Integer
+            .toString(ThreadLocalRandom.current().nextInt());
+
+    private static final Set<String> localhostAddresses = new HashSet<>(
+            Arrays.asList("0:0:0:0:0:0:0:1", "fe80:0:0:0:0:0:0:1", "127.0.0.1",
+                    "::1"));
+
+    @Override
+    public boolean handleRequest(VaadinSession session, VaadinRequest request,
+            VaadinResponse response) throws IOException {
+
+        if (!ServletPortletHelper.isRefreshRequest(request)) {
+            // Not a request for us
+            return false;
+        }
+
+        String remoteAddr = request.getRemoteAddr();
+        // replaceAll removes %0 or similar that identify which network
+        // interface is used
+        if (!localhostAddresses
+                .contains(remoteAddr.replaceAll("%[0-9]+$", ""))) {
+            getLogger().log(Level.FINEST,
+                    "Refresh Request Handler only accepts requests from localhost addresses. Ignored request from "
+                            + remoteAddr + " .");
+            response.sendError(403, remoteAddr + " is not a localhost address");
+            return true;
+        }
+
+        String requestToken = request.getParameter("refresh-token");
+        if (token.equals(requestToken)) {
+            /*
+             * The client sent us the same token back - therefore we can
+             * conclude that the handler has not been reloaded and the servlet
+             * has not been reinitialized
+             */
+            try {
+                /*
+                 * sleep for an arbitrary amount of time - this is merely the
+                 * amount of time we're willing to let this request stay open
+                 */
+                Thread.sleep(1000 * 60 * 5);
+            } catch (InterruptedException e) {
+                /*
+                 * Sleep will be interrupted whenever the servlet is reloaded.
+                 * This usually happens because we've changed a .java file,
+                 * causing recompilation and redeployment.
+                 */
+            }
+        }
+
+        /*
+         * When the time is up, the server shuts down (which interrupts sleep),
+         * or we just received a refresh request with a different token (old or
+         * null) we send a response.
+         *
+         * The client side should then send a new refresh request.
+         */
+        response.setContentType("text/plain");
+        response.setHeader("X-VAADIN-REFRESH", token);
+
+        try {
+            session.lock();
+            response.getWriter().write('|');
+            for (UI ui : session.getUIs()) {
+                response.getWriter().write(ui.getUIId());
+                response.getWriter().write('|');
+            }
+        } finally {
+            session.unlock();
+        }
+        return true;
+    }
+
+    private static Logger getLogger() {
+        return Logger.getLogger(RefreshHandler.class.getName());
+    }
+}

--- a/server/src/main/java/com/vaadin/server/ServletPortletHelper.java
+++ b/server/src/main/java/com/vaadin/server/ServletPortletHelper.java
@@ -148,6 +148,11 @@ public class ServletPortletHelper implements Serializable {
         return isPathInfo(request, ApplicationConstants.PUSH_PATH);
     }
 
+    public static boolean isRefreshRequest(VaadinRequest request) {
+        return request instanceof VaadinServletRequest
+                && hasPathPrefix(request, ApplicationConstants.REFRESH_PATH);
+    }
+
     public static void initDefaultUIProvider(VaadinSession session,
             VaadinService vaadinService) throws ServiceException {
         String uiProperty = vaadinService.getDeploymentConfiguration()

--- a/server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinService.java
@@ -213,6 +213,9 @@ public abstract class VaadinService implements Serializable {
         ArrayList<RequestHandler> handlers = new ArrayList<>();
         handlers.add(new SessionRequestHandler());
         handlers.add(new PublishedFileHandler());
+        if (!getDeploymentConfiguration().isProductionMode()) {
+            handlers.add(new RefreshHandler());
+        }
         handlers.add(new HeartbeatHandler());
         handlers.add(new FileUploadHandler());
         handlers.add(new UidlRequestHandler());

--- a/shared/src/main/java/com/vaadin/shared/ApplicationConstants.java
+++ b/shared/src/main/java/com/vaadin/shared/ApplicationConstants.java
@@ -39,6 +39,9 @@ public class ApplicationConstants implements Serializable {
     public static final String PUBLISHED_PROTOCOL_NAME = "published";
     public static final String PUBLISHED_PROTOCOL_PREFIX = PUBLISHED_PROTOCOL_NAME
             + "://";
+
+    public static final String REFRESH_PATH = APP_PATH + '/' + "REFRESH/";
+
     /**
      * Prefix used for theme resource URLs
      *


### PR DESCRIPTION
When developing a Vaadin application in an IDE, the development is often
done on a local development server configured to redeploy the
application whenever a .java file has been modified.

This patch introduces a refresh request that is used to detect when the
server has been restarted, and then subsequently reload the application
to use the newly deployed code.

The new functionality is only activated when the application is run in
debug mode, and it only works for requests originating from a localhost
address.

Fixes https://dev.vaadin.com/ticket/19102

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/81)
<!-- Reviewable:end -->
