### PR TITLE
Implement "afterViewChange()" as no-op by default.

### DIFF
--- a/server/src/main/java/com/vaadin/navigator/ViewChangeListener.java
+++ b/server/src/main/java/com/vaadin/navigator/ViewChangeListener.java
@@ -21,13 +21,18 @@ import java.util.EventObject;
 
 /**
  * Interface for listening to View changes before and after they occur.
- *
+ * <p>
  * Implementations of this interface can also block navigation between views
- * before it is performed.
+ * before it is performed (using {@link #beforeViewChange(ViewChangeEvent)}).
+ * <p>
+ * The interface contains two methods {@link #beforeViewChange(ViewChangeEvent)}
+ * and {@link #afterViewChange(ViewChangeEvent)}. The latter one has default
+ * empty implementation.
  *
  * @author Vaadin Ltd
  * @since 7.0
  */
+@FunctionalInterface
 public interface ViewChangeListener extends Serializable {
 
     /**
@@ -124,10 +129,14 @@ public interface ViewChangeListener extends Serializable {
      * method blocked the view change, this method is not called. Be careful of
      * unbounded recursion if you decide to change the view again in the
      * listener.
+     * <p>
+     * By default it does nothing. Override it in your listener if you need this
+     * functionality.
      *
      * @param event
      *            view change event
      */
-    public void afterViewChange(ViewChangeEvent event);
+    public default void afterViewChange(ViewChangeEvent event) {
+    }
 
 }

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v70/SimpleLoginUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v70/SimpleLoginUI.java
@@ -56,10 +56,6 @@ public class SimpleLoginUI extends UI {
                 return true;
             }
 
-            @Override
-            public void afterViewChange(ViewChangeEvent event) {
-
-            }
         });
     }
 }

--- a/uitest/src/main/java/com/vaadin/tests/navigator/NavigatorTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/navigator/NavigatorTest.java
@@ -13,10 +13,10 @@ import com.vaadin.tests.util.Log;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.Layout;
+import com.vaadin.ui.RichTextArea;
 import com.vaadin.ui.TextField;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
-import com.vaadin.ui.RichTextArea;
 import com.vaadin.v7.ui.Table;
 
 public class NavigatorTest extends UI {
@@ -107,9 +107,6 @@ public class NavigatorTest extends UI {
             return true;
         }
 
-        @Override
-        public void afterViewChange(ViewChangeEvent event) {
-        }
     }
 
     class NaviButton extends Button {


### PR DESCRIPTION
ViewChangeListener is functional interface now and has empty
implementation for "afterViewChange()" 

Fixes vaadin/framework8-issues#502

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/99)
<!-- Reviewable:end -->
