### PR TITLE
Fix context menu missing box-shadow for Runo on Chrome

### DIFF
--- a/themes/src/main/themes/VAADIN/themes/runo/common/common.scss
+++ b/themes/src/main/themes/VAADIN/themes/runo/common/common.scss
@@ -84,7 +84,7 @@
 	margin: 1px 0 4px 0;
 }
 .v-contextmenu {
-	background: #e9eced url(../tabsheet/img/tab-bg.png);
+	background: #e9eced url(../tabsheet/img/tab-bg.png) content-box;
 	font-family: "Trebuchet MS", geneva, helvetica, arial, tahoma, verdana, sans-serif;
 	background-color: #f6f7f7;
 	color: #464f52;


### PR DESCRIPTION
For Runo theme on Chrome, background image was overlapping box-shadow for ContextMenu. Verified by `RunoThemeTest.testTheme(Windows_Chrome_40)` screenshot that has been broken.

This fix should be imported to FW 8 compatibility runo theme too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/7966)
<!-- Reviewable:end -->
