### PR TITLE
Fix margin in declarative format in gridlayout

### DIFF
--- a/server/src/main/java/com/vaadin/ui/GridLayout.java
+++ b/server/src/main/java/com/vaadin/ui/GridLayout.java
@@ -1628,6 +1628,11 @@ public class GridLayout extends AbstractLayout
         result.add("cursor-y");
         result.add("rows");
         result.add("columns");
+        result.add("margin");
+        result.add("margin-left");
+        result.add("margin-right");
+        result.add("margin-top");
+        result.add("margin-bottom");
         return result;
     }
 }

--- a/server/src/test/java/com/vaadin/tests/server/component/gridlayout/GridLayoutDeclarativeTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/gridlayout/GridLayoutDeclarativeTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.shared.ui.MarginInfo;
 import com.vaadin.shared.ui.label.ContentMode;
 import com.vaadin.tests.server.component.DeclarativeMarginTestBase;
 import com.vaadin.ui.Alignment;
@@ -301,5 +302,27 @@ public class GridLayoutDeclarativeTest
 
         testWrite(design, gl);
         testRead(design, gl);
+    }
+
+    @Test
+    public void testGridLayoutMargins() throws IOException {
+        String design = "<vaadin-grid-layout _id=\"marginComponent\"margin>"
+                + "<row><column><vaadin-grid-layout _id=\"marginLeftComponent\" margin-left></vaadin-grid-layout></column></row>"
+                + "<row><column><vaadin-grid-layout _id=\"marginRightComponent\" margin-right></vaadin-grid-layout></column></row>"
+                + "<row><column><vaadin-grid-layout _id=\"marginTopComponent\" margin-top></vaadin-grid-layout></column></row>"
+                + "<row><column><vaadin-grid-layout _id=\"marginBottomComponent\" margin-bottom></vaadin-grid-layout></column></row>"
+                + "</vaadin-grid-layout>";
+        DesignContext context = Design
+                .read(new ByteArrayInputStream(design.getBytes("UTF-8")), null);
+        Assert.assertEquals(null, context.getCustomAttributes(
+                context.getComponentByLocalId("marginComponent")));
+        Assert.assertEquals(null, context.getCustomAttributes(
+                context.getComponentByLocalId("marginLeftComponent")));
+        Assert.assertEquals(null, context.getCustomAttributes(
+                context.getComponentByLocalId("marginRightComponent")));
+        Assert.assertEquals(null, context.getCustomAttributes(
+                context.getComponentByLocalId("marginTopComponent")));
+        Assert.assertEquals(null, context.getCustomAttributes(
+                context.getComponentByLocalId("marginBottomComponent")));
     }
 }


### PR DESCRIPTION
Backported to 7.7 from master (8).

Fixes vaadin/framework8-issues#465

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/7952)
<!-- Reviewable:end -->
