### PR TITLE
Reduce javadoc errors by adding missing dependencies

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -97,6 +97,20 @@
             <artifactId>vaadin-widgets</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- Needed because referenced from javadocs -->
+        <dependency>
+            <groupId>javax.portlet</groupId>
+            <artifactId>portlet-api</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.liferay.portal</groupId>
+            <artifactId>portal-service</artifactId>
+            <version>${liferay.portal-service.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -323,8 +337,10 @@
                                     <excludePackageNames>com.vaadin.buildhelpers</excludePackageNames>
                                     <skip>false</skip>
                                     <links>
-                                        <link>http://docs.oracle.com/javase/6/docs/api/</link>
-                                        <link>http://docs.oracle.com/j2ee/1.4/docs/api/</link>
+                                        <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                                        <link>https://docs.oracle.com/javaee/6/api/</link>
+                                        <link>https://portals.apache.org/pluto/portlet-2.0-apidocs/</link>
+                                        <link>https://docs.liferay.com/portal/6.2/javadocs/</link>
                                     </links>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Used version numbers for dependencies -->
-        <liferay.portal.version>6.0.2</liferay.portal.version>
+        <liferay.portal-service.version>6.2.5</liferay.portal-service.version>
         <jetty.version>9.3.9.v20160517</jetty.version>
 
         <vaadin.gwt.version>2.8.0</vaadin.gwt.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.liferay.portal</groupId>
             <artifactId>portal-service</artifactId>
-            <version>${liferay.portal.version}</version>
+            <version>${liferay.portal-service.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
vaadin-all currently has +100 errors/warning when creating javadocs,
this reduces most of them related to missing resources to link to.
Also updated liferay dependency to 6.2.5 from 6.0.2 for vaadin-server,
since FW 8 supports liferay 6.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/7959)
<!-- Reviewable:end -->
