### PR TITLE
Add a generic selection listener to Grid & SelectionModels

### DIFF
--- a/server/src/main/java/com/vaadin/data/SelectionModel.java
+++ b/server/src/main/java/com/vaadin/data/SelectionModel.java
@@ -24,6 +24,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import com.vaadin.event.selection.SelectionListener;
+import com.vaadin.shared.Registration;
+
 /**
  * Models the selection logic of a {@code Listing} component. Determines how
  * items can be selected and deselected.
@@ -257,4 +260,14 @@ public interface SelectionModel<T> extends Serializable {
     public default boolean isSelected(T item) {
         return getSelectedItems().contains(item);
     }
+
+    /**
+     * Adds a generic listener to this selection model, accepting both single
+     * and multiselection events.
+     *
+     * @param listener
+     *            the listener to add
+     * @return a registration handle for removing the listener
+     */
+    public Registration addSelectionListener(SelectionListener<T> listener);
 }

--- a/server/src/main/java/com/vaadin/event/selection/MultiSelectionEvent.java
+++ b/server/src/main/java/com/vaadin/event/selection/MultiSelectionEvent.java
@@ -145,4 +145,14 @@ public class MultiSelectionEvent<T> extends ValueChangeEvent<Set<T>>
     public MultiSelect<T> getSource() {
         return (MultiSelect<T>) super.getSource();
     }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This is the same as {@link #getValue()}.
+     */
+    @Override
+    public Set<T> getAllSelectedItems() {
+        return getValue();
+    }
 }

--- a/server/src/main/java/com/vaadin/event/selection/SelectionEvent.java
+++ b/server/src/main/java/com/vaadin/event/selection/SelectionEvent.java
@@ -17,6 +17,7 @@ package com.vaadin.event.selection;
 
 import java.io.Serializable;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A selection event that unifies the way to access to selection event for multi
@@ -33,11 +34,30 @@ public interface SelectionEvent<T> extends Serializable {
     /**
      * Get first selected data item.
      * <p>
-     * This is the same as {@link SingleSelectionChange#getSelectedItem()} in
+     * This is the same as {@link SingleSelectionEvent#getSelectedItem()} in
      * case of single selection and the first selected item from
-     * {@link MultiSelectionChangeEvent#getNewSelection()} in case of multi selection.
-     * 
+     * {@link MultiSelectionEvent#getNewSelection()} in case of multi selection.
+     *
      * @return the first selected item.
      */
     Optional<T> getFirstSelected();
+
+    /**
+     * Gets all the currently selected items.
+     * <p>
+     * This method applies more to multiselection - for single select it returns
+     * either an empty set or a set containing the only selected item.
+     *
+     * @return return all the selected items, if any, never {@code null}
+     */
+    Set<T> getAllSelectedItems();
+
+    /**
+     * Returns whether this selection event was triggered by user interaction,
+     * on the client side, or programmatically, on the server side.
+     *
+     * @return {@code true} if this event originates from the client,
+     *         {@code false} otherwise.
+     */
+    boolean isUserOriginated();
 }

--- a/server/src/main/java/com/vaadin/event/selection/SelectionListener.java
+++ b/server/src/main/java/com/vaadin/event/selection/SelectionListener.java
@@ -15,25 +15,25 @@
  */
 package com.vaadin.event.selection;
 
-import java.io.Serializable;
-import java.util.function.Consumer;
+import com.vaadin.server.SerializableConsumer;
 
 /**
- * A listener for {@code SingleSelectionEvent}.
+ * A listener for {@code SelectionEvent}.
+ * <p>
+ * This is a generic listener for both type of selections, single and
+ * multiselect.
  *
  * @author Vaadin Ltd.
  *
  * @param <T>
  *            the type of the selected item
  *
- * @see SingleSelectionEvent
+ * @see SelectionEvent
  *
  * @since 8.0
  */
 @FunctionalInterface
-public interface SingleSelectionListener<T>
-        extends Consumer<SingleSelectionEvent<T>>, Serializable {
+public interface SelectionListener<T>
+        extends SerializableConsumer<SelectionEvent<T>> {
 
-    @Override
-    public void accept(SingleSelectionEvent<T> event);
 }

--- a/server/src/main/java/com/vaadin/event/selection/SingleSelectionEvent.java
+++ b/server/src/main/java/com/vaadin/event/selection/SingleSelectionEvent.java
@@ -15,7 +15,9 @@
  */
 package com.vaadin.event.selection;
 
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
 import com.vaadin.data.HasValue.ValueChangeEvent;
 import com.vaadin.ui.AbstractSingleSelect;
@@ -95,5 +97,15 @@ public class SingleSelectionEvent<T> extends ValueChangeEvent<T>
     @Override
     public Optional<T> getFirstSelected() {
         return getSelectedItem();
+    }
+
+    @Override
+    public Set<T> getAllSelectedItems() {
+        Optional<T> selectedItem = getSelectedItem();
+        if (selectedItem.isPresent()) {
+            return Collections.singleton(selectedItem.get());
+        } else {
+            return Collections.emptySet();
+        }
     }
 }

--- a/server/src/main/java/com/vaadin/ui/AbstractSingleSelect.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractSingleSelect.java
@@ -97,13 +97,13 @@ public abstract class AbstractSingleSelect<T> extends AbstractListing<T>
 
     /**
      * Adds a selection listener to this select. The listener is called when the
-     * value of this select is changed either by the user or programmatically.
+     * selection is changed either by the user or programmatically.
      *
      * @param listener
-     *            the value change listener, not null
+     *            the selection listener, not null
      * @return a registration for the listener
      */
-    public Registration addSelectionChangeListener(
+    public Registration addSelectionListener(
             SingleSelectionListener<T> listener) {
         return addListener(SingleSelectionEvent.class, listener,
                 SELECTION_CHANGE_METHOD);
@@ -168,7 +168,7 @@ public abstract class AbstractSingleSelect<T> extends AbstractListing<T>
     @Override
     public Registration addValueChangeListener(
             HasValue.ValueChangeListener<T> listener) {
-        return addSelectionChangeListener(event -> listener.accept(
+        return addSelectionListener(event -> listener.accept(
                 new ValueChangeEvent<>(this, event.isUserOriginated())));
     }
 

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -558,7 +558,7 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
     @Override
     public Registration addValueChangeListener(
             HasValue.ValueChangeListener<T> listener) {
-        return addSelectionChangeListener(event -> {
+        return addSelectionListener(event -> {
             listener.accept(new ValueChangeEvent<>(event.getComponent(), this,
                     event.isUserOriginated()));
         });

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -46,6 +46,9 @@ import com.vaadin.data.SelectionModel;
 import com.vaadin.event.ConnectorEvent;
 import com.vaadin.event.ContextClickEvent;
 import com.vaadin.event.EventListener;
+import com.vaadin.event.selection.MultiSelectionListener;
+import com.vaadin.event.selection.SelectionListener;
+import com.vaadin.event.selection.SingleSelectionListener;
 import com.vaadin.server.EncodeResult;
 import com.vaadin.server.Extension;
 import com.vaadin.server.JsonCodec;
@@ -235,6 +238,31 @@ public class Grid<T> extends AbstractListing<T>
          * @return the single select wrapper
          */
         SingleSelect<T> asSingleSelect();
+
+        /**
+         * {@inheritDoc}
+         * <p>
+         * Use {@link #addSingleSelectionListener(SingleSelectionListener)} for
+         * more specific single selection event.
+         *
+         * @see #addSingleSelectionListener(SingleSelectionListener)
+         */
+        @Override
+        public default Registration addSelectionListener(
+                SelectionListener<T> listener) {
+            return addSingleSelectionListener(e -> listener.accept(e));
+        }
+
+        /**
+         * Adds a single selection listener that is called when the value of
+         * this select is changed either by the user or programmatically.
+         *
+         * @param listener
+         *            the value change listener, not {@code null}
+         * @return a registration for the listener
+         */
+        public Registration addSingleSelectionListener(
+                SingleSelectionListener<T> listener);
     }
 
     /**
@@ -253,6 +281,31 @@ public class Grid<T> extends AbstractListing<T>
          * @return the multiselect wrapper
          */
         MultiSelect<T> asMultiSelect();
+
+        /**
+         * {@inheritDoc}
+         * <p>
+         * Use {@link #addMultiSelectionListener(MultiSelectionListener)} for
+         * more specific event on multiselection.
+         *
+         * @see #addMultiSelectionListener(MultiSelectionListener)
+         */
+        @Override
+        public default Registration addSelectionListener(
+                SelectionListener<T> listener) {
+            return addMultiSelectionListener(e -> listener.accept(e));
+        }
+
+        /**
+         * Adds a selection listener that will be called when the selection is
+         * changed either by the user or programmatically.
+         *
+         * @param listener
+         *            the value change listener, not {@code null}
+         * @return a registration for the listener
+         */
+        public Registration addMultiSelectionListener(
+                MultiSelectionListener<T> listener);
     }
 
     /**
@@ -3136,6 +3189,7 @@ public class Grid<T> extends AbstractListing<T>
         if (selectionModel != null) { // null when called from constructor
             selectionModel.remove();
         }
+
         selectionModel = model;
 
         if (selectionModel instanceof AbstractListingExtension) {
@@ -3143,6 +3197,7 @@ public class Grid<T> extends AbstractListing<T>
         } else {
             addExtension(selectionModel);
         }
+
     }
 
     /**
@@ -3176,6 +3231,33 @@ public class Grid<T> extends AbstractListing<T>
         setSelectionModel(model);
 
         return model;
+    }
+
+    /**
+     * Adds a selection listener to the current selection model.
+     * <p>
+     * <em>NOTE:</em> If selection mode is switched with
+     * {@link #setSelectionMode(SelectionMode)}, then this listener is not
+     * triggered anymore when selection changes!
+     * <p>
+     * This is a shorthand for
+     * {@code grid.getSelectionModel().addSelectionListener()}. To get more
+     * detailed selection events, use {@link #getSelectionModel()} and either
+     * {@link SingleSelectionModel#addSingleSelectionListener(SingleSelectionListener)}
+     * or
+     * {@link MultiSelectionModel#addMultiSelectionListener(MultiSelectionListener)}
+     * depending on the used selection mode.
+     *
+     * @param listener
+     *            the listener to add
+     * @return a registration handle to remove the listener
+     * @throws UnsupportedOperationException
+     *             if selection has been disabled with
+     *             {@link SelectionMode.NONE}
+     */
+    public Registration addSelectionListener(SelectionListener<T> listener)
+            throws UnsupportedOperationException {
+        return getSelectionModel().addSelectionListener(listener);
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/components/grid/MultiSelectionModelImpl.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/MultiSelectionModelImpl.java
@@ -243,19 +243,11 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
         }
     }
 
-    /**
-     * Adds a selection listener that will be called when the selection is
-     * changed either by the user or programmatically.
-     *
-     * @param listener
-     *            the value change listener, not {@code null}
-     * @return a registration for the listener
-     */
-    public Registration addSelectionListener(
+    @Override
+    public Registration addMultiSelectionListener(
             MultiSelectionListener<T> listener) {
-        addListener(MultiSelectionEvent.class, listener,
+        return addListener(MultiSelectionEvent.class, listener,
                 SELECTION_CHANGE_METHOD);
-        return () -> removeListener(MultiSelectionEvent.class, listener);
     }
 
     @Override
@@ -348,7 +340,7 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
             public Registration addSelectionListener(
                     MultiSelectionListener<T> listener) {
                 return MultiSelectionModelImpl.this
-                        .addSelectionListener(listener);
+                        .addMultiSelectionListener(listener);
             }
         };
     }

--- a/server/src/main/java/com/vaadin/ui/components/grid/NoSelectionModel.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/NoSelectionModel.java
@@ -19,7 +19,9 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
+import com.vaadin.event.selection.SelectionListener;
 import com.vaadin.server.AbstractExtension;
+import com.vaadin.shared.Registration;
 import com.vaadin.ui.Grid.GridSelectionModel;
 
 /**
@@ -55,6 +57,12 @@ public class NoSelectionModel<T> extends AbstractExtension
 
     @Override
     public void deselectAll() {
+    }
+
+    @Override
+    public Registration addSelectionListener(SelectionListener<T> listener) {
+        throw new UnsupportedOperationException(
+                "This selection model doesn't allow selection, cannot add selection listeners to it");
     }
 
 }

--- a/server/src/main/java/com/vaadin/ui/components/grid/SingleSelectionModelImpl.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/SingleSelectionModelImpl.java
@@ -79,15 +79,8 @@ public class SingleSelectionModelImpl<T> extends AbstractSelectionModel<T>
         return (SingleSelectionModelState) super.getState(markAsDirty);
     }
 
-    /**
-     * Adds a selection listener to this select. The listener is called when the
-     * value of this select is changed either by the user or programmatically.
-     *
-     * @param listener
-     *            the value change listener, not null
-     * @return a registration for the listener
-     */
-    public Registration addSelectionListener(
+    @Override
+    public Registration addSingleSelectionListener(
             SingleSelectionListener<T> listener) {
         return addListener(SingleSelectionEvent.class, listener,
                 SELECTION_CHANGE_METHOD);
@@ -255,8 +248,9 @@ public class SingleSelectionModelImpl<T> extends AbstractSelectionModel<T>
             @Override
             public Registration addValueChangeListener(
                     com.vaadin.data.HasValue.ValueChangeListener<T> listener) {
-                return SingleSelectionModelImpl.this
-                        .addSelectionListener(event -> listener.accept(event));
+                return SingleSelectionModelImpl.this.addSingleSelectionListener(
+                        (SingleSelectionListener<T>) event -> listener
+                                .accept(event));
             }
 
             @Override

--- a/server/src/test/java/com/vaadin/data/GridAsMultiSelectInBinderTest.java
+++ b/server/src/test/java/com/vaadin/data/GridAsMultiSelectInBinderTest.java
@@ -28,7 +28,7 @@ import com.vaadin.ui.Grid.SelectionMode;
 import com.vaadin.ui.MultiSelect;
 import com.vaadin.ui.components.grid.MultiSelectionModelImpl;
 
-public class GridAsMultiSelectInBinder
+public class GridAsMultiSelectInBinderTest
         extends BinderTestBase<Binder<BeanWithEnums>, BeanWithEnums> {
     public class TestEnumSetToStringConverter
             implements Converter<Set<TestEnum>, String> {

--- a/server/src/test/java/com/vaadin/data/GridAsSingleSelectInBinderTest.java
+++ b/server/src/test/java/com/vaadin/data/GridAsSingleSelectInBinderTest.java
@@ -19,7 +19,7 @@ import com.vaadin.ui.Grid.SelectionMode;
 import com.vaadin.ui.SingleSelect;
 import com.vaadin.ui.components.grid.SingleSelectionModelImpl;
 
-public class GridAsSingleSelectInBinder
+public class GridAsSingleSelectInBinderTest
         extends BinderTestBase<Binder<Person>, Person> {
 
     private class GridWithCustomSingleSelectionModel extends Grid<Sex> {

--- a/server/src/test/java/com/vaadin/tests/components/grid/GridMultiSelectionModelTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/grid/GridMultiSelectionModelTest.java
@@ -103,7 +103,7 @@ public class GridMultiSelectionModelTest {
         oldSelectionCapture = new Capture<>();
         events = new AtomicInteger();
 
-        selectionModel.addSelectionListener(event -> {
+        selectionModel.addMultiSelectionListener(event -> {
             currentSelectionCapture
                     .setValue(new ArrayList<>(event.getNewSelection()));
             oldSelectionCapture
@@ -135,7 +135,7 @@ public class GridMultiSelectionModelTest {
         List<String> selectionChanges = new ArrayList<>();
         Capture<List<String>> oldSelectionCapture = new Capture<>();
         ((MultiSelectionModelImpl<String>) customGrid.getSelectionModel())
-                .addSelectionListener(e -> {
+                .addMultiSelectionListener(e -> {
                     selectionChanges.addAll(e.getValue());
                     oldSelectionCapture
                             .setValue(new ArrayList<>(e.getOldSelection()));
@@ -578,7 +578,7 @@ public class GridMultiSelectionModelTest {
         Registration registration = Mockito.mock(Registration.class);
         MultiSelectionModelImpl<String> model = new MultiSelectionModelImpl<String>() {
             @Override
-            public Registration addSelectionListener(
+            public Registration addMultiSelectionListener(
                     MultiSelectionListener<String> listener) {
                 selectionListener.set(listener);
                 return registration;
@@ -595,10 +595,11 @@ public class GridMultiSelectionModelTest {
         grid.setItems("foo", "bar");
 
         AtomicReference<MultiSelectionEvent<String>> event = new AtomicReference<>();
-        Registration actualRegistration = model.addSelectionListener(evt -> {
-            Assert.assertNull(event.get());
-            event.set(evt);
-        });
+        Registration actualRegistration = model
+                .addMultiSelectionListener(evt -> {
+                    Assert.assertNull(event.get());
+                    event.set(evt);
+                });
         Assert.assertSame(registration, actualRegistration);
 
         selectionListener.get().accept(new MultiSelectionEvent<>(grid,

--- a/server/src/test/java/com/vaadin/tests/components/grid/GridSingleSelectionModelTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/grid/GridSingleSelectionModelTest.java
@@ -73,8 +73,8 @@ public class GridSingleSelectionModelTest {
                 .getSelectionModel();
 
         selectionChanges = new ArrayList<>();
-        selectionModel
-                .addSelectionListener(e -> selectionChanges.add(e.getValue()));
+        selectionModel.addSingleSelectionListener(
+                e -> selectionChanges.add(e.getValue()));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -97,7 +97,8 @@ public class GridSingleSelectionModelTest {
 
         List<String> selectionChanges = new ArrayList<>();
         ((SingleSelectionModelImpl<String>) customGrid.getSelectionModel())
-                .addSelectionListener(e -> selectionChanges.add(e.getValue()));
+                .addSingleSelectionListener(
+                        e -> selectionChanges.add(e.getValue()));
 
         customGrid.getSelectionModel().select("Foo");
         assertEquals("Foo",
@@ -292,7 +293,7 @@ public class GridSingleSelectionModelTest {
         String value = "foo";
         SingleSelectionModelImpl<String> select = new SingleSelectionModelImpl<String>() {
             @Override
-            public Registration addSelectionListener(
+            public Registration addSingleSelectionListener(
                     SingleSelectionListener<String> listener) {
                 selectionListener.set(listener);
                 return registration;
@@ -305,10 +306,11 @@ public class GridSingleSelectionModelTest {
         };
 
         AtomicReference<ValueChangeEvent<?>> event = new AtomicReference<>();
-        Registration actualRegistration = select.addSelectionListener(evt -> {
-            Assert.assertNull(event.get());
-            event.set(evt);
-        });
+        Registration actualRegistration = select
+                .addSingleSelectionListener(evt -> {
+                    Assert.assertNull(event.get());
+                    event.set(evt);
+                });
         Assert.assertSame(registration, actualRegistration);
 
         selectionListener.get().accept(new SingleSelectionEvent<>(grid,

--- a/server/src/test/java/com/vaadin/ui/AbstractSingleSelectTest.java
+++ b/server/src/test/java/com/vaadin/ui/AbstractSingleSelectTest.java
@@ -81,7 +81,7 @@ public class AbstractSingleSelectTest {
         listing = new PersonListing();
         listing.setItems(PERSON_A, PERSON_B, PERSON_C);
         selectionChanges = new ArrayList<>();
-        listing.addSelectionChangeListener(
+        listing.addSelectionListener(
                 e -> selectionChanges.add(e.getValue()));
     }
 
@@ -237,7 +237,7 @@ public class AbstractSingleSelectTest {
         String value = "foo";
         AbstractSingleSelect<String> select = new AbstractSingleSelect<String>() {
             @Override
-            public Registration addSelectionChangeListener(
+            public Registration addSelectionListener(
                     SingleSelectionListener<String> listener) {
                 selectionListener.set(listener);
                 return registration;

--- a/server/src/test/java/com/vaadin/ui/RadioButtonGroupTest.java
+++ b/server/src/test/java/com/vaadin/ui/RadioButtonGroupTest.java
@@ -42,7 +42,7 @@ public class RadioButtonGroupTest {
     public void apiSelectionChange_notUserOriginated() {
         AtomicInteger listenerCount = new AtomicInteger(0);
 
-        radioButtonGroup.addSelectionChangeListener(event -> {
+        radioButtonGroup.addSelectionListener(event -> {
             listenerCount.incrementAndGet();
             Assert.assertFalse(event.isUserOriginated());
         });
@@ -60,7 +60,7 @@ public class RadioButtonGroupTest {
     public void rpcSelectionChange_userOriginated() {
         AtomicInteger listenerCount = new AtomicInteger(0);
 
-        radioButtonGroup.addSelectionChangeListener(event -> {
+        radioButtonGroup.addSelectionListener(event -> {
             listenerCount.incrementAndGet();
             Assert.assertTrue(event.isUserOriginated());
         });

--- a/uitest/src/main/java/com/vaadin/tests/components/abstractlisting/AbstractSingleSelectTestUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/abstractlisting/AbstractSingleSelectTestUI.java
@@ -33,7 +33,7 @@ public abstract class AbstractSingleSelectTestUI<T extends AbstractSingleSelect<
 
     protected void createListenerMenu() {
         createListenerAction("Selection listener", "Listeners",
-                c -> c.addSelectionChangeListener(
+                c -> c.addSelectionListener(
                         e -> log("Selected: " + e.getValue())));
     }
 

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/basics/GridBasics.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/basics/GridBasics.java
@@ -230,7 +230,7 @@ public class GridBasics extends AbstractTestUIWithLog {
 
         selectionListenerRegistration = ((SingleSelectionModelImpl<DataObject>) grid
                 .getSelectionModel())
-                        .addSelectionListener(this::onSingleSelect);
+                        .addSingleSelectionListener(this::onSingleSelect);
 
         layout.addComponent(createMenu());
         layout.addComponent(grid);
@@ -512,7 +512,7 @@ public class GridBasics extends AbstractTestUIWithLog {
             grid.setSelectionMode(SelectionMode.SINGLE);
             selectionListenerRegistration = ((SingleSelectionModelImpl<DataObject>) grid
                     .getSelectionModel())
-                            .addSelectionListener(this::onSingleSelect);
+                            .addSingleSelectionListener(this::onSingleSelect);
             grid.asSingleSelect().setReadOnly(isUserSelectionAllowed);
         });
         selectionModelItem.addItem("multi", menuItem -> {
@@ -558,10 +558,10 @@ public class GridBasics extends AbstractTestUIWithLog {
             selectionListenerRegistration.remove();
             MultiSelectionModelImpl<DataObject> model = (MultiSelectionModelImpl<DataObject>) grid
                     .setSelectionMode(SelectionMode.MULTI);
-            model.addSelectionListener(this::onMultiSelect);
+            model.addMultiSelectionListener(this::onMultiSelect);
             grid.asMultiSelect().setReadOnly(isUserSelectionAllowed);
             selectionListenerRegistration = model
-                    .addSelectionListener(this::onMultiSelect);
+                    .addMultiSelectionListener(this::onMultiSelect);
         }
     }
 

--- a/uitest/src/main/java/com/vaadin/tests/components/radiobutton/RadioButtonGroupTestUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/radiobutton/RadioButtonGroupTestUI.java
@@ -102,7 +102,7 @@ public class RadioButtonGroupTestUI
 
     protected void createListenerMenu() {
         createListenerAction("Selection listener", "Listeners",
-                c -> c.addSelectionChangeListener(
+                c -> c.addSelectionListener(
                         e -> log("Selected: " + e.getSelectedItem())));
     }
 


### PR DESCRIPTION
Fixes some inconsistent event naming and invalid javadocs.

Fixes vaadin/framework8-issues#541

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/105)
<!-- Reviewable:end -->
