### PR TITLE
Make AtmospherePushConnection methods public

### DIFF
--- a/server/src/main/java/com/vaadin/server/communication/AtmospherePushConnection.java
+++ b/server/src/main/java/com/vaadin/server/communication/AtmospherePushConnection.java
@@ -258,17 +258,21 @@ public class AtmospherePushConnection implements PushConnection {
     }
 
     /**
-     * @return the UI associated with this connection.
+     * Gets the UI this push connection is associated with.
+     *
+     * @return the UI associated with this connection
      */
-    protected UI getUI() {
+    public UI getUI() {
         return ui;
     }
 
     /**
-     * @return The AtmosphereResource associated with this connection or null if
-     *         connection not open.
+     * Gets the atmosphere resource associated with this connection.
+     *
+     * @return The AtmosphereResource associated with this connection or
+     *         <code>null</code> if the connection is not open.
      */
-    protected AtmosphereResource getResource() {
+    public AtmosphereResource getResource() {
         return resource;
     }
 


### PR DESCRIPTION
There is no sensible way to use a custom version of APC, so protected
access does not help in any way to access the underlying resource and/or
connected UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/7973)
<!-- Reviewable:end -->
