### PR TITLE
Migrate 7.7.3..7.7.4 changes from branch 7.7 to master

### DIFF
--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/ConnectorBundleLoaderFactory.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/ConnectorBundleLoaderFactory.java
@@ -58,6 +58,7 @@ import com.vaadin.client.metadata.TypeData;
 import com.vaadin.client.metadata.TypeDataStore;
 import com.vaadin.client.metadata.TypeDataStore.MethodAttribute;
 import com.vaadin.client.ui.UnknownComponentConnector;
+import com.vaadin.client.ui.UnknownExtensionConnector;
 import com.vaadin.server.widgetsetutils.metadata.ClientRpcVisitor;
 import com.vaadin.server.widgetsetutils.metadata.ConnectorBundle;
 import com.vaadin.server.widgetsetutils.metadata.ConnectorInitVisitor;
@@ -1123,6 +1124,8 @@ public class ConnectorBundleLoaderFactory extends Generator {
                 connectorsByLoadStyle.get(LoadStyle.EAGER));
         eagerBundle.processType(eagerLogger, typeOracle
                 .findType(UnknownComponentConnector.class.getCanonicalName()));
+        eagerBundle.processType(eagerLogger, typeOracle
+                .findType(UnknownExtensionConnector.class.getCanonicalName()));
         eagerBundle.processSubTypes(eagerLogger,
                 typeOracle.getType(ClientRpc.class.getName()));
         eagerBundle.processSubTypes(eagerLogger,

--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/ConnectorBundle.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/ConnectorBundle.java
@@ -48,6 +48,7 @@ import com.vaadin.client.communication.JSONSerializer;
 import com.vaadin.client.connectors.AbstractRendererConnector;
 import com.vaadin.client.metadata.TypeDataStore.MethodAttribute;
 import com.vaadin.client.ui.UnknownComponentConnector;
+import com.vaadin.client.ui.UnknownExtensionConnector;
 import com.vaadin.shared.communication.ClientRpc;
 import com.vaadin.shared.communication.ServerRpc;
 import com.vaadin.shared.ui.Connect;
@@ -469,7 +470,9 @@ public class ConnectorBundle {
     private static boolean isConnected(JClassType type) {
         return type.isAnnotationPresent(Connect.class)
                 || type.getQualifiedSourceName().equals(
-                        UnknownComponentConnector.class.getCanonicalName());
+                        UnknownComponentConnector.class.getCanonicalName())
+                || type.getQualifiedSourceName().equals(
+                        UnknownExtensionConnector.class.getCanonicalName());
     }
 
     public static boolean isConnectedComponentConnector(JClassType type) {

--- a/client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -53,6 +53,7 @@ import com.vaadin.client.metadata.ConnectorBundleLoader;
 import com.vaadin.client.metadata.NoDataException;
 import com.vaadin.client.metadata.TypeData;
 import com.vaadin.client.ui.UnknownComponentConnector;
+import com.vaadin.client.ui.UnknownExtensionConnector;
 import com.vaadin.client.ui.ui.UIConnector;
 import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.shared.ui.ui.UIConstants;
@@ -526,7 +527,11 @@ public class ApplicationConfiguration implements EntryPoint {
                 currentTag = getParentTag(currentTag.intValue());
             }
             if (type == null) {
-                type = UnknownComponentConnector.class;
+                if (isExtensionType(tag)) {
+                    type = UnknownExtensionConnector.class;
+                } else {
+                    type = UnknownComponentConnector.class;
+                }
                 if (unknownComponents == null) {
                     unknownComponents = new HashMap<>();
                 }
@@ -535,6 +540,20 @@ public class ApplicationConfiguration implements EntryPoint {
             classes.put(tag, type);
         }
         return type;
+    }
+
+    private boolean isExtensionType(int tag) {
+        Integer currentTag = Integer.valueOf(tag);
+        while (currentTag != null) {
+            String serverSideClassNameForTag = getServerSideClassNameForTag(
+                    currentTag);
+            if ("com.vaadin.server.AbstractExtension"
+                    .equals(serverSideClassNameForTag)) {
+                return true;
+            }
+            currentTag = getParentTag(currentTag.intValue());
+        }
+        return false;
     }
 
     public void addComponentInheritanceInfo(ValueMap valueMap) {

--- a/client/src/main/java/com/vaadin/client/LayoutManager.java
+++ b/client/src/main/java/com/vaadin/client/LayoutManager.java
@@ -350,9 +350,12 @@ public class LayoutManager {
 
             int firedListeners = 0;
             if (!listenersToFire.isEmpty()) {
+                HashSet<Element> listenersCopy = new HashSet<Element>(
+                        listenersToFire);
+                listenersToFire.clear();
                 firedListeners = listenersToFire.size();
                 Profiler.enter("Layout fire resize events");
-                for (Element element : listenersToFire) {
+                for (Element element : listenersCopy) {
                     Collection<ElementResizeListener> listeners = elementResizeListeners
                             .get(element);
                     if (listeners != null) {
@@ -393,8 +396,6 @@ public class LayoutManager {
                                 "Layout fire resize events - listeners not null");
                     }
                 }
-                listenersToFire.clear();
-
                 Profiler.leave("Layout fire resize events");
             }
 

--- a/client/src/main/java/com/vaadin/client/VUIDLBrowser.java
+++ b/client/src/main/java/com/vaadin/client/VUIDLBrowser.java
@@ -36,6 +36,7 @@ import com.google.gwt.event.dom.client.MouseOutHandler;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.client.ui.UnknownComponentConnector;
+import com.vaadin.client.ui.UnknownExtensionConnector;
 import com.vaadin.client.ui.VWindow;
 
 import elemental.json.JsonArray;
@@ -229,7 +230,8 @@ public class VUIDLBrowser extends SimpleTree {
                 int tag) {
             Class<? extends ServerConnector> widgetClassByDecodedTag = conf
                     .getConnectorClassByEncodedTag(tag);
-            if (widgetClassByDecodedTag == UnknownComponentConnector.class) {
+            if (widgetClassByDecodedTag == UnknownComponentConnector.class
+                    || widgetClassByDecodedTag == UnknownExtensionConnector.class) {
                 return conf.getUnknownServerClassNameByTag(tag)
                         + "(NO CLIENT IMPLEMENTATION FOUND)";
             } else {

--- a/client/src/main/java/com/vaadin/client/WidgetSet.java
+++ b/client/src/main/java/com/vaadin/client/WidgetSet.java
@@ -26,6 +26,8 @@ import com.vaadin.client.metadata.ConnectorBundleLoader;
 import com.vaadin.client.metadata.NoDataException;
 import com.vaadin.client.metadata.TypeData;
 import com.vaadin.client.ui.UnknownComponentConnector;
+import com.vaadin.client.ui.UnknownExtensionConnector;
+import com.vaadin.client.ui.UnknownExtensionConnector;
 
 public class WidgetSet {
     /**
@@ -55,33 +57,43 @@ public class WidgetSet {
         Class<? extends ServerConnector> classType = resolveInheritedConnectorType(
                 conf, tag);
 
-        if (classType == null || classType == UnknownComponentConnector.class) {
-            String serverSideName = conf.getUnknownServerClassNameByTag(tag);
-            UnknownComponentConnector c = GWT
-                    .create(UnknownComponentConnector.class);
-            c.setServerSideClassName(serverSideName);
-            Profiler.leave("WidgetSet.createConnector");
-            return c;
-        } else {
-            /*
-             * let the auto generated code instantiate this type
-             */
-            try {
+        try {
+            if (classType == null
+                    || classType == UnknownComponentConnector.class
+                    || classType == UnknownExtensionConnector.class) {
+                String serverSideName = conf
+                        .getUnknownServerClassNameByTag(tag);
+                if (classType == UnknownExtensionConnector.class) {
+                    // Display message in the console for non-visual connectors
+                    getLogger().severe(UnknownComponentConnector
+                            .createMessage(serverSideName));
+                    return GWT.create(UnknownExtensionConnector.class);
+                } else {
+                    UnknownComponentConnector c = GWT
+                            .create(UnknownComponentConnector.class);
+                    // Set message to be shown in a widget for visual connectors
+                    c.setServerSideClassName(serverSideName);
+                    return c;
+                }
+            } else {
+                /*
+                 * let the auto generated code instantiate this type
+                 */
                 ServerConnector connector = (ServerConnector) TypeData
                         .getType(classType).createInstance();
                 if (connector instanceof HasJavaScriptConnectorHelper) {
                     ((HasJavaScriptConnectorHelper) connector)
                             .getJavascriptConnectorHelper().setTag(tag);
                 }
-                Profiler.leave("WidgetSet.createConnector");
                 return connector;
-            } catch (NoDataException e) {
-                Profiler.leave("WidgetSet.createConnector");
-                throw new IllegalStateException(
-                        "There is no information about " + classType
-                                + ". Did you remember to compile the right widgetset?",
-                        e);
             }
+        } catch (NoDataException e) {
+            throw new IllegalStateException(
+                    "There is no information about " + classType
+                            + ". Did you remember to compile the right widgetset?",
+                    e);
+        } finally {
+            Profiler.leave("WidgetSet.createConnector");
         }
     }
 

--- a/client/src/main/java/com/vaadin/client/debug/internal/OptimizedWidgetsetPanel.java
+++ b/client/src/main/java/com/vaadin/client/debug/internal/OptimizedWidgetsetPanel.java
@@ -26,6 +26,7 @@ import com.vaadin.client.ApplicationConnection;
 import com.vaadin.client.ServerConnector;
 import com.vaadin.client.Util;
 import com.vaadin.client.ui.UnknownComponentConnector;
+import com.vaadin.client.ui.UnknownExtensionConnector;
 
 /**
  * Optimized widgetset view panel of the debug window.
@@ -89,7 +90,8 @@ public class OptimizedWidgetsetPanel extends FlowPanel {
                 break;
             }
 
-            if (connectorClass != UnknownComponentConnector.class) {
+            if (connectorClass != UnknownComponentConnector.class
+                    && connectorClass != UnknownExtensionConnector.class) {
                 usedConnectors.add(connectorClass.getName());
             }
             tag++;

--- a/client/src/main/java/com/vaadin/client/ui/UnknownComponentConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/UnknownComponentConnector.java
@@ -31,13 +31,17 @@ public class UnknownComponentConnector extends AbstractComponentConnector {
     }
 
     public void setServerSideClassName(String serverClassName) {
-        getWidget().setCaption("Widgetset '" + GWT.getModuleName()
-                + "' does not contain implementation for " + serverClassName
-                + ". Check its component connector's @Connect mapping, widgetsets "
+        getWidget().setCaption(createMessage(serverClassName));
+    }
+
+    public static String createMessage(String serverClassName) {
+        return "Widgetset '" + GWT.getModuleName()
+                + "' does not contain an implementation for " + serverClassName
+                + ". Check the connector's @Connect mapping, the widgetset's "
                 + "GWT module description file and re-compile your"
                 + " widgetset. In case you have downloaded a vaadin"
                 + " add-on package, you might want to refer to "
                 + "<a href='http://vaadin.com/using-addons'>add-on "
-                + "instructions</a>.");
+                + "instructions</a>.";
     }
 }

--- a/client/src/main/java/com/vaadin/client/ui/UnknownExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/UnknownExtensionConnector.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2014 Vaadin Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.client.ui;
+
+import com.vaadin.client.ServerConnector;
+import com.vaadin.client.extensions.AbstractExtensionConnector;
+
+/**
+ * Connector used as a placeholder for extensions that are not present in the
+ * widgetset.
+ * 
+ * @since 7.7.4
+ * @author Vaadin Ltd
+ */
+public class UnknownExtensionConnector extends AbstractExtensionConnector {
+    @Override
+    protected void extend(ServerConnector target) {
+        // Noop
+    }
+}

--- a/client/src/main/java/com/vaadin/client/ui/VWindow.java
+++ b/client/src/main/java/com/vaadin/client/ui/VWindow.java
@@ -1463,4 +1463,15 @@ public class VWindow extends VOverlay implements ShortcutActionHandlerOwner,
         return addHandler(handler, WindowMoveEvent.getType());
     }
 
+    /**
+     * Checks if a modal window is currently open.
+     * 
+     * @return <code>true</code> if a modal window is open, <code>false</code>
+     *         otherwise.
+     */
+    public static boolean isModalWindowOpen() {
+        return Document.get().getBody()
+                .hasClassName(MODAL_WINDOW_OPEN_CLASSNAME);
+    }
+
 }

--- a/client/src/main/java/com/vaadin/client/ui/ui/UIConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/ui/UIConnector.java
@@ -490,6 +490,9 @@ public class UIConnector extends AbstractSingleComponentContainerConnector
         shortcutContextWidget.addDomHandler(new KeyDownHandler() {
             @Override
             public void onKeyDown(KeyDownEvent event) {
+                if (VWindow.isModalWindowOpen()) {
+                    return;
+                }
                 if (getWidget().actionHandler != null) {
                     Element target = Element
                             .as(event.getNativeEvent().getEventTarget());

--- a/client/src/main/java/com/vaadin/client/widget/escalator/ScrollbarBundle.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/ScrollbarBundle.java
@@ -362,6 +362,7 @@ public abstract class ScrollbarBundle implements DeferredWorker {
 
     private HandlerRegistration scrollSizeTemporaryScrollHandler;
     private HandlerRegistration offsetSizeTemporaryScrollHandler;
+    private HandlerRegistration scrollInProgress;
 
     private ScrollbarBundle() {
         root.appendChild(scrollSizeElement);
@@ -523,6 +524,16 @@ public abstract class ScrollbarBundle implements DeferredWorker {
         scrollPos = Math.max(0, Math.min(maxScrollPos, truncate(px)));
 
         if (!WidgetUtil.pixelValuesEqual(oldScrollPos, scrollPos)) {
+            if (scrollInProgress == null) {
+                // Only used for tracking that there is "workPending"
+                scrollInProgress = addScrollHandler(new ScrollHandler() {
+                    @Override
+                    public void onScroll(ScrollEvent event) {
+                        scrollInProgress.removeHandler();
+                        scrollInProgress = null;
+                    }
+                });
+            }
             if (isInvisibleScrollbar) {
                 invisibleScrollbarTemporaryResizer.show();
             }
@@ -911,6 +922,6 @@ public abstract class ScrollbarBundle implements DeferredWorker {
         // requestAnimationFrame - which is not automatically checked
         return scrollSizeTemporaryScrollHandler != null
                 || offsetSizeTemporaryScrollHandler != null
-                || scrollEventFirer.isBeingFired;
+                || scrollInProgress != null || scrollEventFirer.isBeingFired;
     }
 }

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -672,13 +672,13 @@ public class Escalator extends Widget
         /*-{
             var vScroll = esc.@com.vaadin.client.widgets.Escalator::verticalScrollbar;
             var vScrollElem = vScroll.@com.vaadin.client.widget.escalator.ScrollbarBundle::getElement()();
-        
+
             var hScroll = esc.@com.vaadin.client.widgets.Escalator::horizontalScrollbar;
             var hScrollElem = hScroll.@com.vaadin.client.widget.escalator.ScrollbarBundle::getElement()();
-        
+
             return $entry(function(e) {
                 var target = e.target;
-        
+
                 // in case the scroll event was native (i.e. scrollbars were dragged, or
                 // the scrollTop/Left was manually modified), the bundles have old cache
                 // values. We need to make sure that the caches are kept up to date.
@@ -699,29 +699,29 @@ public class Escalator extends Widget
             return $entry(function(e) {
                 var deltaX = e.deltaX ? e.deltaX : -0.5*e.wheelDeltaX;
                 var deltaY = e.deltaY ? e.deltaY : -0.5*e.wheelDeltaY;
-        
+
                 // Delta mode 0 is in pixels; we don't need to do anything...
-        
+
                 // A delta mode of 1 means we're scrolling by lines instead of pixels
                 // We need to scale the number of lines by the default line height
                 if(e.deltaMode === 1) {
                     var brc = esc.@com.vaadin.client.widgets.Escalator::body;
                     deltaY *= brc.@com.vaadin.client.widgets.Escalator.AbstractRowContainer::getDefaultRowHeight()();
                 }
-        
+
                 // Other delta modes aren't supported
                 if((e.deltaMode !== undefined) && (e.deltaMode >= 2 || e.deltaMode < 0)) {
                     var msg = "Unsupported wheel delta mode \"" + e.deltaMode + "\"";
-        
+
                     // Print warning message
                     esc.@com.vaadin.client.widgets.Escalator::logWarning(*)(msg);
                 }
-        
+
                 // IE8 has only delta y
                 if (isNaN(deltaY)) {
                     deltaY = -0.5*e.wheelDelta;
                 }
-        
+
                 @com.vaadin.client.widgets.Escalator.JsniUtil::moveScrollFromEvent(*)(esc, deltaX, deltaY, e);
             });
         }-*/;
@@ -5567,7 +5567,21 @@ public class Escalator extends Widget
         // init default dimensions
         setHeight(null);
         setWidth(null);
+
+        publishJSHelpers(root);
     }
+
+    private int getBodyRowCount() {
+        return getBody().getRowCount();
+    }
+
+    private native void publishJSHelpers(Element root)
+    /*-{
+        var self = this;
+        root.getBodyRowCount = $entry(function () {
+           return self.@Escalator::getBodyRowCount()();
+        });
+    }-*/;
 
     private void setupScrollbars(final Element root) {
 
@@ -6602,15 +6616,19 @@ public class Escalator extends Widget
         } else if (type.equalsIgnoreCase("cell")) {
             // If wanted row is not visible, we need to scroll there.
             Range visibleRowRange = getVisibleRowRange();
-            if (indices.length > 0 && !visibleRowRange.contains(indices[0])) {
-                try {
-                    scrollToRow(indices[0], ScrollDestination.ANY, 0);
-                } catch (IllegalArgumentException e) {
-                    getLogger().log(Level.SEVERE, e.getMessage());
+            if (indices.length > 0) {
+                // Contains a row number, ensure it is available and visible
+                boolean rowInCache = visibleRowRange.contains(indices[0]);
+
+                // Scrolling might be a no-op if row is already in the viewport
+                scrollToRow(indices[0], ScrollDestination.ANY, 0);
+
+                if (!rowInCache) {
+                    // Row was not in cache, scrolling caused lazy loading and
+                    // the caller needs to wait and call this method again to be
+                    // able to get the requested element
+                    return null;
                 }
-                // Scrolling causes a lazy loading event. No element can
-                // currently be retrieved.
-                return null;
             }
             container = getBody();
         } else if (type.equalsIgnoreCase("footer")) {

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VFilterSelect.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VFilterSelect.java
@@ -2381,6 +2381,9 @@ public class VFilterSelect extends Composite
 
         focused = false;
         if (!readonly) {
+            if (textInputEnabled && allowNewItem) {
+                suggestionPopup.menu.doSelectedItemAction();
+            }
             if (selectedOptionKey == null) {
                 if (explicitSelectedCaption != null) {
                     setPromptingOff(explicitSelectedCaption);

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTree.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTree.java
@@ -825,7 +825,7 @@ public class VTree extends FocusElementPanel
          */
         public boolean isCaptionElement(
                 com.google.gwt.dom.client.Element target) {
-            return (target == nodeCaptionSpan
+            return (nodeCaptionSpan.isOrHasChild(target)
                     || (icon != null && target == icon.getElement()));
         }
 

--- a/compatibility-server/pom.xml
+++ b/compatibility-server/pom.xml
@@ -80,7 +80,7 @@
                     <instructions>
                         <Bundle-RequiredExecutionEnvironment>${osgi.execution.environment}</Bundle-RequiredExecutionEnvironment>
                         <Bundle-Version>${osgi.bundle.version}</Bundle-Version>
-                        <Export-Package>com.vaadin.v7.*;version="${osgi.bundle.version}"</Export-Package>
+                        <Export-Package>VAADIN;version="${osgi.bundle.version}",com.vaadin.v7.*;version="${osgi.bundle.version}"</Export-Package>
 
                         <Require-Bundle>
                             com.vaadin.server;bundle-version="${osgi.bundle.version}",

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/Container.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/Container.java
@@ -768,9 +768,8 @@ public interface Container extends Serializable {
         /**
          * Tests if the Item specified with <code>itemId</code> is a root Item.
          * The hierarchical container can have more than one root and must have
-         * at least one unless it is empty. The
-         * {@link #getParent(Object itemId)} method always returns
-         * <code>null</code> for root Items.
+         * at least one unless it is empty. The {@link #getParent(Object itemId)}
+         * method always returns <code>null</code> for root Items.
          *
          * @param itemId
          *            ID of the Item whose root status is to be tested
@@ -1268,7 +1267,6 @@ public interface Container extends Serializable {
          *             {@link #removePropertySetChangeListener(PropertySetChangeListener)}
          **/
         @Deprecated
-        public void removeListener(
-                Container.PropertySetChangeListener listener);
+        public void removeListener(Container.PropertySetChangeListener listener);
     }
 }

--- a/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/grid/GridColumnsTest.java
+++ b/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/grid/GridColumnsTest.java
@@ -410,4 +410,22 @@ public class GridColumnsTest {
 
         assertThat(firstColumn.getHeaderCaption(), is("Column0"));
     }
+
+    @Test(expected = IllegalStateException.class)
+    public void addColumnManyTimes() {
+        grid.removeAllColumns();
+        grid.addColumn("column0");
+        grid.addColumn("column0");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setColumnDuplicates() {
+        grid.removeAllColumns();
+        grid.setColumns("column0", "column0");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setColumnOrderDuplicates() {
+        grid.setColumnOrder("column0", "column0");
+    }
 }

--- a/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/grid/GridSelectionTest.java
+++ b/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/grid/GridSelectionTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -373,5 +374,38 @@ public class GridSelectionTest {
                 mockListener.getRemoved().iterator().next());
         assertEquals("selectedRows is correct", itemId2Present,
                 grid.getSelectedRow());
+    }
+
+    @Test
+    public void selectionChangeEventWhenChangingSelectionModeSingleToNone() {
+        grid.select(itemId1Present);
+        Assert.assertEquals(itemId1Present, grid.getSelectedRow());
+        mockListener.clearEvent();
+        grid.setSelectionMode(SelectionMode.NONE);
+        assertTrue(mockListener.eventHasHappened());
+        assertTrue(mockListener.getRemoved().contains(itemId1Present));
+    }
+
+    @Test
+    public void selectionChangeEventWhenChangingSelectionModeMultiToNone() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        grid.select(itemId1Present);
+        grid.select(itemId2Present);
+        mockListener.clearEvent();
+        grid.setSelectionMode(SelectionMode.NONE);
+        assertTrue(mockListener.eventHasHappened());
+        assertTrue(mockListener.getRemoved().contains(itemId1Present));
+        assertTrue(mockListener.getRemoved().contains(itemId2Present));
+    }
+
+    @Test
+    public void noSelectionChangeEventWhenChanginModeWithNoneSelected() {
+        mockListener.clearEvent();
+        grid.setSelectionMode(SelectionMode.SINGLE);
+        assertFalse(mockListener.eventHasHappened());
+        grid.setSelectionMode(SelectionMode.NONE);
+        assertFalse(mockListener.eventHasHappened());
+        grid.setSelectionMode(SelectionMode.MULTI);
+        assertFalse(mockListener.eventHasHappened());
     }
 }

--- a/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/grid/MultiSelectionModelTest.java
+++ b/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/grid/MultiSelectionModelTest.java
@@ -28,11 +28,19 @@ import com.vaadin.v7.data.Container;
 import com.vaadin.v7.data.util.IndexedContainer;
 import com.vaadin.v7.event.SelectionEvent;
 import com.vaadin.v7.event.SelectionEvent.SelectionListener;
+import com.vaadin.v7.shared.ui.grid.selection.MultiSelectionModelState;
 import com.vaadin.v7.ui.Grid;
-import com.vaadin.v7.ui.Grid.MultiSelectionModel;
-import com.vaadin.v7.ui.Grid.SelectionMode;
 
 public class MultiSelectionModelTest {
+
+    private static class MultiSelectionModel
+            extends com.vaadin.v7.ui.Grid.MultiSelectionModel {
+        @Override
+        protected MultiSelectionModelState getState() {
+            // Overridden to be accessible from test
+            return super.getState();
+        }
+    }
 
     private Object itemId1Present = "itemId1Present";
     private Object itemId2Present = "itemId2Present";
@@ -52,8 +60,8 @@ public class MultiSelectionModelTest {
     public void setUp() {
         dataSource = createDataSource();
         grid = new Grid(dataSource);
-        grid.setSelectionMode(SelectionMode.MULTI);
-        model = (MultiSelectionModel) grid.getSelectionModel();
+        model = new MultiSelectionModel();
+        grid.setSelectionModel(model);
     }
 
     @After
@@ -102,6 +110,17 @@ public class MultiSelectionModelTest {
         }
 
         verifyCurrentSelection(itemId1Present, itemId2Present);
+    }
+
+    @Test
+    public void testSelectAllWithoutItems() throws Throwable {
+        Assert.assertFalse(model.getState().allSelected);
+        dataSource.removeAllItems();
+        Assert.assertFalse(model.getState().allSelected);
+        model.select();
+        Assert.assertFalse(model.getState().allSelected);
+        model.deselect();
+        Assert.assertFalse(model.getState().allSelected);
     }
 
     @Test

--- a/documentation/addons/addons-cval.asciidoc
+++ b/documentation/addons/addons-cval.asciidoc
@@ -1,11 +1,11 @@
 ---
-title: Installing Commercial Vaadin Add-on Licence
+title: Installing Commercial Vaadin Add-on License
 order: 5
 layout: page
 ---
 
 [[addons.cval]]
-= Installing Commercial Vaadin Add-on Licence
+= Installing Commercial Vaadin Add-on License
 
 The commercial Vaadin add-ons require installing a license key before using
 them. The license keys are development licenses and checked during widget set

--- a/documentation/addons/addons-maven.asciidoc
+++ b/documentation/addons/addons-maven.asciidoc
@@ -76,7 +76,7 @@ Click [guilabel]#Activate# to buy a license, obtain a trial license key, or get 
 +
 image::img/directory-activate.png[width=50%, scaledwidth=70%]
 +
-For official Vaadin add-ons, see <<addons-cval#addons.cval, "Installing Commercial Vaadin Add-on Licence">> for more information.
+For official Vaadin add-ons, see <<addons-cval#addons.cval, "Installing Commercial Vaadin Add-on License">> for more information.
 
 . _In Vaadin 7.6 and older_: You need to compile the widget set as described in <<addons.maven.compiling>>.
 

--- a/documentation/addons/addons-overview.asciidoc
+++ b/documentation/addons/addons-overview.asciidoc
@@ -39,7 +39,7 @@ offered under a dual licensing agreement so that they can be used in open source
 projects for free, and many have a trial period for closed-source development.
 Commercial Vaadin add-ons distributed under the CVAL license require installing
 a license key as instructed in
-<<dummy/../../../framework/addons/addons-cval#addons.cval, "Installing Commercial Vaadin Add-on Licence">>.
+<<dummy/../../../framework/addons/addons-cval#addons.cval, "Installing Commercial Vaadin Add-on License">>.
 
 == Feedback and Support
 

--- a/documentation/advanced/advanced-spring.asciidoc
+++ b/documentation/advanced/advanced-spring.asciidoc
@@ -25,7 +25,7 @@ API documentation for add-ons is available at:
 * Vaadin Spring Boot API at link:https://vaadin.com/api/vaadin-spring-boot[vaadin.com/api/vaadin-spring-boot]
 
 To learn more about Vaadin Spring, the
-link:https://vaadin.com/wiki/-/wiki/Main/Vaadin+Spring[Vaadin Spring Tutorial]
+link:https://vaadin.github.io/spring-tutorial/[Vaadin Spring Tutorial]
 gives a hands-on introduction. The source code of the Spring Tutorial demo is
 available for browsing or cloning at
 link:https://github.com/Vaadin/spring-tutorial[github.com/Vaadin/spring-tutorial].
@@ -58,7 +58,7 @@ Framework Reference Documentation].
 
 * link:http://projects.spring.io/spring-framework/[Spring Project]
 
-* link:https://vaadin.com/wiki/-/wiki/Main/Vaadin+Spring[Vaadin Spring Tutorial]
+* link:https://vaadin.github.io/spring-tutorial/[Vaadin Spring Tutorial]
 
 endif::web[]
 
@@ -177,13 +177,12 @@ enables general Spring functionalities in a web application.
 
 You can use the Spring Initializr at
 link:https://start.spring.io/[start.spring.io] website to generate a project,
-which you can then download as a package and import in your IDE. The generated
-project is a Spring application stub; you need to add at least Vaadin
-dependencies ( [literal]#++vaadin-spring-boot++#, [literal]#++vaadin-themes++#,
-and [literal]#++vaadin-client-compiled++#) and a UI class to the generated
-project, as well as a theme, and so forth.
+which you can then download as a package and import in your IDE. Pick Vaadin as
+a dependency on the site to include all the required Vaadin Spring dependencies
+and auto-configuration.The generated project is a Spring application stub; you
+need to add at least a UI class to the generated project.
 
-See the link:https://vaadin.com/wiki/-/wiki/Main/Vaadin+Spring[Vaadin Spring
+See the link:https://vaadin.github.io/spring-tutorial/[Vaadin Spring
 Tutorial] for detailed instructions for using Spring Boot.
 
 
@@ -198,9 +197,9 @@ up the Development Environment">>.
 
 To install the Vaadin Spring and/or Vaadin Spring Boot add-ons, either define
 them as an Ivy or Maven dependency or download from the Vaadin Directory add-on
-page at <<,vaadin.com/directory#addon/vaadin-spring>> or
-<<,vaadin.com/directory#addon/vaadin-spring-boot>>. See
-<<dummy/../../../framework/addons/addons-overview.asciidoc#addons.overview,"Using
+page at link:https://vaadin.com/directory#addon/vaadin-spring[vaadin.com/directory#addon/vaadin-spring]
+or link:https://vaadin.com/directory#addon/vaadin-spring-boot[vaadin.com/directory#addon/vaadin-spring-boot].
+See <<dummy/../../../framework/addons/addons-overview.asciidoc#addons.overview,"Using
 Vaadin Add-ons">> for general instructions for installing and using Vaadin
 add-ons.
 
@@ -222,11 +221,17 @@ The Maven dependency is as follows:
     &lt;/dependency&gt;
 ----
 
+For Vaadin Spring Boot, depending on [literal]#++vaadin-spring-boot-starter++# will
+include all the required Vaadin dependencies.
+
+
 [[advanced.spring.preparing]]
 == Preparing Application for Spring
 
 A Vaadin application that uses Spring must have a file named
 [filename]#applicationContext.xml# in the [filename]#WEB-INF# directory.
+Using Spring Initializr automatically generates a suitable file, but if
+you configure Vaadin Spring manually, you can follow the model below.
 
 [subs="verbatim,replacements,quotes"]
 ----
@@ -249,7 +254,7 @@ A Vaadin application that uses Spring must have a file named
 &lt;/beans&gt;
 ----
 The application should not have a servlet extending [classname]#VaadinServlet#,
-as Vaadin servlet has its own [classname]#VaadinSpringServlet# that is deployed
+as Vaadin servlet has its own [classname]#SpringVaadinServlet# that is deployed
 automatically. If you need multiple servlets or need to customize the Vaadin
 Spring servlet, see <<advanced.spring.deployment>>.
 
@@ -345,7 +350,7 @@ that scope.
 === [classname]#@UIScope#
 
 UI-scoped beans are uniquely identified within a UI instance, that is, a browser
-window or tab. The lifecycle of UI-scoped beans is bound between to the
+window or tab. The lifecycle of UI-scoped beans is bound between the
 initialization and closing of a UI. Whenever you inject a bean, as long as you
 are within the same UI, you will get the same instance.
 
@@ -374,36 +379,36 @@ ifdef::web[]
 Vaadin Spring extends the navigation framework in Vaadin, described in
 <<dummy/../../../framework/advanced/advanced-navigator#advanced.navigator,"Navigating
 in an Application">>. It manages Spring views with a special view provider and
-enables view scoping.
+enables view scoping. Furthermore, Vaadin Spring provides a customized navigator class
+[classname]#SpringNavigator# that supports the scope functionality.
+
 
 [[advanced.spring.navigation.ui]]
 === Preparing the UI
 
-You can define navigation for any single-component container, as described in
+You can define navigation for any single-component container, component container or bean
+implementing [classname]#ViewDisplay#, as described in
 <<dummy/../../../framework/advanced/advanced-navigator#advanced.navigator.navigating,"Setting
 Up for Navigation">>, but typically you set up navigation for the entire UI
-content. To use Vaadin Spring views, you need to inject a
-[classname]#SpringViewProvider# in the UI and add it as a provider for the
-navigator.
+content. The easiest way to set up navigation is to use the annotation
+[classname]#@SpringViewDisplay# on the UI (in which case the whole contents of the UI are
+replaced on navigation) or on any UI scoped bean implementing one of the above mentioned
+interfaces.
 
 
 [source, java]
 ----
 @SpringUI(path="/myspringui")
+@SpringViewDisplay
 public class MySpringUI extends UI {
-    @Autowired
-    SpringViewProvider viewProvider;
-
     @Override
     protected void init(VaadinRequest request) {
-        Navigator navigator = new Navigator(this, this);
-        navigator.addProvider(viewProvider);
-
-        // Navigate to start view
-        navigator.navigateTo("");
     }
 }
 ----
+
+If not using Spring Boot, auto-configuration of navigation can be enabled with the annotation
+@EnableVaadinNavigation on a configuration class.
 
 
 [[advanced.spring.navigation.view]]
@@ -445,20 +450,8 @@ It is a recommended pattern to have the view name in a static member constant in
 the view class, as was done in the example previously, so that the name can be
 referred to safely.
 
-supportsParameters:: Specifies whether view parameters can be passed to the view as a suffix to the
-name in the navigation state, that is, in the form of
-[literal]#++viewname+viewparameters++#. The view name is merely a prefix and
-there is no separator nor format for the parameters, but those are left for the
-view to handle. The parameter support mode is disabled by default.
-
-
 +
-[source, java]
-----
-@SpringView(name="myview", supportsParameters=true)
-----
-+
-You could then navigate to the state with a URI fragment such as
+You can also navigate to a view with a URI fragment such as
 [literal]#++#!myview/someparameter++# or programmatically with:
 
 
@@ -470,12 +463,6 @@ getUI().getNavigator().navigateTo("myview/someparameter");
 +
 The [methodname]#enter()# method of the view gets the URI fragment as parameter
 as is and can interpret it in any application-defined way.
-
-+
-Note that in this mode, matching a navigation state to a view is done by the
-prefix of the fragment! Thereby, no other views may start with the name of the
-view as prefix. For example, if the view name is " [literal]#++main++#", you
-must not have a view named " [literal]#++maintenance++#".
 
 uis:: If the application has multiple UIs that use [classname]#SpringViewProvider#,
 you can use this parameter to specify which UIs can show the view.
@@ -556,33 +543,40 @@ by additional unofficial add-ons on top of Vaadin Spring.
 [[advanced.spring.accesscontrol.accessdenied]]
 === Access Denied View
 
-By default, the view provider acts as if a denied view didn't exist. You can set
+If access to a view is denied by an access control bean, the access denied view
+is shown for it. For non-existing views, the error view is shown. You can set
 up an "Access Denied" view that is shown if the access is denied with
-[methodname]#setAccessDeniedView()# in [classname]#SpringViewProvider#.
+[methodname]#setAccessDeniedViewClass()# in [classname]#SpringViewProvider#,
+and an error view with [methodname]#setErrorView()# in [classname]#SpringNavigator#.
+The same view can also be used both as an access denied view and as an error
+view to hide the existence of views the user is not allowed to access.
 
 
 [source, java]
 ----
 @Autowired
 SpringViewProvider viewProvider;
+@Autowired
+SpringNavigator navigator;
 
 @Override
 protected void init(VaadinRequest request) {
-    Navigator navigator = new Navigator(this, this);
-    navigator.addProvider(viewProvider);
-
     // Set up access denied view
     viewProvider.setAccessDeniedViewClass(
         MyAccessDeniedView.class);
+    // Set up error view
+    navigator.setErrorView(MyErrorView.class);
 ----
 
+Note that the error view can also be a class with which an error view bean is
+found. In this case, the error view must be UI scoped.
 
 
 [[advanced.spring.deployment]]
 == Deploying Spring UIs and Servlets
 
 Vaadin Spring hooks into Vaadin framework by using a special
-[classname]#VaadinSpringServlet#. As described earlier, you do not need to map
+[classname]#SpringVaadinServlet#. As described earlier, you do not need to map
 an URL path to a UI, as it is handled by Vaadin Spring. However, in the
 following, we go through some cases where you need to customize the servlet or
 use Spring with non-Spring servlets and UIs in a web application.
@@ -593,7 +587,7 @@ use Spring with non-Spring servlets and UIs in a web application.
 When customizing the Vaadin servlet, as outlined in
 <<dummy/../../../framework/application/application-lifecycle#application.lifecycle.servlet-service,"Vaadin
 Servlet, Portlet, and Service">>, you simply need to extend
-[classname]#com.vaadin.spring.internal.VaadinSpringServlet# instead of
+[classname]#com.vaadin.spring.server.SpringVaadinServlet# instead of
 [classname]#com.vaadin.servlet.VaadinServlet#.
 
 [subs="normal"]
@@ -611,7 +605,7 @@ an Application">>.
 [[advanced.spring.deployment.urlmapping]]
 === Defining Servlet Root
 
-Spring UIs are managed by a Spring servlet ( [classname]#VaadinSpringServlet#),
+Spring UIs are managed by a Spring servlet ( [classname]#SpringVaadinServlet#),
 which is by default mapped to the root of the application context. For example,
 if the name of a Spring UI is " [literal]#++my-spring-ui++#" and application
 context is [literal]#++/myproject++#, the UI would by default have URL "
@@ -648,7 +642,7 @@ You can also map the Spring servlet to another URL in servlet definition in
 [[advanced.spring.servlets.mixing]]
 === Mixing With Other Servlets
 
-The [classname]#VaadinSpringServlet# is normally used as the default servlet,
+The [classname]#SpringVaadinServlet# is normally used as the default servlet,
 but if you have other servlets in the application, such as for non-Spring UIs,
 you need to define the Spring servlet explicitly in the [filename]#web.xml#. You
 can map the servlet to any URL path, but perhaps typically, you define it as the
@@ -661,7 +655,7 @@ default servlet as follows, and map the other servlets to other URL paths:
   &lt;servlet&gt;
     &lt;servlet-name&gt;Default&lt;/servlet-name&gt;
     &lt;servlet-class&gt;
-      com.vaadin.spring.internal.VaadinSpringServlet
+      com.vaadin.spring.server.SpringVaadinServlet
     &lt;/servlet-class&gt;
   &lt;/servlet&gt;
 

--- a/scripts/BuildDemos.py
+++ b/scripts/BuildDemos.py
@@ -30,7 +30,7 @@ def dump_status(error_occurred):
 	pickle.dump(status_dump, open("result/demo_validation_status.pickle", "wb"))
 
 def log_status(log_string):
-	status_dump["messages"].add(log_string)
+	status_dump["messages"].append(log_string)
 	print(log_string)
 
 def checkout(folder, url, repoBranch = "master"):

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -189,7 +189,7 @@
                     <instructions>
                         <Bundle-RequiredExecutionEnvironment>${osgi.execution.environment}</Bundle-RequiredExecutionEnvironment>
                         <Bundle-Version>${osgi.bundle.version}</Bundle-Version>
-                        <Export-Package>com.vaadin.*;version="${osgi.bundle.version}"</Export-Package>
+                        <Export-Package>VAADIN;version="${osgi.bundle.version}",com.vaadin.*;version="${osgi.bundle.version}"</Export-Package>
                         <Import-Package>javax.servlet;version="${osgi.javax.servlet.version}",
                             javax.servlet.http;version="${osgi.javax.servlet.version}",
                             javax.validation;version="${javax.validation.version}";resolution:=optional,

--- a/server/src/main/java/com/vaadin/ui/UI.java
+++ b/server/src/main/java/com/vaadin/ui/UI.java
@@ -471,9 +471,23 @@ public abstract class UI extends AbstractSingleComponentContainer
                             "Error while detaching UI from session", e);
                 }
                 // Disable push when the UI is detached. Otherwise the
-                // push connection and possibly VaadinSession will live on.
+                // push connection and possibly VaadinSession will live
+                // on.
                 getPushConfiguration().setPushMode(PushMode.DISABLED);
-                setPushConnection(null);
+
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        // This intentionally does disconnect without locking
+                        // the VaadinSession to avoid deadlocks where the server
+                        // uses a lock for the websocket connection
+
+                        // See https://dev.vaadin.com/ticket/18436
+                        // The underlying problem is
+                        // https://dev.vaadin.com/ticket/16919
+                        setPushConnection(null);
+                    }
+                }).start();
             }
             this.session = session;
         }

--- a/server/src/test/java/com/vaadin/ui/UITest.java
+++ b/server/src/test/java/com/vaadin/ui/UITest.java
@@ -1,0 +1,155 @@
+package com.vaadin.ui;
+
+import java.util.Properties;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.servlet.ServletConfig;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.server.DefaultDeploymentConfiguration;
+import com.vaadin.server.MockServletConfig;
+import com.vaadin.server.MockVaadinSession;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.server.VaadinServlet;
+import com.vaadin.server.VaadinServletService;
+import com.vaadin.server.VaadinSession;
+import com.vaadin.server.communication.PushConnection;
+import com.vaadin.shared.communication.PushMode;
+
+public class UITest {
+
+    @Test
+    public void removeFromSessionWithExternalLock() throws Exception {
+        // See https://dev.vaadin.com/ticket/18436
+        final UI ui = new UI() {
+
+            @Override
+            protected void init(VaadinRequest request) {
+            }
+
+        };
+        final Lock externalLock = new ReentrantLock();
+
+        ServletConfig servletConfig = new MockServletConfig();
+        VaadinServlet servlet = new VaadinServlet();
+        servlet.init(servletConfig);
+
+        DefaultDeploymentConfiguration deploymentConfiguration = new DefaultDeploymentConfiguration(
+                UI.class, new Properties());
+
+        MockVaadinSession session = new MockVaadinSession(
+                new VaadinServletService(servlet, deploymentConfiguration));
+        session.lock();
+        ui.setSession(session);
+        ui.getPushConfiguration().setPushMode(PushMode.MANUAL);
+        ui.setPushConnection(new PushConnection() {
+
+            private boolean connected = true;
+
+            @Override
+            public void push() {
+            }
+
+            @Override
+            public boolean isConnected() {
+                return connected;
+            }
+
+            @Override
+            public void disconnect() {
+                externalLock.lock();
+                try {
+                    connected = false;
+                } finally {
+                    externalLock.unlock();
+                }
+
+            }
+        });
+        session.unlock();
+
+        final CountDownLatch websocketReachedCheckpoint = new CountDownLatch(1);
+        final CountDownLatch uiDisconnectReachedCheckpoint = new CountDownLatch(
+                1);
+
+        final VaadinSession uiSession = ui.getSession();
+        final ConcurrentLinkedQueue<Exception> exceptions = new ConcurrentLinkedQueue<Exception>();
+
+        // Simulates the websocket close thread
+        Runnable websocketClose = new Runnable() {
+            @Override
+            public void run() {
+                externalLock.lock();
+                // Wait for disconnect thread to lock VaadinSession
+                websocketReachedCheckpoint.countDown();
+                try {
+                    uiDisconnectReachedCheckpoint.await();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    exceptions.add(e);
+                    return;
+                }
+                uiSession.lock();
+                externalLock.unlock();
+            }
+        };
+
+        Runnable disconnectPushFromUI = new Runnable() {
+            @Override
+            public void run() {
+                uiSession.lock();
+                // Wait for websocket thread to lock external lock
+                uiDisconnectReachedCheckpoint.countDown();
+                try {
+                    websocketReachedCheckpoint.await();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    exceptions.add(e);
+                    return;
+                }
+
+                ui.setSession(null);
+                uiSession.unlock();
+            }
+        };
+
+        Thread websocketThread = new Thread(websocketClose);
+        websocketThread.start();
+        Thread uiDisconnectThread = new Thread(disconnectPushFromUI);
+        uiDisconnectThread.start();
+
+        websocketThread.join(5000);
+        uiDisconnectThread.join(5000);
+
+        if (websocketThread.isAlive() || uiDisconnectThread.isAlive()) {
+            websocketThread.interrupt();
+            uiDisconnectThread.interrupt();
+            Assert.fail("Threads are still running");
+        }
+        if (!exceptions.isEmpty()) {
+            for (Exception e : exceptions) {
+                e.printStackTrace();
+            }
+            Assert.fail("There were exceptions in the threads");
+        }
+
+        Assert.assertNull(ui.getSession());
+
+        // PushConnection is set to null in another thread. We need to wait for
+        // that to happen
+        for (int i = 0; i < 10; i++) {
+            if (ui.getPushConnection() == null) {
+                break;
+            }
+
+            Thread.sleep(500);
+        }
+        Assert.assertNull(ui.getPushConnection());
+
+    }
+}

--- a/shared/src/main/java/com/vaadin/shared/util/SharedUtil.java
+++ b/shared/src/main/java/com/vaadin/shared/util/SharedUtil.java
@@ -16,6 +16,9 @@
 package com.vaadin.shared.util;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 
 /**
@@ -123,6 +126,31 @@ public class SharedUtil implements Serializable {
         return join(parts, " ");
     }
 
+    /**
+     * Converts an UPPER_CASE_STRING to a human friendly format (Upper Case
+     * String).
+     * <p>
+     * Splits words on {@code _}. Examples:
+     * <p>
+     * {@literal MY_BEAN_CONTAINER} becomes {@literal My Bean Container}
+     * {@literal AWESOME_URL_FACTORY} becomes {@literal Awesome Url Factory}
+     * {@literal SOMETHING} becomes {@literal Something}
+     *
+     * @since 7.7.4
+     * @param upperCaseUnderscoreString
+     *            The input string in UPPER_CASE_UNDERSCORE format
+     * @return A human friendly version of the input
+     */
+    public static String upperCaseUnderscoreToHumanFriendly(
+            String upperCaseUnderscoreString) {
+        String[] parts = upperCaseUnderscoreString.replaceFirst("^_*", "")
+                .split("_");
+        for (int i = 0; i < parts.length; i++) {
+            parts[i] = capitalize(parts[i].toLowerCase(Locale.ENGLISH));
+        }
+        return join(parts, " ");
+    }
+
     private static boolean isAllUpperCase(String string) {
         for (int i = 0; i < string.length(); i++) {
             char c = string.charAt(i);
@@ -145,6 +173,9 @@ public class SharedUtil implements Serializable {
      * @return The constructed string of words and separators
      */
     public static String join(String[] parts, String separator) {
+        if (parts.length == 0) {
+            return "";
+        }
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < parts.length; i++) {
             sb.append(parts[i]);
@@ -195,6 +226,11 @@ public class SharedUtil implements Serializable {
         int dotLocation = string.lastIndexOf('.');
         if (dotLocation > 0 && dotLocation < string.length() - 1) {
             string = string.substring(dotLocation + 1);
+        }
+
+        if (string.matches("^[0-9A-Z_]+$")) {
+            // Deal with UPPER_CASE_PROPERTY_IDS
+            return upperCaseUnderscoreToHumanFriendly(string);
         }
 
         return camelCaseToHumanFriendly(string);
@@ -264,6 +300,41 @@ public class SharedUtil implements Serializable {
         }
 
         return join(parts, "");
+    }
+
+    /**
+     * Checks if the given array contains duplicates (according to
+     * {@link Object#equals(Object)}.
+     * 
+     * @param values
+     *            the array to check for duplicates
+     * @return <code>true</code> if the array contains duplicates,
+     *         <code>false</code> otherwise
+     */
+    public static boolean containsDuplicates(Object[] values) {
+        int uniqueCount = new HashSet<Object>(Arrays.asList(values)).size();
+        return uniqueCount != values.length;
+    }
+
+    /**
+     * Return duplicate values in the given array in the format
+     * "duplicateValue1, duplicateValue2".
+     * 
+     * @param values
+     *            the values to check for duplicates
+     * @return a comma separated string of duplicates or an empty string if no
+     *         duplicates were found
+     */
+    public static String getDuplicates(Object[] values) {
+        HashSet<Object> set = new HashSet<Object>();
+        LinkedHashSet<String> duplicates = new LinkedHashSet<String>();
+        for (Object o : values) {
+            if (!set.add(o)) {
+                duplicates.add(String.valueOf(o));
+            }
+
+        }
+        return join(duplicates.toArray(new String[duplicates.size()]), ", ");
     }
 
 }

--- a/shared/src/test/java/com/vaadin/shared/util/SharedUtilTest.java
+++ b/shared/src/test/java/com/vaadin/shared/util/SharedUtilTest.java
@@ -118,4 +118,64 @@ public class SharedUtilTest {
         }
     }
 
+    @Test
+    public void duplicatesInArray() {
+        Assert.assertTrue(
+                SharedUtil.containsDuplicates(new Object[] { "a", "a" }));
+        Assert.assertTrue(
+                SharedUtil.containsDuplicates(new Object[] { "a", "b", "a" }));
+        Assert.assertTrue(SharedUtil
+                .containsDuplicates(new Object[] { "a", "b", "a", "b" }));
+        Assert.assertTrue(
+                SharedUtil.containsDuplicates(new Object[] { 1, "b", 1 }));
+
+        Assert.assertFalse(SharedUtil.containsDuplicates(new Object[] {}));
+        Assert.assertFalse(SharedUtil.containsDuplicates(new Object[] { "a" }));
+        Assert.assertFalse(
+                SharedUtil.containsDuplicates(new Object[] { "a", "b" }));
+        Assert.assertFalse(
+                SharedUtil.containsDuplicates(new Object[] { "1", 1 }));
+    }
+
+    @Test
+    public void getDuplicates() {
+        Assert.assertEquals("", SharedUtil.getDuplicates(new Object[] { "a" }));
+        Assert.assertEquals("a",
+                SharedUtil.getDuplicates(new Object[] { "a", "a" }));
+        Assert.assertEquals("a, b",
+                SharedUtil.getDuplicates(new Object[] { "a", "b", "a", "b" }));
+        Assert.assertEquals("a, b, c", SharedUtil
+                .getDuplicates(new Object[] { "c", "a", "b", "a", "b", "c" }));
+        Assert.assertEquals("1.2",
+                SharedUtil.getDuplicates(new Object[] { 1.2, "a", 1.2 }));
+    }
+
+    @Test
+    public void propertyIdToHumanFriendly() {
+        Assert.assertEquals("", SharedUtil.propertyIdToHumanFriendly(""));
+        Assert.assertEquals("First Name",
+                SharedUtil.propertyIdToHumanFriendly("firstName"));
+        Assert.assertEquals("First Name",
+                SharedUtil.propertyIdToHumanFriendly("FirstName"));
+        Assert.assertEquals("First Name",
+                SharedUtil.propertyIdToHumanFriendly("FIRST_NAME"));
+        Assert.assertEquals("Firstname",
+                SharedUtil.propertyIdToHumanFriendly("FIRSTNAME"));
+
+        Assert.assertEquals("2015 Q3",
+                SharedUtil.propertyIdToHumanFriendly("2015_Q3"));
+        Assert.assertEquals("Column X",
+                SharedUtil.propertyIdToHumanFriendly("_COLUMN_X"));
+        Assert.assertEquals("Column X",
+                SharedUtil.propertyIdToHumanFriendly("__COLUMN_X"));
+        Assert.assertEquals("1column Foobar",
+                SharedUtil.propertyIdToHumanFriendly("1COLUMN_FOOBAR"));
+        Assert.assertEquals("Result 2015",
+                SharedUtil.propertyIdToHumanFriendly("RESULT_2015"));
+        Assert.assertEquals("2015result",
+                SharedUtil.propertyIdToHumanFriendly("2015RESULT"));
+        Assert.assertEquals("Result2015",
+                SharedUtil.propertyIdToHumanFriendly("RESULT2015"));
+
+    }
 }

--- a/test/addon-using-init-param-widget-set/src/test/java/com/vaadin/test/addonusinginitparamwidgetset/AddonUsingInitParamWidgetSetIT.java
+++ b/test/addon-using-init-param-widget-set/src/test/java/com/vaadin/test/addonusinginitparamwidgetset/AddonUsingInitParamWidgetSetIT.java
@@ -8,8 +8,9 @@ public class AddonUsingInitParamWidgetSetIT extends AbstractWidgetSetIT {
 
     @Test
     public void appStartsUserCanInteract() {
-        testAppStartsUserCanInteract("com.vaadin.DefaultWidgetSet");
-        assertUnknownComponentShown("com.vaadin.addon.contextmenu.ContextMenu");
+        testAppStartsUserCanInteract("com.vaadin.DefaultWidgetSet", true);
+        assertHasDebugMessage(
+                "does not contain an implementation for com.vaadin.addon.contextmenu.ContextMenu");
     }
 
 }

--- a/test/widget-set-testutil/src/test/java/com/vaadin/test/defaultwidgetset/AbstractWidgetSetIT.java
+++ b/test/widget-set-testutil/src/test/java/com/vaadin/test/defaultwidgetset/AbstractWidgetSetIT.java
@@ -1,5 +1,7 @@
 package com.vaadin.test.defaultwidgetset;
 
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -26,7 +28,16 @@ public abstract class AbstractWidgetSetIT extends TestBenchTestCase {
     }
 
     protected void testAppStartsUserCanInteract(String expectedWidgetSet) {
-        getDriver().get("http://localhost:8080");
+        testAppStartsUserCanInteract(expectedWidgetSet, false);
+    }
+
+    protected void testAppStartsUserCanInteract(String expectedWidgetSet,
+            boolean debug) {
+        String url = "http://localhost:8080";
+        if (debug) {
+            url += "?debug";
+        }
+        getDriver().get(url);
 
         TextFieldElement nameInput = $(TextFieldElement.class).first();
         nameInput.setValue("John Dåe");
@@ -54,6 +65,21 @@ public abstract class AbstractWidgetSetIT extends TestBenchTestCase {
                 By.className("vaadin-unknown-caption"));
         Assert.assertTrue(unknownComponentCaption.getText().contains(
                 "does not contain implementation for " + componentClass));
+    }
+
+    protected void assertHasDebugMessage(String message) {
+        List<WebElement> elements = getDriver().findElements(
+                By.xpath("//span[@class='v-debugwindow-message']"));
+        boolean found = false;
+        for (WebElement element : elements) {
+            if (element.getText().contains(message)) {
+                found = true;
+                break;
+            }
+        }
+        Assert.assertTrue(
+                "Cannot find debug message containing '" + message + "'",
+                found);
     }
 
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridRefreshRow.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridRefreshRow.java
@@ -1,0 +1,112 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.annotations.Theme;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUIWithLog;
+import com.vaadin.tests.util.Person;
+import com.vaadin.tests.util.PersonContainer;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Button.ClickEvent;
+import com.vaadin.ui.Button.ClickListener;
+import com.vaadin.ui.CheckBox;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.v7.ui.Grid;
+import com.vaadin.v7.ui.Grid.CellReference;
+import com.vaadin.v7.ui.Grid.CellStyleGenerator;
+import com.vaadin.v7.ui.Grid.RowReference;
+import com.vaadin.v7.ui.Grid.RowStyleGenerator;
+
+@Theme("valo")
+public class GridRefreshRow extends AbstractTestUIWithLog {
+
+    private PersonContainer container;
+    private Grid grid;
+
+    private boolean styles[] = new boolean[] { false, false, false };
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        getPage().getStyles()
+                .add(".rowstyle td {background-color: lightgreen !important;}");
+        getPage().getStyles()
+                .add("td.cellstyle {background-color: lightblue !important;}");
+        container = PersonContainer.createWithTestData(100);
+        container.addNestedContainerBean("address");
+        grid = new Grid(container);
+        grid.setWidth("800px");
+        grid.setRowStyleGenerator(new RowStyleGenerator() {
+            @Override
+            public String getStyle(RowReference row) {
+                int index = container.indexOfId(row.getItemId());
+                if (index < 3 && styles[index]) {
+                    return "rowstyle";
+                }
+
+                return null;
+            }
+        });
+        grid.setCellStyleGenerator(new CellStyleGenerator() {
+            @Override
+            public String getStyle(CellReference cell) {
+                int index = container.indexOfId(cell.getItemId());
+                if (index < 3 && styles[index]
+                        && "email".equals(cell.getPropertyId())) {
+                    return "cellstyle";
+                }
+
+                return null;
+            }
+        });
+        addComponent(grid);
+
+        addComponents(new HorizontalLayout(update(0), update(1), update(2)));
+        Button refresh10 = new Button("Refresh 0-9", new ClickListener() {
+            @Override
+            public void buttonClick(ClickEvent event) {
+                grid.refreshRows(container.getItemIds(0, 9).toArray());
+            }
+        });
+        refresh10.setId("refresh10");
+        addComponents(new HorizontalLayout(refresh(0), refresh(1), refresh(2),
+                new Button("Refresh non-existant", new ClickListener() {
+                    @Override
+                    public void buttonClick(ClickEvent event) {
+                        grid.refreshRows("foobar");
+                    }
+                })), refresh10);
+        addComponents(new HorizontalLayout(style(0), style(1), style(2)));
+    }
+
+    private Component style(final int i) {
+        final CheckBox checkBox = new CheckBox("Style for " + i);
+        checkBox.addValueChangeListener(
+                event -> styles[i] = checkBox.getValue());
+        checkBox.setId("style" + i);
+        return checkBox;
+    }
+
+    private Component update(final int i) {
+        Button button = new Button("Update " + i, new ClickListener() {
+            @Override
+            public void buttonClick(ClickEvent event) {
+                Person p = container.getIdByIndex(i);
+                p.setFirstName("!" + p.getFirstName());
+            }
+        });
+        button.setId("update" + i);
+        return button;
+    }
+
+    protected Component refresh(final int i) {
+        Button button = new Button("Refresh row " + i, new ClickListener() {
+            @Override
+            public void buttonClick(ClickEvent event) {
+                grid.refreshRows(container.getIdByIndex(i));
+            }
+        });
+        button.setId("refresh" + i);
+        return button;
+    }
+
+}

--- a/uitest/src/main/java/com/vaadin/tests/components/tree/TreeHtmlContentAllowed.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/tree/TreeHtmlContentAllowed.java
@@ -28,18 +28,20 @@ public class TreeHtmlContentAllowed extends AbstractReindeerTestUI {
         String htmlParent = "Some <b>html</b>";
         String textChild = "Child text";
         String htmlChild = "Child <i>html</i>";
+        String htmlElementChild = "Child <span id='my-html-element'>element html</span>";
 
         final Tree tree = new Tree("A tree");
         tree.addItem(textParent);
         tree.addItem(htmlParent);
         tree.addItem(textChild);
         tree.addItem(htmlChild);
-
+        tree.addItem(htmlElementChild);
         tree.setParent(textChild, textParent);
         tree.setParent(htmlChild, htmlParent);
 
         tree.setChildrenAllowed(textChild, false);
         tree.setChildrenAllowed(htmlChild, false);
+        tree.setChildrenAllowed(htmlElementChild, false);
 
         final CheckBox toggle = new CheckBox("HTML content allowed",
                 tree.isHtmlContentAllowed());

--- a/uitest/src/main/java/com/vaadin/tests/extensions/UnknownExtensionHandling.java
+++ b/uitest/src/main/java/com/vaadin/tests/extensions/UnknownExtensionHandling.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2014 Vaadin Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.extensions;
+
+import com.vaadin.server.AbstractClientConnector;
+import com.vaadin.server.AbstractExtension;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Label;
+
+public class UnknownExtensionHandling extends AbstractTestUI {
+
+    // Extension without @Connect counterpart
+    public static class MyExtension extends AbstractExtension {
+        @Override
+        public void extend(AbstractClientConnector target) {
+            super.extend(target);
+        }
+    }
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        Label label = new Label(
+                "A label with a missing extension, should cause sensible output in the debug window / browser console");
+
+        MyExtension extension = new MyExtension();
+        extension.extend(label);
+
+        addComponent(label);
+    }
+
+}

--- a/uitest/src/main/java/com/vaadin/tests/layoutmanager/ConcurrentModificationUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/layoutmanager/ConcurrentModificationUI.java
@@ -1,0 +1,29 @@
+package com.vaadin.tests.layoutmanager;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.ui.Alignment;
+import com.vaadin.ui.CssLayout;
+import com.vaadin.ui.FormLayout;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Panel;
+import com.vaadin.ui.UI;
+
+public class ConcurrentModificationUI extends UI {
+
+    @Override
+    protected void init(VaadinRequest request) {
+        Panel panel = new Panel();
+        setContent(panel);
+
+        FormLayout form = new FormLayout();
+        panel.setContent(form);
+
+        HorizontalLayout horizLyt = new HorizontalLayout();
+        form.addComponent(horizLyt);
+
+        CssLayout cssLyt = new CssLayout();
+        horizLyt.addComponent(cssLyt);
+        horizLyt.setComponentAlignment(cssLyt, Alignment.MIDDLE_LEFT);
+    }
+
+}

--- a/uitest/src/main/java/com/vaadin/tests/push/PushWebsocketDeadlockUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/push/PushWebsocketDeadlockUI.java
@@ -1,0 +1,120 @@
+package com.vaadin.tests.push;
+
+import com.vaadin.annotations.Push;
+import com.vaadin.server.SessionDestroyEvent;
+import com.vaadin.server.SessionDestroyListener;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.server.WrappedSession;
+import com.vaadin.shared.ui.ui.Transport;
+import com.vaadin.tests.components.AbstractTestUIWithLog;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Button.ClickEvent;
+import com.vaadin.ui.Button.ClickListener;
+import com.vaadin.ui.Label;
+
+@Push(transport = Transport.WEBSOCKET)
+public class PushWebsocketDeadlockUI extends AbstractTestUIWithLog {
+
+    // Test for https://dev.vaadin.com/ticket/18436
+    // Needs breakpoints to test, see ticket for more information
+    // Can reproduce on Tomcat 8, can't seem to reproduce using
+    // DevelopmentServerLauncher
+
+    // Rough steps to reproduce
+    // 1. Open test in a new Chrome window
+    // 2. Set breakpoint in PushHandler.connectionLost
+    // 3. Set breakpoint in UI.close
+    // 4. Set breakpoint in PushRequestHandler.handleRequest
+    // 5. Click the "schedule UI close" button
+    // 6. Close the Chrome window before the 5s timeout expires and ensure it
+    // really closes
+    // 7. Wait for three threads to hit their breakpoints
+    // 8. Continue/step forward in proper order (see ticket)
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        WrappedSession wrappedSession = getSession().getSession();
+        request.getService()
+                .addSessionDestroyListener(new SessionDestroyListener() {
+                    @Override
+                    public void sessionDestroy(SessionDestroyEvent e) {
+                        System.out.println(
+                                "Session " + e.getSession() + " destroyed");
+                    }
+                });
+        final Label l = new Label("Session timeout is "
+                + wrappedSession.getMaxInactiveInterval() + "s");
+        addComponents(l);
+
+        Button button = new Button("Invalidate session");
+        button.addClickListener(new ClickListener() {
+            @Override
+            public void buttonClick(ClickEvent e) {
+                System.out.println(
+                        "invalidating " + getSession() + " for http session "
+                                + getSession().getSession().getId());
+                getSession().getSession().invalidate();
+                System.out.println("invalidated " + getSession());
+            }
+        });
+        addComponents(button);
+        button = new Button("Close UI");
+        button.addClickListener(new ClickListener() {
+            @Override
+            public void buttonClick(ClickEvent e) {
+                System.out.println("closing UI " + getUIId() + " in session "
+                        + getSession() + " for http session "
+                        + getSession().getSession().getId());
+                close();
+            }
+        });
+        addComponents(button);
+        button = new Button("Schedule Close UI (5s delay)");
+        button.addClickListener(new ClickListener() {
+            @Override
+            public void buttonClick(ClickEvent e) {
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            Thread.sleep(5000);
+                        } catch (InterruptedException e1) {
+                            // TODO Auto-generated catch block
+                            e1.printStackTrace();
+                        }
+                        // Breakpoint here
+                        access(new Runnable() {
+                            @Override
+                            public void run() {
+                                close();
+                                System.out.println("closing UI " + getUIId()
+                                        + " in session " + getSession()
+                                        + " for http session "
+                                        + getSession().getSession().getId());
+
+                            }
+                        });
+
+                    }
+                }).start();
+            }
+        });
+        addComponents(button);
+        button = new Button("Slow (5s) operation");
+        button.addClickListener(new ClickListener() {
+            @Override
+            public void buttonClick(ClickEvent e) {
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException e1) {
+                    e1.printStackTrace();
+                }
+                addComponent(new Label("Slow operation done"));
+            }
+        });
+
+        addComponents(button);
+
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/UnknownComponentConnectorTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/UnknownComponentConnectorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2014 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+/**
+ * Tests that a user is notified about a missing component from the widgetset
+ */
+public class UnknownComponentConnectorTest extends MultiBrowserTest {
+
+    @Test
+    public void testConnectorNotFoundInWidgetset() throws Exception {
+        openTestURL();
+        WebElement component = vaadinElementById("no-connector-component");
+        assertTrue(component.getText().startsWith(
+                "Widgetset 'com.vaadin.DefaultWidgetSet' does not contain an "
+                        + "implementation for com.vaadin.tests.components.UnknownComponentConnector."
+                        + "ComponentWithoutConnector."));
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/abstractembedded/EmbeddedWithNullSourceTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/abstractembedded/EmbeddedWithNullSourceTest.java
@@ -31,7 +31,8 @@ public class EmbeddedWithNullSourceTest extends MultiBrowserTest {
     public List<DesiredCapabilities> getBrowsersToTest() {
         // No Flash on PhantomJS, IE 11 has a timeout issue, looks like a
         // IEDriver problem, not reproduced running locally.
-        return getBrowserCapabilities(Browser.CHROME, Browser.FIREFOX);
+        // Flash is disabled in Chrome.
+        return getBrowserCapabilities(Browser.FIREFOX);
     }
 
     @Test

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingWithNewItemsAllowedTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingWithNewItemsAllowedTest.java
@@ -65,6 +65,14 @@ public class ComboBoxSelectingWithNewItemsAllowedTest extends MultiBrowserTest {
     }
 
     @Test
+    public void itemIsAddedWhenClickingOutside() {
+        clearInputAndType("foo");
+        findElement(By.tagName("body")).click();
+        assertOneMoreThanInitial();
+        assertThatSelectedValueIs("foo");
+    }
+
+    @Test
     public void matchingSuggestionIsSelectedWithEnter() {
         typeInputAndHitEnter("a0");
 
@@ -122,14 +130,14 @@ public class ComboBoxSelectingWithNewItemsAllowedTest extends MultiBrowserTest {
     }
 
     @Test
-    public void noSelectionAfterMouseOut() {
+    public void selectionOnMouseOut() {
         typeInputAndHitEnter("a20");
         comboBoxElement.sendKeys(Keys.ARROW_DOWN, Keys.ARROW_DOWN);
 
         findElement(By.className("v-app")).click();
 
         assertInitialItemCount();
-        assertThatSelectedValueIs("a20");
+        assertThatSelectedValueIs("a21");
     }
 
     @Test

--- a/uitest/src/test/java/com/vaadin/tests/components/flash/FlashIsVisibleTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/flash/FlashIsVisibleTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.junit.Test;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
+import com.vaadin.testbench.parallel.Browser;
 import com.vaadin.tests.tb3.MultiBrowserTest;
 
 public class FlashIsVisibleTest extends MultiBrowserTest {
@@ -12,7 +13,10 @@ public class FlashIsVisibleTest extends MultiBrowserTest {
     @Override
     public List<DesiredCapabilities> getBrowsersToTest() {
         // FF and PhantomJS fail at Flash and ShiftClick
-        return getBrowsersSupportingShiftClick();
+        List<DesiredCapabilities> capabilities = getBrowsersSupportingShiftClick();
+        // Flash support in Chrome is disabled
+        capabilities.removeAll(getBrowserCapabilities(Browser.CHROME));
+        return capabilities;
     }
 
     @Test

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridRefreshRowTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridRefreshRowTest.java
@@ -1,0 +1,73 @@
+package com.vaadin.tests.components.grid;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.CheckBoxElement;
+import com.vaadin.testbench.elements.GridElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class GridRefreshRowTest extends SingleBrowserTest {
+
+    private GridElement grid;
+
+    @Test
+    public void refreshRow() {
+        openTestURL();
+        grid = $(GridElement.class).first();
+        update(0);
+        update(1);
+        update(2);
+        style(1);
+        style(2);
+
+        Assert.assertEquals("Lisa", grid.getCell(0, 1).getText());
+        Assert.assertEquals("Joshua", grid.getCell(1, 1).getText());
+        Assert.assertEquals("Marge", grid.getCell(2, 1).getText());
+
+        Assert.assertFalse(hasCssClass(grid.getRow(0), "rowstyle"));
+        Assert.assertFalse(hasCssClass(grid.getRow(1), "rowstyle"));
+        Assert.assertFalse(hasCssClass(grid.getRow(2), "rowstyle"));
+        Assert.assertFalse(hasCssClass(grid.getCell(0, 0), "cellstyle"));
+        Assert.assertFalse(hasCssClass(grid.getCell(1, 0), "cellstyle"));
+        Assert.assertFalse(hasCssClass(grid.getCell(2, 0), "cellstyle"));
+
+        refresh(1);
+        Assert.assertEquals("Lisa", grid.getCell(0, 1).getText());
+        Assert.assertEquals("!Joshua", grid.getCell(1, 1).getText());
+        Assert.assertEquals("Marge", grid.getCell(2, 1).getText());
+
+        Assert.assertFalse(hasCssClass(grid.getRow(0), "rowstyle"));
+        Assert.assertTrue(hasCssClass(grid.getRow(1), "rowstyle"));
+        Assert.assertFalse(hasCssClass(grid.getRow(2), "rowstyle"));
+        Assert.assertFalse(hasCssClass(grid.getCell(0, 0), "cellstyle"));
+        Assert.assertTrue(hasCssClass(grid.getCell(1, 0), "cellstyle"));
+        Assert.assertFalse(hasCssClass(grid.getCell(2, 0), "cellstyle"));
+
+        // Assert refreshing works many times and for many rows at the same time
+        update(0);
+        update(1);
+        update(2);
+        refresh10First();
+        Assert.assertEquals("!!Lisa", grid.getCell(0, 1).getText());
+        Assert.assertEquals("!!Joshua", grid.getCell(1, 1).getText());
+        Assert.assertEquals("!!Marge", grid.getCell(2, 1).getText());
+    }
+
+    private void refresh10First() {
+        $(ButtonElement.class).id("refresh10").click();
+    }
+
+    private void update(int i) {
+        $(ButtonElement.class).id("update" + i).click();
+    }
+
+    private void style(int i) {
+        $(CheckBoxElement.class).id("style" + i).click();
+    }
+
+    private void refresh(int i) {
+        $(ButtonElement.class).id("refresh" + i).click();
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/tree/TreeHtmlContentAllowedTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/tree/TreeHtmlContentAllowedTest.java
@@ -37,19 +37,32 @@ public class TreeHtmlContentAllowedTest extends SingleBrowserTest {
                 "unchecked", toggle.getValue());
 
         // Markup is seen as plain text
-        assertTreeCaptionTexts("Just text", "Some <b>html</b>");
+        assertTreeCaptionTexts("Just text", "Some <b>html</b>",
+                "Child <span id='my-html-element'>element html</span>");
 
         toggle.click();
-        assertTreeCaptionTexts("Just text", "Some html");
+        assertTreeCaptionTexts("Just text", "Some html", "Child element html");
 
         // Expand the HTML parent
         findElements(By.className("v-tree-node")).get(1).click();
 
-        assertTreeCaptionTexts("Just text", "Some html", "Child html");
+        assertTreeCaptionTexts("Just text", "Some html", "Child html",
+                "Child element html");
 
         toggle.click();
         assertTreeCaptionTexts("Just text", "Some <b>html</b>",
-                "Child <i>html</i>");
+                "Child <i>html</i>",
+                "Child <span id='my-html-element'>element html</span>");
+
+        toggle.click();
+        findElements(By.id("my-html-element")).get(0).click();
+        assertHtmlElementSelected();
+
+    }
+
+    private void assertHtmlElementSelected() {
+        TreeElement tree = $(TreeElement.class).first();
+        Assert.assertEquals(tree.getValue(), "Child element html");
     }
 
     private void assertTreeCaptionTexts(String... captions) {

--- a/uitest/src/test/java/com/vaadin/tests/components/ui/WindowAndUIShortcutsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ui/WindowAndUIShortcutsTest.java
@@ -17,7 +17,9 @@ package com.vaadin.tests.components.ui;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
 
 import com.vaadin.testbench.elements.ButtonElement;
 import com.vaadin.testbench.elements.TextFieldElement;
@@ -40,5 +42,20 @@ public class WindowAndUIShortcutsTest extends SingleBrowserTest {
         // "Close page" should not have been clicked
         Assert.assertTrue(
                 $(ButtonElement.class).caption("Close page").exists());
+    }
+
+    @Test
+    public void modalCurtainShouldNotTriggerShortcuts() {
+        openTestURL();
+        $(ButtonElement.class).caption("Show page").first().click();
+        $(ButtonElement.class).caption("Open dialog window").first().click();
+
+        WebElement curtain = findElement(
+                By.className("v-window-modalitycurtain"));
+        curtain.sendKeys(Keys.ESCAPE);
+        // "Close page" should not have been clicked
+        Assert.assertTrue(
+                $(ButtonElement.class).caption("Close page").exists());
+
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/extensions/UnknownExtensionHandlingTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/extensions/UnknownExtensionHandlingTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2014 Vaadin Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.extensions;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.tests.extensions.UnknownExtensionHandling.MyExtension;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class UnknownExtensionHandlingTest extends SingleBrowserTest {
+
+    @Test
+    public void testUnknownExtensionHandling() {
+        setDebug(true);
+        openTestURL();
+
+        openDebugLogTab();
+
+        Assert.assertTrue(
+                hasMessageContaining(MyExtension.class.getCanonicalName()));
+
+        Assert.assertFalse(hasMessageContaining("Hierachy claims"));
+    }
+
+    private boolean hasMessageContaining(String needle) {
+        List<WebElement> elements = findElements(
+                By.className("v-debugwindow-message"));
+        for (WebElement messageElement : elements) {
+            // Can't use getText() since element isn't scrolled into view
+            String text = (String) executeScript(
+                    "return arguments[0].textContent", messageElement);
+            if (text.contains(needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/layoutmanager/ConcurrentModificationUITest.java
+++ b/uitest/src/test/java/com/vaadin/tests/layoutmanager/ConcurrentModificationUITest.java
@@ -1,0 +1,16 @@
+package com.vaadin.tests.layoutmanager;
+
+import org.junit.Test;
+
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class ConcurrentModificationUITest extends SingleBrowserTest {
+
+    @Test
+    public void noExceptionWhenEnlarging() {
+        testBench().resizeViewPortTo(100, 100);
+        openTestURL("debug");
+        testBench().resizeViewPortTo(200, 200);
+        assertNoErrorNotifications();
+    }
+}

--- a/uitest/src/test/java/com/vaadin/v7/tests/components/grid/basicfeatures/server/GridScrollTest.java
+++ b/uitest/src/test/java/com/vaadin/v7/tests/components/grid/basicfeatures/server/GridScrollTest.java
@@ -54,4 +54,24 @@ public class GridScrollTest extends GridBasicFeaturesTest {
                 "0. Requested items 247 - 346", getLogRow(0));
         assertEquals("There should be only one log row", " ", getLogRow(1));
     }
+
+    @Test
+    public void workPendingWhileScrolling() {
+        openTestURL("theme=valo");
+        String script = "var c = window.vaadin.clients.runcomvaadintestscomponentsgridbasicfeaturesGridBasicFeatures;\n"
+                // Scroll down and cause lazy loading
+                + "c.getElementByPath(\"//Grid[0]#cell[21]\"); \n"
+                + "return c.isActive();";
+
+        Boolean active = (Boolean) executeScript(script);
+        assertTrue("Grid should be marked to have workPending while scrolling",
+                active);
+    }
+
+    @Test
+    public void scrollIntoViewThroughSubPart() {
+        openTestURL("theme=valo");
+        GridElement grid = $(GridElement.class).first();
+        assertEquals("(10, 0)", grid.getCell(10, 0).getText());
+    }
 }

--- a/uitest/src/test/java/com/vaadin/v7/tests/components/grid/basicfeatures/server/GridSelectionTest.java
+++ b/uitest/src/test/java/com/vaadin/v7/tests/components/grid/basicfeatures/server/GridSelectionTest.java
@@ -426,4 +426,44 @@ public class GridSelectionTest extends GridBasicFeaturesTest {
     private GridRowElement getRow(int i) {
         return getGridElement().getRow(i);
     }
+
+    @Test
+    public void changeSelectionModelSingleToNone() throws Exception {
+        openTestURL();
+
+        setSelectionModelSingle();
+        getGridElement().getCell(0, 0).click();
+        assertTrue("row should become selected", getRow(0).isSelected());
+        setSelectionModelNone();
+        assertFalse("row should become deselected", getRow(0).isSelected());
+        setSelectionModelSingle();
+        assertFalse("row should still be deselected", getRow(0).isSelected());
+        getGridElement().getCell(0, 0).click();
+        assertTrue("row should become selected", getRow(0).isSelected());
+    }
+
+    @Test
+    public void changeSelectionModelMultiToNone() throws Exception {
+        openTestURL();
+
+        setSelectionModelMulti();
+        getGridElement().getCell(0, 0).click();
+        getGridElement().getCell(1, 0).click();
+        getGridElement().getCell(2, 0).click();
+        assertTrue("row should become selected", getRow(0).isSelected());
+        assertTrue("row should become selected", getRow(1).isSelected());
+        assertTrue("row should become selected", getRow(2).isSelected());
+
+        setSelectionModelNone();
+        assertFalse("row should become deselected", getRow(0).isSelected());
+        assertFalse("row should become deselected", getRow(1).isSelected());
+        assertFalse("row should become deselected", getRow(2).isSelected());
+        setSelectionModelMulti();
+        assertFalse("row should still be deselected", getRow(0).isSelected());
+        assertFalse("row should still be deselected", getRow(1).isSelected());
+        assertFalse("row should still be deselected", getRow(2).isSelected());
+
+        getGridElement().getCell(0, 0).click();
+        assertTrue("row should become selected", getRow(0).isSelected());
+    }
 }

--- a/uitest/src/test/java/com/vaadin/v7/tests/components/grid/basicfeatures/server/GridStructureTest.java
+++ b/uitest/src/test/java/com/vaadin/v7/tests/components/grid/basicfeatures/server/GridStructureTest.java
@@ -514,4 +514,18 @@ public class GridStructureTest extends GridBasicFeaturesTest {
         selectMenuPath("Component", "Body rows", "Add third row");
         assertFalse(logContainsText("Exception occured"));
     }
+
+    @Test
+    public void getBodyRowCountJS() {
+        openTestURL();
+        GridElement grid = $(GridElement.class).first();
+        assertEquals(1000L,
+                executeScript("return arguments[0].getBodyRowCount()", grid));
+        selectMenuPath("Component", "Body rows", "Remove all rows");
+        assertEquals(0L,
+                executeScript("return arguments[0].getBodyRowCount()", grid));
+        selectMenuPath("Component", "Body rows", "Add first row");
+        assertEquals(1L,
+                executeScript("return arguments[0].getBodyRowCount()", grid));
+    }
 }


### PR DESCRIPTION
Commit messages for included changes:

Workaround for deadlock issue (#18436)
Never check the selectAll checkbox in an empty grid (#20301)
Check for duplicate property ids when setting Grid columns or column order (#20386)
Add Grid.refreshRows to allow refreshing individual rows (#16765)
Make UPPER_CASE_PROPERTY_IDS more human friendly by default (#20380)
Send selection change events when changing selection mode (#20391)
Update client side selection state when changing selection model (#20370)
Make Grid isWorkPending wait for scroll events to complete (#20417)
Make modal window block shortcuts for underlying components (#20366)
Update Hierarchical container JavaDocs to match code (#5864)
Allow a resize listener to fire a resize listener (#20338)
Publish Escalator.getBodyRowCount to JS (#20344)
Ensure #cell[N] always scrolls row N into view (#20423)
Use US english (license) in all places
Show a sensible message for missing extensions (#10799)
Make vaadin-server export the VAADIN package again (#20332)
Correct addon init param widgetset IT test.
Update @since tag for 7.7.4.
Update Vaadin Spring documentation for 1.1.0
Fix some modern browsers tests failures.
Make clicking outside a ComboBox add a pending new item (#18366)
Fix python list syntax in BuildDemos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/82)
<!-- Reviewable:end -->
