### PR TITLE
Fix broken test for RadioButtonGroup and CheckBoxGroup

### DIFF
--- a/uitest-common/src/main/java/com/vaadin/testbench/customelements/CheckBoxGroupElement.java
+++ b/uitest-common/src/main/java/com/vaadin/testbench/customelements/CheckBoxGroupElement.java
@@ -21,30 +21,18 @@ import java.util.List;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.testbench.By;
-import com.vaadin.testbench.elements.AbstractSelectElement;
-import com.vaadin.testbench.elementsbase.ServerClass;
 
 /**
  * TestBench element supporting CheckBoxGroup
  *
  * @author Vaadin Ltd
  */
-
-@ServerClass("com.vaadin.ui.CheckBoxGroup")
-public class CheckBoxGroupElement extends AbstractSelectElement {
+public class CheckBoxGroupElement
+        extends com.vaadin.testbench.elements.CheckBoxGroupElement {
     private static org.openqa.selenium.By byButtonSpan = By
             .className("v-select-option");
     private static org.openqa.selenium.By byLabel = By.tagName("label");
     private static org.openqa.selenium.By byInput = By.tagName("input");
-
-    public List<String> getOptions() {
-        List<String> optionTexts = new ArrayList<>();
-        List<WebElement> options = findElements(byButtonSpan);
-        for (WebElement option : options) {
-            optionTexts.add(option.findElement(byLabel).getText());
-        }
-        return optionTexts;
-    }
 
     public List<String> getOptionsCssClasses() {
         List<String> optionTexts = new ArrayList<>();
@@ -68,26 +56,6 @@ public class CheckBoxGroupElement extends AbstractSelectElement {
 
         }
         return icons;
-    }
-
-    public void selectByText(String text) throws ReadOnlyException {
-        if (isReadOnly()) {
-            throw new ReadOnlyException();
-        }
-        List<WebElement> options = findElements(byButtonSpan);
-        for (int i = 0; i < options.size(); i++) {
-            WebElement option = options.get(i);
-            if (text.equals(option.findElement(byLabel).getText())) {
-                option.findElement(byInput).click();
-
-                // Seems like this is needed because of #19753
-                waitForVaadin();
-
-                // Toggling selection causes the DOM to be rebuilt, so fetch new
-                // items and continue iterating from the same index
-                options = findElements(byButtonSpan);
-            }
-        }
     }
 
     /**

--- a/uitest-common/src/main/java/com/vaadin/testbench/customelements/RadioButtonGroupElement.java
+++ b/uitest-common/src/main/java/com/vaadin/testbench/customelements/RadioButtonGroupElement.java
@@ -15,13 +15,12 @@
  */
 package com.vaadin.testbench.customelements;
 
-import com.vaadin.testbench.By;
-import com.vaadin.testbench.elements.AbstractSelectElement;
-import com.vaadin.testbench.elementsbase.ServerClass;
-import org.openqa.selenium.WebElement;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.testbench.By;
 
 /**
  * TestBench element supporting RadioButtonGroup
@@ -29,41 +28,10 @@ import java.util.List;
  * @author Vaadin Ltd
  */
 
-@ServerClass("com.vaadin.ui.RadioButtonGroup")
-public class RadioButtonGroupElement extends AbstractSelectElement {
+public class RadioButtonGroupElement
+        extends com.vaadin.testbench.elements.RadioButtonGroupElement {
     private static org.openqa.selenium.By byButtonSpan = By
             .className("v-select-option");
-    private static org.openqa.selenium.By byLabel = By.tagName("label");
-    private static org.openqa.selenium.By byInput = By.tagName("input");
-
-    public List<String> getOptions() {
-        List<String> optionTexts = new ArrayList<>();
-        List<WebElement> options = findElements(byButtonSpan);
-        for (WebElement option : options) {
-            optionTexts.add(option.findElement(byLabel).getText());
-        }
-        return optionTexts;
-    }
-
-    public void selectByText(String text) throws ReadOnlyException {
-        if (isReadOnly()) {
-            throw new ReadOnlyException();
-        }
-        List<WebElement> options = findElements(byButtonSpan);
-        for (int i = 0; i < options.size(); i++) {
-            WebElement option = options.get(i);
-            if (text.equals(option.findElement(byLabel).getText())) {
-                option.findElement(byInput).click();
-
-                // Seems like this is needed because of #19753
-                waitForVaadin();
-
-                // Toggling selection causes the DOM to be rebuilt, so fetch new
-                // items and continue iterating from the same index
-                options = findElements(byButtonSpan);
-            }
-        }
-    }
 
     /**
      * Return list of the selected options in the radiobutton group

--- a/uitest/src/test/java/com/vaadin/tests/components/checkboxgroup/CheckBoxGroupFocusBlurTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/checkboxgroup/CheckBoxGroupFocusBlurTest.java
@@ -40,12 +40,12 @@ public class CheckBoxGroupFocusBlurTest extends MultiBrowserTest {
 
         List<WebElement> checkBoxes = $(CheckBoxGroupElement.class).first()
                 .findElements(By.tagName("input"));
-        checkBoxes.get(0).click();
+        $(CheckBoxGroupElement.class).first().selectByText("1");
 
         // Focus event is fired
         Assert.assertTrue(logContainsText("1. Focus Event"));
 
-        checkBoxes.get(1).click();
+        $(CheckBoxGroupElement.class).first().selectByText("2");
         // click on the second checkbox doesn't fire anything
         Assert.assertFalse(logContainsText("2."));
 
@@ -71,7 +71,7 @@ public class CheckBoxGroupFocusBlurTest extends MultiBrowserTest {
         // blur event is fired
         Assert.assertTrue(logContainsText("2. Blur Event"));
 
-        checkBoxes.get(3).click();
+        $(CheckBoxGroupElement.class).first().selectByText("4");
         // Focus event is fired
         Assert.assertTrue(logContainsText("3. Focus Event"));
 

--- a/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupFocusBlurTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupFocusBlurTest.java
@@ -38,14 +38,16 @@ public class RadioButtonGroupFocusBlurTest extends MultiBrowserTest {
     public void focusBlurEvents() {
         openTestURL();
 
-        List<WebElement> radioButtons = $(RadioButtonGroupElement.class).first()
+        RadioButtonGroupElement radioButtonGroup = $(
+                RadioButtonGroupElement.class).first();
+        List<WebElement> radioButtons = radioButtonGroup
                 .findElements(By.tagName("input"));
-        radioButtons.get(0).click();
+        radioButtonGroup.selectByText("1");
 
         // Focus event is fired
         Assert.assertTrue(logContainsText("1. Focus Event"));
 
-        radioButtons.get(1).click();
+        radioButtonGroup.selectByText("2");
         // click on the second radio button doesn't fire anything
         Assert.assertFalse(logContainsText("2."));
 
@@ -60,8 +62,7 @@ public class RadioButtonGroupFocusBlurTest extends MultiBrowserTest {
         Assert.assertFalse(logContainsText("2."));
 
         // click to label of a radio button
-        $(RadioButtonGroupElement.class).first()
-                .findElements(By.tagName("label")).get(2).click();
+        radioButtonGroup.findElements(By.tagName("label")).get(2).click();
         // no new events
         Assert.assertFalse(logContainsText("2."));
 
@@ -70,7 +71,7 @@ public class RadioButtonGroupFocusBlurTest extends MultiBrowserTest {
         // blur event is fired
         Assert.assertTrue(logContainsText("2. Blur Event"));
 
-        radioButtons.get(3).click();
+        radioButtonGroup.selectByText("4");
         // Focus event is fired
         Assert.assertTrue(logContainsText("3. Focus Event"));
 


### PR DESCRIPTION
Selection by clicking options was broken on Chrome 40 on Windows. Using selectByText instead.
Switched the custom element to extend corresponding elements from TestBench API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/7970)
<!-- Reviewable:end -->
