### PR TITLE
Replace box-sizing @include with bare box-sizing

### DIFF
--- a/themes/src/main/themes/VAADIN/themes/valo/components/_absolutelayout.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_absolutelayout.scss
@@ -13,7 +13,7 @@
   
   .#{$primary-stylename}-margin,
   .#{$primary-stylename}-canvas {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
   
   .#{$primary-stylename}.v-has-height > div,

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_accordion.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_accordion.scss
@@ -144,6 +144,6 @@
 @mixin valo-accordion-item-content-style {
   @include box-shadow(valo-bevel-and-shadow($shadow: join(inset, $v-shadow), $shadow-opacity: $v-shadow-opacity/2));
   background-color: $v-panel-background-color;
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include valo-panel-adjust-content-margins;
 }

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_calendar.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_calendar.scss
@@ -206,7 +206,7 @@ $v-calendar-event-colors: #00ace0, #2d9f19, #d18100, #ce3812, #2d55cd !default;
 
   .#{$primary-stylename}-month-day {
     outline: none;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     line-height: 1.2;
   }
 
@@ -408,7 +408,7 @@ $v-calendar-event-colors: #00ace0, #2d9f19, #d18100, #ce3812, #2d55cd !default;
 
   .#{$primary-stylename}-event-month {
     padding: 0 round($v-unit-size/8);
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     margin-bottom: round($v-unit-size/12);
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -430,7 +430,7 @@ $v-calendar-event-colors: #00ace0, #2d9f19, #d18100, #ce3812, #2d55cd !default;
 
   .#{$primary-stylename}-event-all-day {
     padding: 0 round($v-unit-size/8);
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     height: round($v-font-size * 1.2);
     line-height: round($v-font-size * 1.2);
     border-radius: 0;

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_checkbox.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_checkbox.scss
@@ -87,7 +87,7 @@
     & ~ label:after {
       content: "";
       display: inline-block;
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       width: round($size);
       height: round($size);
       position: absolute;

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_combobox.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_combobox.scss
@@ -234,7 +234,7 @@
 
     $states: normal focus disabled
 ) {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include valo-textfield-style($unit-size: $unit-size,
                                 $padding: $padding,
                                 $font-color: $font-color,
@@ -355,7 +355,7 @@
 
   [class$="suggestmenu"] {
     @include valo-selection-overlay-style($animate-in: false, $animate-out: false);
-    @include box-sizing(content-box);
+    box-sizing: content-box;
     position: relative;
     z-index: 1;
     display: block;

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_datefield.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_datefield.scss
@@ -142,7 +142,7 @@
   border-radius: $border-radius;
 
   [class*="textfield"] {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     @include valo-textfield-style($bevel: $bevel, $shadow: $shadow, $unit-size: $unit-size, $border: $border, $border-radius: $border-radius, $background-color: $background-color, $states: $states) ;
     padding-left: $unit-size * 1.2;
     width: 100%;
@@ -319,7 +319,7 @@
   .#{$primary-stylename}-day {
     @include valo-datefield-calendarpanel-day-style;
     display: inline-block;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     cursor: pointer;
     &:hover {
       @include valo-datefield-calendarpanel-day-hover-style;
@@ -476,7 +476,7 @@
  * @group datefield
  */
 @mixin valo-datefield-calendarpanel-day-style {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   width: round($v-unit-size * 0.8);
   height: round($v-unit-size * 0.7);
   border: first-number(valo-border()) solid transparent;

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_escalator.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_escalator.scss
@@ -8,7 +8,7 @@
     position: absolute;
     z-index: 1;
     outline: none;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .#{$primaryStyleName}-scroller-horizontal {
@@ -30,7 +30,7 @@
   .#{$primaryStyleName}-tablewrapper {
     position: absolute;
     overflow: hidden;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     z-index: 5;
   }
 
@@ -44,7 +44,7 @@
   .#{$primaryStyleName}-footer-deco {
     position: absolute;
     right: 0;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .#{$primaryStyleName}-horizontal-scrollbar-deco {
@@ -52,7 +52,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .#{$primaryStyleName}-header,
@@ -104,7 +104,7 @@
     float: left;
     padding: 2px;
     white-space: nowrap;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     overflow: hidden;
 
      // Because Vaadin changes the font size after the initial render, we
@@ -128,7 +128,7 @@
     > td {
       width: 100%;
       height: 100%;
-      @include box-sizing(border-box);
+      box-sizing: border-box;
     }
   }
 }

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_form.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_form.scss
@@ -16,7 +16,7 @@
   
   .#{$primary-stylename}-content {
     height: 100%;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
   
 }

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_grid.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_grid.scss
@@ -423,7 +423,7 @@ $v-grid-details-border-bottom-stripe: 1px solid darken($v-grid-row-background-co
 
     > div {
       display: inline-block;
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       vertical-align: middle;
       background: $v-grid-editor-background-color;
 

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_menubar.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_menubar.scss
@@ -130,7 +130,7 @@
   position: relative;
   z-index: 1;
   display: inline-block;
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include valo-button-style($states: normal, $border-radius: 0, $shadow: null, $font-color: inherit, $cursor: pointer);
   background: transparent;
   @include box-shadow(none);

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_orderedlayout.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_orderedlayout.scss
@@ -12,7 +12,7 @@
 
   .v-layout.v-vertical > .v-expand,
   .v-layout.v-horizontal > .v-expand {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     width: 100%;
     height: 100%;
   }

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_panel.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_panel.scss
@@ -31,7 +31,7 @@ $v-panel-background-color: scale-color(lighten($v-app-background-color, 5%), $sa
   }
 
   .#{$primary-stylename}-content {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     width: 100%;
     height: 100%;
     @include valo-panel-adjust-content-margins;
@@ -101,7 +101,7 @@ $v-panel-background-color: scale-color(lighten($v-app-background-color, 5%), $sa
  * @group panel
  */
 @mixin valo-panel-caption-style ( $background-color : $v-background-color,  $bevel  : $v-bevel, $gradient : valo-gradient-style($v-gradient) valo-gradient-opacity($v-gradient)/4, $border   : $v-panel-border ) {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   padding: 0 round($v-unit-size/3);
   line-height: $v-unit-size - first-number($v-border);
   $bg: $background-color;

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_progressbar.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_progressbar.scss
@@ -67,7 +67,7 @@ $v-progressbar-border-radius: $v-border-radius !default;
   height: round($v-unit-size/4);
   $bg-lightness: if(color-luminance($background-color) < 10, min($v-bevel-depth/2, 10%), min($v-bevel-depth/-2, -10%));
   @include valo-gradient($color: scale-color($background-color, $lightness: $bg-lightness, $saturation: $v-bevel-depth/-2), $direction: to top);
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 }
 
 
@@ -89,6 +89,6 @@ $v-progressbar-border-radius: $v-border-radius !default;
   } @else {
     border: none;
   }
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   max-width: 100%;
 }

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_slider.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_slider.scss
@@ -128,7 +128,7 @@ $_valo-slider-base-margin-horizontal: round($v-slider-handle-width/2);
     &:before,
     &:after {
       content: "";
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       padding: 0;
       width: $v-slider-handle-width;
       height: $v-slider-handle-height;

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_splitpanel.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_splitpanel.scss
@@ -78,7 +78,7 @@
   .#{$primary-stylename}-hsplitter div,
   .#{$primary-stylename}-vsplitter div {
     &:before {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       content: "";
       position: absolute;
       top: 0;

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_table.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_table.scss
@@ -191,7 +191,7 @@ $v-table-background-color: null !default;
     overflow: hidden;
     line-height: 1;
     min-height: $v-table-row-height;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .#{$primary-stylename}-footer-container {
@@ -247,7 +247,7 @@ $v-table-background-color: null !default;
   .#{$primary-stylename}-cell-wrapper {
     line-height: 1;
     padding: 0 $v-table-cell-padding-horizontal;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     margin-right: 0 !important;
 
     > .v-widget {

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_tabsheet.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_tabsheet.scss
@@ -45,7 +45,7 @@ $v-tabsheet-content-animation-enabled: $v-animations-enabled !default;
 
   .#{$primary-stylename}-tabs {
     white-space: nowrap;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .#{$primary-stylename}-content {
@@ -162,7 +162,7 @@ $v-tabsheet-content-animation-enabled: $v-animations-enabled !default;
  */
 @mixin valo-tabsheet-tabcontainer-style ($primary-stylename: v-tabsheet) {
   position: relative;
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   &:before {
     content: "";
@@ -197,7 +197,7 @@ $v-tabsheet-content-animation-enabled: $v-animations-enabled !default;
   .v-caption {
     margin-left: round($v-unit-size/2);
     padding: 0 round($v-unit-size/10);
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     cursor: pointer;
     text-align: center;
     line-height: $v-unit-size;

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_treetable.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_treetable.scss
@@ -10,7 +10,7 @@
     [class*="caption-container"],
     [class*="footer-container"],
     [class*="cell-wrapper"] {
-      @include box-sizing(content-box);
+      box-sizing: content-box;
       padding-left: 0;
       padding-right: 0;
     }

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_widget.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_widget.scss
@@ -3,7 +3,7 @@
  */
 @mixin valo-widget-style {
   // Baseline expectations for all Vaadin widgets
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   display: inline-block;
   vertical-align: top;
 

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_window.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_window.scss
@@ -161,7 +161,7 @@ $v-window-modality-curtain-background-color: #222 !default;
     z-index: 3;
     top: 0;
     right: 0;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     width: $v-unit-size - round($v-unit-size/9);
     height: $v-unit-size - 1px;
     background-color: $v-window-background-color;
@@ -241,7 +241,7 @@ $v-window-modality-curtain-background-color: #222 !default;
   }
 
   .#{$primary-stylename}-contents {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     border-radius: $v-border-radius;
     margin-top: 0 !important;
 
@@ -348,7 +348,7 @@ $v-window-modality-curtain-background-color: #222 !default;
   .v-margin-left.v-margin-right.v-margin-top {
     .#{$primary-stylename}-top-toolbar {
       &.v-layout {
-        @include box-sizing(content-box);
+        box-sizing: content-box;
         margin: round($v-unit-size/-3) round($v-unit-size/-3) 0;
       }
 
@@ -366,7 +366,7 @@ $v-window-modality-curtain-background-color: #222 !default;
   .v-margin-left.v-margin-right.v-margin-bottom {
     .#{$primary-stylename}-bottom-toolbar {
       &.v-layout {
-        @include box-sizing(content-box);
+        box-sizing: content-box;
         margin: 0 round($v-unit-size/-3) round($v-unit-size/-3);
       }
     }

--- a/themes/src/main/themes/VAADIN/themes/valo/shared/_loading-indicator.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/shared/_loading-indicator.scss
@@ -25,7 +25,7 @@
   $size: round($size) + round($size) % 2;
   height: $size !important;
   width: $size !important;
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   border: $thickness solid transparentize($color, .8);
   border-top-color: $color;
   border-right-color: $color;


### PR DESCRIPTION
Browsers support unprefixed box-sizing since:
Chrome 10
Firefox 29
Opera 10
Safari 5.1
iOS 5.1
IE 8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/92)
<!-- Reviewable:end -->
