### PR TITLE
Extends declarative tests for selection components for "data-" attribute

### DIFF
--- a/server/src/test/java/com/vaadin/tests/design/DeclarativeTestBaseBase.java
+++ b/server/src/test/java/com/vaadin/tests/design/DeclarativeTestBaseBase.java
@@ -213,6 +213,14 @@ public abstract class DeclarativeTestBaseBase<T extends Component> {
         return read;
     }
 
+    public DesignContext readComponentAndCompare(String design, T expected) {
+        TestLogHandler l = new TestLogHandler();
+        DesignContext context = readAndReturnContext(design);
+        assertEquals(expected, context.getRootComponent());
+        Assert.assertEquals("", l.getMessages());
+        return context;
+    }
+
     public void testWrite(String design, T expected) {
         TestLogHandler l = new TestLogHandler();
         testWrite(design, expected, false);

--- a/server/src/test/java/com/vaadin/tests/server/component/abstractmultiselect/AbstractMultiSelectDeclarativeTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/abstractmultiselect/AbstractMultiSelectDeclarativeTest.java
@@ -20,11 +20,14 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.data.Listing;
+import com.vaadin.tests.design.DeclarativeTestBaseBase;
 import com.vaadin.tests.server.component.abstractlisting.AbstractListingDeclarativeTest;
 import com.vaadin.ui.AbstractMultiSelect;
+import com.vaadin.ui.declarative.DesignContext;
 
 /**
  * {@link AbstractMultiSelect} component declarative test.
@@ -50,19 +53,29 @@ public abstract class AbstractMultiSelectDeclarativeTest<T extends AbstractMulti
             IllegalAccessException, InvocationTargetException {
         List<String> items = Arrays.asList("foo", "bar", "foobar");
 
+        String type = "com.vaadin.SomeType";
+        String attribute = "data-type";
+
         String design = String.format(
-                "<%s>\n" + "<option item='foo' selected>foo1</option>\n"
+                "<%s %s='%s'>\n" + "<option item='foo' selected>foo1</option>\n"
                         + "<option item='bar'>bar1</option>"
                         + "<option item='foobar' selected>foobar1</option></%s>",
-                getComponentTag(), getComponentTag());
+                getComponentTag(), attribute, type, getComponentTag());
         T component = getComponentClass().newInstance();
         component.setItems(items);
         component.select("foo");
         component.select("foobar");
         component.setItemCaptionGenerator(item -> item + "1");
 
-        testRead(design, component);
-        testWrite(design, component, true);
+        DesignContext context = readComponentAndCompare(design, component);
+        Assert.assertEquals(type,
+                context.getCustomAttributes(context.getRootComponent())
+                        .get(attribute));
+        context = new DesignContext();
+        context.setCustomAttribute(component, attribute, type);
+        context.setShouldWriteDataDelegate(
+                DeclarativeTestBaseBase.ALWAYS_WRITE_DATA);
+        testWrite(component, design, context);
     }
 
     @Override
@@ -71,18 +84,28 @@ public abstract class AbstractMultiSelectDeclarativeTest<T extends AbstractMulti
             IllegalAccessException, InvocationTargetException {
         List<String> items = Arrays.asList("foo", "bar", "foobar");
 
+        String type = "com.vaadin.SomeType";
+        String attribute = "data-type";
+
         String design = String.format(
-                "<%s>\n" + "<option item='foo' selected>foo1</option>\n"
+                "<%s %s='%s'>\n" + "<option item='foo' selected>foo1</option>\n"
                         + "<option item='bar'>bar1</option>"
                         + "<option item='foobar' selected>foobar1</option></%s>",
-                getComponentTag(), getComponentTag());
+                getComponentTag(), attribute, type, getComponentTag());
         T component = getComponentClass().newInstance();
         component.setItems(items);
         component.setValue(new HashSet<>(Arrays.asList("foo", "foobar")));
         component.setItemCaptionGenerator(item -> item + "1");
 
-        testRead(design, component);
-        testWrite(design, component, true);
+        DesignContext context = readComponentAndCompare(design, component);
+        Assert.assertEquals(type,
+                context.getCustomAttributes(context.getRootComponent())
+                        .get(attribute));
+        context = new DesignContext();
+        context.setCustomAttribute(component, attribute, type);
+        context.setShouldWriteDataDelegate(
+                DeclarativeTestBaseBase.ALWAYS_WRITE_DATA);
+        testWrite(component, design, context);
     }
 
     @Override

--- a/server/src/test/java/com/vaadin/tests/server/component/abstractsingleselect/AbstractSingleSelectDeclarativeTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/abstractsingleselect/AbstractSingleSelectDeclarativeTest.java
@@ -20,12 +20,15 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.data.Listing;
+import com.vaadin.tests.design.DeclarativeTestBaseBase;
 import com.vaadin.tests.server.component.abstractlisting.AbstractListingDeclarativeTest;
 import com.vaadin.ui.AbstractSingleSelect;
 import com.vaadin.ui.ItemCaptionGenerator;
+import com.vaadin.ui.declarative.DesignContext;
 
 /**
  * {@link AbstractSingleSelect} component declarative test.
@@ -49,17 +52,27 @@ public abstract class AbstractSingleSelectDeclarativeTest<T extends AbstractSing
             IllegalAccessException, InvocationTargetException {
         List<String> items = Arrays.asList("foo", "bar", "foobar");
 
+        String type = "com.vaadin.SomeType";
+        String attribute = "data-type";
+
         String design = String.format(
-                "<%s>\n" + "<option item='foo'>foo</option>\n"
+                "<%s %s='%s'>\n" + "<option item='foo'>foo</option>\n"
                         + "<option item='bar' selected>bar</option>"
                         + "<option item='foobar'>foobar</option></%s>",
-                getComponentTag(), getComponentTag());
+                getComponentTag(), attribute, type, getComponentTag());
         T component = getComponentClass().newInstance();
         component.setItems(items);
         component.setSelectedItem("bar");
 
-        testRead(design, component);
-        testWrite(design, component, true);
+        DesignContext context = readComponentAndCompare(design, component);
+        Assert.assertEquals(type,
+                context.getCustomAttributes(context.getRootComponent())
+                        .get(attribute));
+        context = new DesignContext();
+        context.setCustomAttribute(component, attribute, type);
+        context.setShouldWriteDataDelegate(
+                DeclarativeTestBaseBase.ALWAYS_WRITE_DATA);
+        testWrite(component, design, context);
     }
 
     @Override
@@ -68,17 +81,27 @@ public abstract class AbstractSingleSelectDeclarativeTest<T extends AbstractSing
             IllegalAccessException, InvocationTargetException {
         List<String> items = Arrays.asList("foo", "bar", "foobar");
 
+        String type = "com.vaadin.SomeType";
+        String attribute = "data-type";
+
         String design = String.format(
-                "<%s>\n" + "<option item='foo'>foo</option>\n"
+                "<%s  %s='%s'>\n" + "<option item='foo'>foo</option>\n"
                         + "<option item='bar' selected>bar</option>"
                         + "<option item='foobar'>foobar</option></%s>",
-                getComponentTag(), getComponentTag());
+                getComponentTag(), attribute, type, getComponentTag());
         T component = getComponentClass().newInstance();
         component.setItems(items);
         component.setValue("bar");
 
-        testRead(design, component);
-        testWrite(design, component, true);
+        DesignContext context = readComponentAndCompare(design, component);
+        Assert.assertEquals(type,
+                context.getCustomAttributes(context.getRootComponent())
+                        .get(attribute));
+        context = new DesignContext();
+        context.setCustomAttribute(component, attribute, type);
+        context.setShouldWriteDataDelegate(
+                DeclarativeTestBaseBase.ALWAYS_WRITE_DATA);
+        testWrite(component, design, context);
     }
 
     @Test


### PR DESCRIPTION
Fixes vaadin/framework8-issues#392


Change-Id: If4f765fb83eabf959ef4e9c3bdd5238c458f264d

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/85)
<!-- Reviewable:end -->
