### PR TITLE
Add a SelectionMode shorthand for Grid.

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -68,10 +68,13 @@ import com.vaadin.shared.ui.grid.HeightMode;
 import com.vaadin.shared.ui.grid.SectionState;
 import com.vaadin.shared.util.SharedUtil;
 import com.vaadin.ui.Grid.FooterRow;
+import com.vaadin.ui.components.grid.AbstractSelectionModel;
 import com.vaadin.ui.components.grid.EditorImpl;
 import com.vaadin.ui.components.grid.Footer;
 import com.vaadin.ui.components.grid.Header;
 import com.vaadin.ui.components.grid.Header.Row;
+import com.vaadin.ui.components.grid.MultiSelectionModelImpl;
+import com.vaadin.ui.components.grid.NoSelectionModel;
 import com.vaadin.ui.components.grid.SingleSelectionModelImpl;
 import com.vaadin.ui.declarative.DesignContext;
 import com.vaadin.ui.renderers.AbstractRenderer;
@@ -131,12 +134,72 @@ public class Grid<T> extends AbstractListing<T>
     }
 
     /**
+     * Selection mode representing the built-in selection models in grid.
+     * <p>
+     * These enums can be used in {@link Grid#setSelectionMode(SelectionMode)}
+     * to easily switch between the build-in selection models.
+     *
+     * @see Grid#setSelectionMode(SelectionMode)
+     * @see Grid#setSelectionModel(GridSelectionModel)
+     */
+    public enum SelectionMode {
+
+        /**
+         * Single selection mode that maps to build-in
+         * {@link SingleSelectionModel}.
+         *
+         * @see SingleSelectionModelImpl
+         */
+        SINGLE {
+            @Override
+            protected <T> GridSelectionModel<T> createModel() {
+                return new SingleSelectionModelImpl<>();
+            }
+        },
+
+        /**
+         * Multiselection mode that maps to build-in
+         * {@link MultiSelectionModel}.
+         *
+         * @see MultiSelectionModelImpl
+         */
+        MULTI {
+            @Override
+            protected <T> GridSelectionModel<T> createModel() {
+                return new MultiSelectionModelImpl<>();
+            }
+        },
+
+        /**
+         * Selection model that doesn't allow selection.
+         *
+         * @see NoSelectionModel
+         */
+        NONE {
+            @Override
+            protected <T> GridSelectionModel<T> createModel() {
+                return new NoSelectionModel<>();
+            }
+        };
+
+        /**
+         * Creates the selection model to use with this enum.
+         *
+         * @param <T>
+         *            the type of items in the grid
+         * @return the selection model
+         */
+        protected abstract <T> GridSelectionModel<T> createModel();
+    }
+
+    /**
      * The server-side interface that controls Grid's selection state.
      * SelectionModel should extend {@link AbstractGridExtension}.
      * <p>
      *
      * @param <T>
      *            the grid bean type
+     * @see AbstractSelectionModel
      * @see SingleSelectionModel
      * @see MultiSelectionModel
      */
@@ -151,7 +214,7 @@ public class Grid<T> extends AbstractListing<T>
          * empty selection).
          */
         @Override
-        void remove();
+        public void remove();
     }
 
     /**
@@ -1672,29 +1735,33 @@ public class Grid<T> extends AbstractListing<T>
         }
 
         /**
-         * Merges column cells in the row. Original cells are hidden, and new merged cell is shown instead.
-         * The cell has a width of all merged cells together, inherits styles of the first merged cell
-         * but has empty caption.
+         * Merges column cells in the row. Original cells are hidden, and new
+         * merged cell is shown instead. The cell has a width of all merged
+         * cells together, inherits styles of the first merged cell but has
+         * empty caption.
          *
          * @param cellsToMerge
-         *            the cells which should be merged. The cells should not be merged to any other cell set.
+         *            the cells which should be merged. The cells should not be
+         *            merged to any other cell set.
          * @return the remaining visible cell after the merge
          *
-         *  @see #join(Grid.HeaderCell...)
+         * @see #join(Grid.HeaderCell...)
          * @see com.vaadin.ui.AbstractComponent#setCaption(String) setCaption
          */
         HeaderCell join(Set<HeaderCell> cellsToMerge);
 
         /**
-         * Merges column cells in the row. Original cells are hidden, and new merged cell is shown instead.
-         * The cell has a width of all merged cells together, inherits styles of the first merged cell
-         * but has empty caption.
+         * Merges column cells in the row. Original cells are hidden, and new
+         * merged cell is shown instead. The cell has a width of all merged
+         * cells together, inherits styles of the first merged cell but has
+         * empty caption.
          *
          * @param cellsToMerge
-         *            the cells which should be merged. The cells should not be merged to any other cell set.
+         *            the cells which should be merged. The cells should not be
+         *            merged to any other cell set.
          * @return the remaining visible cell after the merge
          *
-         *  @see #join(Set)
+         * @see #join(Set)
          * @see com.vaadin.ui.AbstractComponent#setCaption(String) setCaption
          */
         HeaderCell join(HeaderCell... cellsToMerge);
@@ -1797,12 +1864,14 @@ public class Grid<T> extends AbstractListing<T>
         }
 
         /**
-         * Merges column cells in the row. Original cells are hidden, and new merged cell is shown instead.
-         * The cell has a width of all merged cells together, inherits styles of the first merged cell
-         * but has empty caption.
+         * Merges column cells in the row. Original cells are hidden, and new
+         * merged cell is shown instead. The cell has a width of all merged
+         * cells together, inherits styles of the first merged cell but has
+         * empty caption.
          *
          * @param cellsToMerge
-         *            the cells which should be merged. The cells should not be merged to any other cell set.
+         *            the cells which should be merged. The cells should not be
+         *            merged to any other cell set.
          * @return the remaining visible cell after the merge
          *
          * @see #join(Grid.FooterCell...)
@@ -1811,18 +1880,20 @@ public class Grid<T> extends AbstractListing<T>
         FooterCell join(Set<FooterCell> cellsToMerge);
 
         /**
-         * Merges column cells in the row. Original cells are hidden, and new merged cell is shown instead.
-         * The cell has a width of all merged cells together, inherits styles of the first merged cell
-         * but has empty caption.
+         * Merges column cells in the row. Original cells are hidden, and new
+         * merged cell is shown instead. The cell has a width of all merged
+         * cells together, inherits styles of the first merged cell but has
+         * empty caption.
          *
          * @param cellsToMerge
-         *            the cells which should be merged. The cells should not be merged to any other cell set.
+         *            the cells which should be merged. The cells should not be
+         *            merged to any other cell set.
          * @return the remaining visible cell after the merge
          *
          * @see #join(Set)
          * @see com.vaadin.ui.AbstractComponent#setCaption(String) setCaption
          */
-        FooterCell join(FooterCell ... cellsToMerge);
+        FooterCell join(FooterCell... cellsToMerge);
     }
 
     /**
@@ -2114,7 +2185,7 @@ public class Grid<T> extends AbstractListing<T>
 
         setDefaultHeaderRow(appendHeaderRow());
 
-        selectionModel = new SingleSelectionModelImpl<>(this);
+        setSelectionModel(new SingleSelectionModelImpl<>());
 
         detailsManager = new DetailsManager<>();
         addExtension(detailsManager);
@@ -2967,7 +3038,7 @@ public class Grid<T> extends AbstractListing<T>
     }
 
     /**
-     * Returns the selection model for this listing.
+     * Returns the selection model for this grid.
      *
      * @return the selection model, not null
      */
@@ -3021,17 +3092,68 @@ public class Grid<T> extends AbstractListing<T>
     }
 
     /**
-     * Sets the selection model for this listing.
+     * Sets the selection model for the grid.
+     * <p>
+     * This method is for setting a custom selection model, and is
+     * {@code protected} because {@link #setSelectionMode(SelectionMode)} should
+     * be used for easy switching between built-in selection models.
      * <p>
      * The default selection model is {@link SingleSelectionModelImpl}.
+     * <p>
+     * To use a custom selection model, you can e.g. extend the grid call this
+     * method with your custom selection model.
      *
      * @param model
      *            the selection model to use, not {@code null}
+     *
+     * @see #setSelectionMode(SelectionMode)
      */
-    public void setSelectionModel(GridSelectionModel<T> model) {
+    @SuppressWarnings("unchecked")
+    protected void setSelectionModel(GridSelectionModel<T> model) {
         Objects.requireNonNull(model, "selection model cannot be null");
-        selectionModel.remove();
+        if (selectionModel != null) { // null when called from constructor
+            selectionModel.remove();
+        }
         selectionModel = model;
+
+        if (selectionModel instanceof AbstractListingExtension) {
+            ((AbstractListingExtension<T>) selectionModel).extend(this);
+        } else {
+            addExtension(selectionModel);
+        }
+    }
+
+    /**
+     * Sets the grid's selection mode.
+     * <p>
+     * The built-in selection models are:
+     * <ul>
+     * <li>{@link SelectionMode#SINGLE} -> {@link SingleSelectionModelImpl},
+     * <b>the default model</b></li>
+     * <li>{@link SelectionMode#MULTI} -> {@link MultiSelectionModelImpl}, with
+     * checkboxes in the first column for selection</li>
+     * <li>{@link SelectionMode#NONE} -> {@link NoSelectionModel}, preventing
+     * selection</li>
+     * </ul>
+     * <p>
+     * To use your custom selection model, you can use
+     * {@link #setSelectionModel(GridSelectionModel)}, see existing selection
+     * model implementations for example.
+     *
+     * @param selectionMode
+     *            the selection mode to switch to, not {@code null}
+     * @return the used selection model
+     *
+     * @see SelectionMode
+     * @see GridSelectionModel
+     * @see #setSelectionModel(GridSelectionModel)
+     */
+    public GridSelectionModel<T> setSelectionMode(SelectionMode selectionMode) {
+        Objects.requireNonNull(selectionMode, "Selection mode cannot be null.");
+        GridSelectionModel<T> model = selectionMode.createModel();
+        setSelectionModel(model);
+
+        return model;
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/components/grid/AbstractSelectionModel.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/AbstractSelectionModel.java
@@ -17,6 +17,8 @@ package com.vaadin.ui.components.grid;
 
 import com.vaadin.shared.data.DataCommunicatorConstants;
 import com.vaadin.shared.ui.grid.AbstractSelectionModelState;
+import com.vaadin.ui.AbstractListing;
+import com.vaadin.ui.Grid;
 import com.vaadin.ui.Grid.AbstractGridExtension;
 import com.vaadin.ui.Grid.GridSelectionModel;
 
@@ -51,6 +53,40 @@ public abstract class AbstractSelectionModel<T> extends AbstractGridExtension<T>
     protected AbstractSelectionModelState getState(boolean markAsDirty) {
         return (AbstractSelectionModelState) super.getState(markAsDirty);
     }
+
+    /**
+     * Returns the grid this selection model is attached to using, or throws
+     * {@link IllegalStateException} if not attached to any selection model.
+     *
+     * @return the grid this selection model is attached to
+     * @throws IllegalStateException
+     *             if this selection mode is not attached to any grid
+     */
+    protected Grid<T> getGrid() throws IllegalStateException {
+        Grid<T> parent = getParent();
+        if (parent == null) {
+            throw new IllegalStateException(
+                    "This selection model is no currently attached to any grid.");
+        }
+        return parent;
+    }
+
+    @Override
+    public void extend(AbstractListing<T> grid) {
+        if (getParent() != null) {
+            throw new IllegalStateException(
+                    "This selection model has been bound to a grid already. Please remove the existing binding with model.remove() first.");
+        }
+        // type is verified in parent
+        super.extend(grid);
+
+        init();
+    }
+
+    /**
+     * Initializes the selection model after it has been attached to a grid.
+     */
+    protected abstract void init();
 
     @Override
     public void remove() {

--- a/server/src/main/java/com/vaadin/ui/components/grid/MultiSelectionModelImpl.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/MultiSelectionModelImpl.java
@@ -27,12 +27,12 @@ import java.util.stream.Stream;
 
 import com.vaadin.event.selection.MultiSelectionEvent;
 import com.vaadin.event.selection.MultiSelectionListener;
+import com.vaadin.server.data.DataCommunicator;
 import com.vaadin.server.data.DataProvider;
 import com.vaadin.server.data.Query;
 import com.vaadin.shared.Registration;
 import com.vaadin.shared.data.selection.GridMultiSelectServerRpc;
 import com.vaadin.shared.ui.grid.MultiSelectionModelState;
-import com.vaadin.ui.Grid;
 import com.vaadin.ui.Grid.MultiSelectionModel;
 import com.vaadin.ui.MultiSelect;
 import com.vaadin.util.ReflectTools;
@@ -127,22 +127,12 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
             .findMethod(MultiSelectionListener.class, "accept",
                     MultiSelectionEvent.class);
 
-    private final Grid<T> grid;
-
     private Set<T> selection = new LinkedHashSet<>();
 
     private SelectAllCheckBoxVisible selectAllCheckBoxVisible = SelectAllCheckBoxVisible.DEFAULT;
 
-    /**
-     * Constructs a new multiselection model for the given grid.
-     *
-     * @param grid
-     *            the grid to bind the selection model into
-     */
-    public MultiSelectionModelImpl(Grid<T> grid) {
-        this.grid = grid;
-        extend(grid);
-
+    @Override
+    protected void init() {
         registerRpc(new GridMultiSelectServerRpcImpl());
     }
 
@@ -164,7 +154,7 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
      * in- memory.
      *
      * @param selectAllCheckBoxVisible
-     *            the mode to use
+     *            the visiblity mode to use
      * @see SelectAllCheckBoxVisible
      */
     public void setSelectAllCheckBoxVisible(
@@ -178,7 +168,7 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
     /**
      * Gets the current mode for the select all checkbox visibility.
      *
-     * @return the select all checkbox visibility state
+     * @return the select all checkbox visibility mode
      * @see SelectAllCheckBoxVisible
      * @see #isSelectAllCheckBoxVisible()
      */
@@ -245,8 +235,8 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
             getState(false).selectAllCheckBoxVisible = false;
             break;
         case DEFAULT:
-            getState(false).selectAllCheckBoxVisible = grid.getDataProvider()
-                    .isInMemory();
+            getState(false).selectAllCheckBoxVisible = getGrid()
+                    .getDataProvider().isInMemory();
             break;
         default:
             break;
@@ -384,7 +374,7 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
             getState().allSelected = true;
         }
 
-        DataProvider<T, ?> dataSource = grid.getDataProvider();
+        DataProvider<T, ?> dataSource = getGrid().getDataProvider();
         // this will fetch everything from backend
         Stream<T> stream = dataSource.fetch(new Query<>());
         LinkedHashSet<T> allItems = new LinkedHashSet<>();
@@ -460,8 +450,10 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
             set.addAll(addedItems);
 
             // refresh method is NOOP for items that are not present client side
-            removedItems.forEach(grid.getDataCommunicator()::refresh);
-            addedItems.forEach(grid.getDataCommunicator()::refresh);
+            DataCommunicator<T, ?> dataCommunicator = getGrid()
+                    .getDataCommunicator();
+            removedItems.forEach(dataCommunicator::refresh);
+            addedItems.forEach(dataCommunicator::refresh);
         }, userOriginated);
     }
 
@@ -475,7 +467,7 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
         LinkedHashSet<T> oldSelection = new LinkedHashSet<>(selection);
         handler.accept(selection);
 
-        fireEvent(new MultiSelectionEvent<>(grid, asMultiSelect(), oldSelection,
-                userOriginated));
+        fireEvent(new MultiSelectionEvent<>(getGrid(), asMultiSelect(),
+                oldSelection, userOriginated));
     }
 }

--- a/server/src/main/java/com/vaadin/ui/components/grid/NoSelectionModel.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/NoSelectionModel.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.vaadin.server.AbstractExtension;
-import com.vaadin.ui.Grid;
 import com.vaadin.ui.Grid.GridSelectionModel;
 
 /**
@@ -35,16 +34,6 @@ import com.vaadin.ui.Grid.GridSelectionModel;
  */
 public class NoSelectionModel<T> extends AbstractExtension
         implements GridSelectionModel<T> {
-
-    /**
-     * Creates a new no selection model and attaches it for the given grid.
-     *
-     * @param grid
-     *            the grid to bind the selection model into
-     */
-    public NoSelectionModel(Grid<T> grid) {
-        extend(grid);
-    }
 
     @Override
     public Set<T> getSelectedItems() {

--- a/server/src/main/java/com/vaadin/ui/components/grid/SingleSelectionModelImpl.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/SingleSelectionModelImpl.java
@@ -29,7 +29,6 @@ import com.vaadin.shared.Registration;
 import com.vaadin.shared.data.selection.SelectionServerRpc;
 import com.vaadin.shared.ui.grid.SingleSelectionModelState;
 import com.vaadin.ui.Component;
-import com.vaadin.ui.Grid;
 import com.vaadin.ui.Grid.SingleSelectionModel;
 import com.vaadin.ui.SingleSelect;
 import com.vaadin.util.ReflectTools;
@@ -50,18 +49,10 @@ public class SingleSelectionModelImpl<T> extends AbstractSelectionModel<T>
             .findMethod(SingleSelectionListener.class, "accept",
                     SingleSelectionEvent.class);
 
-    private final Grid<T> grid;
     private T selectedItem = null;
 
-    /**
-     * Constructs a new single selection model for the given grid.
-     *
-     * @param grid
-     *            the grid to bind the selection model into
-     */
-    public SingleSelectionModelImpl(Grid<T> grid) {
-        this.grid = grid;
-        extend(grid);
+    @Override
+    protected void init() {
         registerRpc(new SelectionServerRpc() {
 
             @Override
@@ -159,11 +150,11 @@ public class SingleSelectionModelImpl<T> extends AbstractSelectionModel<T>
         }
 
         if (selectedItem != null) {
-            grid.getDataCommunicator().refresh(selectedItem);
+            getGrid().getDataCommunicator().refresh(selectedItem);
         }
         selectedItem = getData(key);
         if (selectedItem != null) {
-            grid.getDataCommunicator().refresh(selectedItem);
+            getGrid().getDataCommunicator().refresh(selectedItem);
         }
     }
 
@@ -183,7 +174,8 @@ public class SingleSelectionModelImpl<T> extends AbstractSelectionModel<T>
         }
 
         doSetSelectedKey(key);
-        fireEvent(new SingleSelectionEvent<>(grid, asSingleSelect(), true));
+        fireEvent(
+                new SingleSelectionEvent<>(getGrid(), asSingleSelect(), true));
     }
 
     /**
@@ -203,7 +195,8 @@ public class SingleSelectionModelImpl<T> extends AbstractSelectionModel<T>
         }
 
         doSetSelectedKey(key);
-        fireEvent(new SingleSelectionEvent<>(grid, asSingleSelect(), false));
+        fireEvent(
+                new SingleSelectionEvent<>(getGrid(), asSingleSelect(), false));
     }
 
     /**
@@ -218,7 +211,7 @@ public class SingleSelectionModelImpl<T> extends AbstractSelectionModel<T>
             return null;
         } else {
             // TODO creates a key if item not in data provider
-            return grid.getDataCommunicator().getKeyMapper().key(item);
+            return getGrid().getDataCommunicator().getKeyMapper().key(item);
         }
     }
 

--- a/server/src/test/java/com/vaadin/data/GridAsMultiSelectInBinder.java
+++ b/server/src/test/java/com/vaadin/data/GridAsMultiSelectInBinder.java
@@ -24,9 +24,9 @@ import com.vaadin.tests.data.bean.BeanWithEnums;
 import com.vaadin.tests.data.bean.Sex;
 import com.vaadin.tests.data.bean.TestEnum;
 import com.vaadin.ui.Grid;
+import com.vaadin.ui.Grid.SelectionMode;
 import com.vaadin.ui.MultiSelect;
 import com.vaadin.ui.components.grid.MultiSelectionModelImpl;
-import com.vaadin.ui.components.grid.SingleSelectionModelImpl;
 
 public class GridAsMultiSelectInBinder
         extends BinderTestBase<Binder<BeanWithEnums>, BeanWithEnums> {
@@ -50,10 +50,6 @@ public class GridAsMultiSelectInBinder
 
     private class CustomMultiSelectModel extends MultiSelectionModelImpl<Sex> {
 
-        public CustomMultiSelectModel(Grid<Sex> grid) {
-            super(grid);
-        }
-
         @Override
         public void updateSelection(Set<Sex> addedItems, Set<Sex> removedItems,
                 boolean userOriginated) {
@@ -72,7 +68,7 @@ public class GridAsMultiSelectInBinder
         item = new BeanWithEnums();
         grid = new Grid<>();
         grid.setItems(TestEnum.values());
-        grid.setSelectionModel(new MultiSelectionModelImpl<>(grid));
+        grid.setSelectionMode(SelectionMode.MULTI);
         select = grid.asMultiSelect();
 
         converterBinder.forField(select)
@@ -82,7 +78,7 @@ public class GridAsMultiSelectInBinder
 
     @Test(expected = IllegalStateException.class)
     public void boundGridInBinder_selectionModelChanged_throws() {
-        grid.setSelectionModel(new SingleSelectionModelImpl<>(grid));
+        grid.setSelectionMode(SelectionMode.SINGLE);
 
         select.select(TestEnum.ONE);
     }
@@ -204,9 +200,12 @@ public class GridAsMultiSelectInBinder
 
     @Test
     public void addValueChangeListener_selectionUpdated_eventTriggeredForMultiSelect() {
-        Grid<Sex> grid = new Grid<>();
-        CustomMultiSelectModel model = new CustomMultiSelectModel(grid);
-        grid.setSelectionModel(model);
+        CustomMultiSelectModel model = new CustomMultiSelectModel();
+        Grid<Sex> grid = new Grid<Sex>() {
+            {
+                setSelectionModel(model);
+            }
+        };
         grid.setItems(Sex.values());
         MultiSelect<Sex> select = grid.asMultiSelect();
 

--- a/server/src/test/java/com/vaadin/data/GridAsSingleSelectInBinder.java
+++ b/server/src/test/java/com/vaadin/data/GridAsSingleSelectInBinder.java
@@ -15,8 +15,8 @@ import org.junit.Test;
 import com.vaadin.tests.data.bean.Person;
 import com.vaadin.tests.data.bean.Sex;
 import com.vaadin.ui.Grid;
+import com.vaadin.ui.Grid.SelectionMode;
 import com.vaadin.ui.SingleSelect;
-import com.vaadin.ui.components.grid.MultiSelectionModelImpl;
 import com.vaadin.ui.components.grid.SingleSelectionModelImpl;
 
 public class GridAsSingleSelectInBinder
@@ -30,11 +30,8 @@ public class GridAsSingleSelectInBinder
         }
     }
 
-    private class CustomSingleSelectModel extends SingleSelectionModelImpl<Sex> {
-
-        public CustomSingleSelectModel(Grid<Sex> grid) {
-            super(grid);
-        }
+    private class CustomSingleSelectModel
+            extends SingleSelectionModelImpl<Sex> {
 
         public void setSelectedFromClient(Sex item) {
             setSelectedFromClient(itemToKey(item));
@@ -55,7 +52,7 @@ public class GridAsSingleSelectInBinder
 
     @Test(expected = IllegalStateException.class)
     public void boundGridInBinder_selectionModelChanged_throws() {
-        grid.setSelectionModel(new MultiSelectionModelImpl<>(grid));
+        grid.setSelectionMode(SelectionMode.MULTI);
 
         select.setValue(Sex.MALE);
     }
@@ -126,7 +123,7 @@ public class GridAsSingleSelectInBinder
     @Test
     public void addValueChangeListener_selectionUpdated_eventTriggeredForSelect() {
         GridWithCustomSingleSelectionModel grid = new GridWithCustomSingleSelectionModel();
-        CustomSingleSelectModel model = new CustomSingleSelectModel(grid);
+        CustomSingleSelectModel model = new CustomSingleSelectModel();
         grid.setSelectionModel(model);
         grid.setItems(Sex.values());
         select = grid.asSingleSelect();

--- a/server/src/test/java/com/vaadin/tests/components/grid/GridMultiSelectionModelTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/grid/GridMultiSelectionModelTest.java
@@ -32,10 +32,10 @@ import com.vaadin.shared.Registration;
 import com.vaadin.tests.util.MockUI;
 import com.vaadin.ui.Grid;
 import com.vaadin.ui.Grid.GridSelectionModel;
+import com.vaadin.ui.Grid.SelectionMode;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.components.grid.MultiSelectionModelImpl;
 import com.vaadin.ui.components.grid.MultiSelectionModelImpl.SelectAllCheckBoxVisible;
-import com.vaadin.ui.components.grid.SingleSelectionModelImpl;
 
 import elemental.json.JsonObject;
 
@@ -55,10 +55,6 @@ public class GridMultiSelectionModelTest {
             extends MultiSelectionModelImpl<String> {
         public final Map<String, Boolean> generatedData = new LinkedHashMap<>();
 
-        public CustomMultiSelectionModel(Grid<String> grid) {
-            super(grid);
-        }
-
         @Override
         public void generateData(String item, JsonObject jsonObject) {
             super.generateData(item, jsonObject);
@@ -68,11 +64,24 @@ public class GridMultiSelectionModelTest {
 
     }
 
+    public static class CustomSelectionModelGrid extends Grid<String> {
+        public CustomSelectionModelGrid() {
+            this(new CustomMultiSelectionModel());
+        }
+
+        public CustomSelectionModelGrid(
+                GridSelectionModel<String> selectionModel) {
+            super();
+            setSelectionModel(selectionModel);
+        }
+    }
+
     @Before
     public void setUp() {
         grid = new Grid<>();
-        selectionModel = new MultiSelectionModelImpl<>(grid);
-        grid.setSelectionModel(selectionModel);
+        selectionModel = (MultiSelectionModelImpl<Person>) grid
+                .setSelectionMode(SelectionMode.MULTI);
+
         grid.setItems(PERSON_A, PERSON_B, PERSON_C);
 
         currentSelectionCapture = new Capture<>();
@@ -90,7 +99,7 @@ public class GridMultiSelectionModelTest {
 
     @Test(expected = IllegalStateException.class)
     public void selectionModelChanged_usingPreviousSelectionModel_throws() {
-        grid.setSelectionModel(new SingleSelectionModelImpl<>(grid));
+        grid.setSelectionMode(SelectionMode.SINGLE);
 
         selectionModel.select(PERSON_A);
     }
@@ -98,7 +107,7 @@ public class GridMultiSelectionModelTest {
     @Test
     public void changingSelectionModel_firesSelectionEvent() {
         Grid<String> customGrid = new Grid<>();
-        customGrid.setSelectionModel(new MultiSelectionModelImpl<>(customGrid));
+        customGrid.setSelectionMode(SelectionMode.MULTI);
         customGrid.setItems("Foo", "Bar", "Baz");
 
         List<String> selectionChanges = new ArrayList<>();
@@ -120,8 +129,7 @@ public class GridMultiSelectionModelTest {
         assertEquals(Arrays.asList("Foo", "Bar"), selectionChanges);
         selectionChanges.clear();
 
-        customGrid
-                .setSelectionModel(new SingleSelectionModelImpl<>(customGrid));
+        customGrid.setSelectionMode(SelectionMode.SINGLE);
         assertFalse(customGrid.getSelectionModel().getFirstSelectedItem()
                 .isPresent());
         assertEquals(Arrays.asList(), selectionChanges);
@@ -131,12 +139,11 @@ public class GridMultiSelectionModelTest {
 
     @Test
     public void serverSideSelection_GridChangingSelectionModel_sendsUpdatedRowsToClient() {
-        Grid<String> customGrid = new Grid<>();
+        Grid<String> customGrid = new CustomSelectionModelGrid();
+        CustomMultiSelectionModel customModel = (CustomMultiSelectionModel) customGrid
+                .getSelectionModel();
         customGrid.setItems("Foo", "Bar", "Baz");
 
-        CustomMultiSelectionModel customModel = new CustomMultiSelectionModel(
-                customGrid);
-        customGrid.setSelectionModel(customModel);
         customGrid.getDataCommunicator().beforeClientResponse(true);
 
         Assert.assertFalse("Item should have been updated as selected",
@@ -172,8 +179,7 @@ public class GridMultiSelectionModelTest {
 
         // switch to single to cause event
         customModel.generatedData.clear();
-        customGrid
-                .setSelectionModel(new SingleSelectionModelImpl<>(customGrid));
+        customGrid.setSelectionMode(SelectionMode.SINGLE);
         customGrid.getDataCommunicator().beforeClientResponse(false);
 
         // changing selection model should trigger row updates, but the old
@@ -184,8 +190,7 @@ public class GridMultiSelectionModelTest {
     @Test
     public void select_gridWithStrings() {
         Grid<String> gridWithStrings = new Grid<>();
-        gridWithStrings.setSelectionModel(
-                new MultiSelectionModelImpl<>(gridWithStrings));
+        gridWithStrings.setSelectionMode(SelectionMode.MULTI);
         gridWithStrings.setItems("Foo", "Bar", "Baz");
 
         GridSelectionModel<String> model = gridWithStrings.getSelectionModel();
@@ -545,13 +550,11 @@ public class GridMultiSelectionModelTest {
     @SuppressWarnings({ "serial" })
     @Test
     public void addValueChangeListener() {
+        String value = "foo";
+
         AtomicReference<MultiSelectionListener<String>> selectionListener = new AtomicReference<>();
         Registration registration = Mockito.mock(Registration.class);
-        Grid<String> grid = new Grid<>();
-        grid.setItems("foo", "bar");
-        String value = "foo";
-        MultiSelectionModelImpl<String> select = new MultiSelectionModelImpl<String>(
-                grid) {
+        MultiSelectionModelImpl<String> model = new MultiSelectionModelImpl<String>() {
             @Override
             public Registration addSelectionListener(
                     MultiSelectionListener<String> listener) {
@@ -565,15 +568,19 @@ public class GridMultiSelectionModelTest {
             }
         };
 
+        Grid<String> grid = new CustomSelectionModelGrid(model);
+
+        grid.setItems("foo", "bar");
+
         AtomicReference<MultiSelectionEvent<String>> event = new AtomicReference<>();
-        Registration actualRegistration = select.addSelectionListener(evt -> {
+        Registration actualRegistration = model.addSelectionListener(evt -> {
             Assert.assertNull(event.get());
             event.set(evt);
         });
         Assert.assertSame(registration, actualRegistration);
 
         selectionListener.get().accept(new MultiSelectionEvent<>(grid,
-                select.asMultiSelect(), Collections.emptySet(), true));
+                model.asMultiSelect(), Collections.emptySet(), true));
 
         Assert.assertEquals(grid, event.get().getComponent());
         Assert.assertEquals(new LinkedHashSet<>(Arrays.asList(value)),
@@ -583,14 +590,13 @@ public class GridMultiSelectionModelTest {
 
     @Test
     public void selectAllCheckboxVisible__inMemoryDataProvider() {
-        Grid<String> grid = new Grid<>();
         UI ui = new MockUI();
+
+        Grid<String> grid = new Grid<>();
+        MultiSelectionModelImpl<String> model = (MultiSelectionModelImpl<String>) grid
+                .setSelectionMode(SelectionMode.MULTI);
+
         ui.setContent(grid);
-
-        MultiSelectionModelImpl<String> model = new MultiSelectionModelImpl<>(
-                grid);
-        grid.setSelectionModel(model);
-
         // no items yet, default data provider is empty not in memory one
         Assert.assertFalse(model.isSelectAllCheckBoxVisible());
         Assert.assertEquals(SelectAllCheckBoxVisible.DEFAULT,
@@ -624,9 +630,8 @@ public class GridMultiSelectionModelTest {
         UI ui = new MockUI();
         ui.setContent(grid);
 
-        MultiSelectionModelImpl<String> model = new MultiSelectionModelImpl<>(
-                grid);
-        grid.setSelectionModel(model);
+        MultiSelectionModelImpl<String> model = (MultiSelectionModelImpl<String>) grid
+                .setSelectionMode(SelectionMode.MULTI);
 
         // no items yet, default data provider is empty not in memory one
         Assert.assertFalse(model.isSelectAllCheckBoxVisible());
@@ -662,8 +667,7 @@ public class GridMultiSelectionModelTest {
         Assert.assertFalse(model.isSelectAllCheckBoxVisible());
 
         // change back to depends on data provider
-        model.setSelectAllCheckBoxVisible(
-                SelectAllCheckBoxVisible.DEFAULT);
+        model.setSelectAllCheckBoxVisible(SelectAllCheckBoxVisible.DEFAULT);
 
         Assert.assertFalse(model.isSelectAllCheckBoxVisible());
         Assert.assertEquals(SelectAllCheckBoxVisible.DEFAULT,

--- a/server/src/test/java/com/vaadin/tests/components/grid/GridNoSelectionModelTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/grid/GridNoSelectionModelTest.java
@@ -11,9 +11,7 @@ import org.junit.Test;
 import com.vaadin.server.data.provider.bov.Person;
 import com.vaadin.ui.Grid;
 import com.vaadin.ui.Grid.GridSelectionModel;
-import com.vaadin.ui.components.grid.MultiSelectionModelImpl;
-import com.vaadin.ui.components.grid.NoSelectionModel;
-import com.vaadin.ui.components.grid.SingleSelectionModelImpl;
+import com.vaadin.ui.Grid.SelectionMode;
 
 public class GridNoSelectionModelTest {
 
@@ -29,8 +27,7 @@ public class GridNoSelectionModelTest {
         grid = new Grid<>();
         grid.setItems(PERSON_A, PERSON_B, PERSON_C);
 
-        model = new NoSelectionModel<>(grid);
-        grid.setSelectionModel(model);
+        model = grid.setSelectionMode(SelectionMode.NONE);
     }
 
     @Test
@@ -50,7 +47,7 @@ public class GridNoSelectionModelTest {
 
     @Test
     public void changingToSingleSelectionModel() {
-        grid.setSelectionModel(new SingleSelectionModelImpl<>(grid));
+        grid.setSelectionMode(SelectionMode.SINGLE);
 
         grid.getSelectionModel().select(PERSON_B);
         Assert.assertEquals(PERSON_B,
@@ -59,7 +56,7 @@ public class GridNoSelectionModelTest {
 
     @Test
     public void changingToMultiSelectionModel() {
-        grid.setSelectionModel(new MultiSelectionModelImpl<>(grid));
+        grid.setSelectionMode(SelectionMode.MULTI);
 
         grid.getSelectionModel().select(PERSON_B);
         Assert.assertEquals(new LinkedHashSet<>(Arrays.asList(PERSON_B)),

--- a/server/src/test/java/com/vaadin/tests/components/grid/GridSelectionModeTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/grid/GridSelectionModeTest.java
@@ -1,0 +1,49 @@
+package com.vaadin.tests.components.grid;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.Grid.SelectionMode;
+import com.vaadin.ui.components.grid.MultiSelectionModelImpl;
+import com.vaadin.ui.components.grid.NoSelectionModel;
+import com.vaadin.ui.components.grid.SingleSelectionModelImpl;
+
+public class GridSelectionModeTest {
+
+    private Grid<String> grid;
+
+    @Before
+    public void setup() {
+        grid = new Grid<>();
+        grid.setItems("foo", "bar", "baz");
+    }
+
+    @Test
+    public void testSelectionModes() {
+        Assert.assertEquals(SingleSelectionModelImpl.class,
+                grid.getSelectionModel().getClass());
+
+        Assert.assertEquals(MultiSelectionModelImpl.class,
+                grid.setSelectionMode(SelectionMode.MULTI).getClass());
+        Assert.assertEquals(MultiSelectionModelImpl.class,
+                grid.getSelectionModel().getClass());
+
+        Assert.assertEquals(NoSelectionModel.class,
+                grid.setSelectionMode(SelectionMode.NONE).getClass());
+        Assert.assertEquals(NoSelectionModel.class,
+                grid.getSelectionModel().getClass());
+
+        Assert.assertEquals(SingleSelectionModelImpl.class,
+                grid.setSelectionMode(SelectionMode.SINGLE).getClass());
+        Assert.assertEquals(SingleSelectionModelImpl.class,
+                grid.getSelectionModel().getClass());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullSelectionMode() {
+        grid.setSelectionMode(null);
+    }
+
+}

--- a/server/src/test/java/com/vaadin/tests/server/component/StateGetDoesNotMarkDirtyTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/StateGetDoesNotMarkDirtyTest.java
@@ -30,6 +30,7 @@ public class StateGetDoesNotMarkDirtyTest {
         excludedMethods.add(Label.class.getName() + "getDataProviderValue");
         excludedMethods.add("getConnectorId");
         excludedMethods.add("getContent");
+        excludedMethods.add("com.vaadin.ui.Grid:getSelectAllCheckBoxVisible");
     }
 
     @Test
@@ -62,8 +63,8 @@ public class StateGetDoesNotMarkDirtyTest {
                             // we still wouldnt know what to put into
                             continue;
                         }
-                        if (excludedMethods
-                                .contains(clazz.getName() + method.getName())) {
+                        if (excludedMethods.contains(
+                                clazz.getName() + ":" + method.getName())) {
                             // blacklisted method for specific classes
                             continue;
                         }

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridCustomSelectionModel.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridCustomSelectionModel.java
@@ -32,9 +32,6 @@ public class GridCustomSelectionModel extends AbstractTestUI {
     public static class MySelectionModel
             extends MultiSelectionModelImpl<DataObject> {
 
-        public MySelectionModel(Grid<DataObject> grid) {
-            super(grid);
-        }
     }
 
     private Grid<DataObject> grid;
@@ -47,9 +44,7 @@ public class GridCustomSelectionModel extends AbstractTestUI {
         // Create grid
         grid = new Grid<DataObject>() {
             {
-                MySelectionModel model = new MySelectionModel(this);
-                setSelectionModel(model);
-                model.extend(this);
+                setSelectionModel(new MySelectionModel());
             }
         };
         grid.setItems(data);

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridDisabledMultiselect.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridDisabledMultiselect.java
@@ -4,7 +4,7 @@ import com.vaadin.server.VaadinRequest;
 import com.vaadin.tests.components.AbstractReindeerTestUI;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Grid;
-import com.vaadin.ui.components.grid.MultiSelectionModelImpl;
+import com.vaadin.ui.Grid.SelectionMode;
 
 public class GridDisabledMultiselect extends AbstractReindeerTestUI {
 
@@ -18,7 +18,7 @@ public class GridDisabledMultiselect extends AbstractReindeerTestUI {
         addButton("Multi", new Button.ClickListener() {
             @Override
             public void buttonClick(Button.ClickEvent event) {
-                grid.setSelectionModel(new MultiSelectionModelImpl<>(grid));
+                grid.setSelectionMode(SelectionMode.MULTI);
             }
         });
 

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridDragSelectionWhileScrolled.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridDragSelectionWhileScrolled.java
@@ -20,10 +20,10 @@ import com.vaadin.tests.components.AbstractTestUI;
 import com.vaadin.tests.components.grid.basics.DataObject;
 import com.vaadin.tests.components.grid.basics.GridBasics;
 import com.vaadin.ui.Grid;
+import com.vaadin.ui.Grid.SelectionMode;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.VerticalLayout;
-import com.vaadin.ui.components.grid.MultiSelectionModelImpl;
 import com.vaadin.ui.renderers.DateRenderer;
 import com.vaadin.ui.renderers.HtmlRenderer;
 import com.vaadin.ui.renderers.NumberRenderer;
@@ -55,8 +55,7 @@ public class GridDragSelectionWhileScrolled extends AbstractTestUI {
                 .setCaption(GridBasics.COLUMN_CAPTIONS[5]);
         grid.addColumn(DataObject::getBigRandom, new NumberRenderer())
                 .setCaption(GridBasics.COLUMN_CAPTIONS[6]);
-
-        grid.setSelectionModel(new MultiSelectionModelImpl<>(grid));
+        grid.setSelectionMode(SelectionMode.MULTI);
 
         layout.addComponent(grid);
 

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridMultiSelectionOnInit.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridMultiSelectionOnInit.java
@@ -21,6 +21,7 @@ import com.vaadin.server.VaadinRequest;
 import com.vaadin.tests.components.AbstractTestUI;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Grid;
+import com.vaadin.ui.Grid.SelectionMode;
 import com.vaadin.ui.RadioButtonGroup;
 import com.vaadin.ui.components.grid.MultiSelectionModelImpl;
 import com.vaadin.ui.components.grid.MultiSelectionModelImpl.SelectAllCheckBoxVisible;
@@ -32,9 +33,9 @@ public class GridMultiSelectionOnInit extends AbstractTestUI {
         final Grid<String> grid = new Grid<>();
         grid.setItems("Foo 1", "Foo 2");
         grid.addColumn(item -> item);
-        MultiSelectionModelImpl<String> model = new MultiSelectionModelImpl<>(
-                grid);
-        grid.setSelectionModel(model);
+        MultiSelectionModelImpl<String> selectionModel = (MultiSelectionModelImpl<String>) grid
+                .setSelectionMode(SelectionMode.MULTI);
+
         addComponent(grid);
 
         addComponent(new Button("Select rows",
@@ -48,9 +49,9 @@ public class GridMultiSelectionOnInit extends AbstractTestUI {
                 Arrays.asList(SelectAllCheckBoxVisible.VISIBLE,
                         SelectAllCheckBoxVisible.HIDDEN,
                         SelectAllCheckBoxVisible.DEFAULT));
-        rbg.setValue(model.getSelectAllCheckBoxVisible());
-        rbg.addValueChangeListener(
-                event -> model.setSelectAllCheckBoxVisible(event.getValue()));
+        rbg.setValue(selectionModel.getSelectAllCheckBoxVisible());
+        rbg.addValueChangeListener(event -> selectionModel
+                .setSelectAllCheckBoxVisible(event.getValue()));
         addComponent(rbg);
     }
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/basics/GridBasics.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/basics/GridBasics.java
@@ -31,6 +31,7 @@ import com.vaadin.ui.Grid.DetailsGenerator;
 import com.vaadin.ui.Grid.FooterRow;
 import com.vaadin.ui.Grid.HeaderRow;
 import com.vaadin.ui.Grid.MultiSelectionModel;
+import com.vaadin.ui.Grid.SelectionMode;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.MenuBar;
 import com.vaadin.ui.MenuBar.Command;
@@ -42,7 +43,6 @@ import com.vaadin.ui.TextField;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.components.grid.MultiSelectionModelImpl;
 import com.vaadin.ui.components.grid.MultiSelectionModelImpl.SelectAllCheckBoxVisible;
-import com.vaadin.ui.components.grid.NoSelectionModel;
 import com.vaadin.ui.components.grid.SingleSelectionModelImpl;
 import com.vaadin.ui.renderers.DateRenderer;
 import com.vaadin.ui.renderers.HtmlRenderer;
@@ -488,7 +488,7 @@ public class GridBasics extends AbstractTestUIWithLog {
                 null);
         selectionModelItem.addItem("single", menuItem -> {
             selectionListenerRegistration.remove();
-            grid.setSelectionModel(new SingleSelectionModelImpl<>(grid));
+            grid.setSelectionMode(SelectionMode.SINGLE);
             selectionListenerRegistration = ((SingleSelectionModelImpl<DataObject>) grid
                     .getSelectionModel())
                             .addSelectionListener(this::onSingleSelect);
@@ -498,7 +498,7 @@ public class GridBasics extends AbstractTestUIWithLog {
         });
         selectionModelItem.addItem("none", menuItem -> {
             selectionListenerRegistration.remove();
-            grid.setSelectionModel(new NoSelectionModel<>(grid));
+            grid.setSelectionMode(SelectionMode.NONE);
         });
 
         selectionModelItem.addItem("Select All", menuItem -> {
@@ -534,11 +534,9 @@ public class GridBasics extends AbstractTestUIWithLog {
     private void switchToMultiSelect() {
         if (!(grid.getSelectionModel() instanceof MultiSelectionModel)) {
             selectionListenerRegistration.remove();
-            MultiSelectionModelImpl<DataObject> model = new MultiSelectionModelImpl<>(
-                    grid);
-            grid.setSelectionModel(model);
-            selectionListenerRegistration = model
-                    .addSelectionListener(this::onMultiSelect);
+            ((MultiSelectionModelImpl<DataObject>) grid
+                    .setSelectionMode(SelectionMode.MULTI))
+                            .addSelectionListener(this::onMultiSelect);
         }
     }
 


### PR DESCRIPTION
Hides setSelectionModel(...) by making it protected.
Adds shortcuts for Grid to set select all checkbox visible, if SelectionMode.MULTI is used.
Refactores the usage of constructor / extend method for Abstract-, Single- and MultiSelectionModelImpl.

Fixes vaadin/framework8-issues#519

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/83)
<!-- Reviewable:end -->
