### PR TITLE
Remove usage of Consumer from event listeners

### DIFF
--- a/server/src/main/java/com/vaadin/data/BeanBinder.java
+++ b/server/src/main/java/com/vaadin/data/BeanBinder.java
@@ -130,7 +130,7 @@ public class BeanBinder<BEAN> extends Binder<BEAN> {
 
         @Override
         public BeanBindingBuilder<BEAN, TARGET> withValidationStatusHandler(
-                ValidationStatusHandler handler);
+                BindingValidationStatusHandler handler);
 
         @Override
         public default BeanBindingBuilder<BEAN, TARGET> withStatusLabel(
@@ -196,7 +196,7 @@ public class BeanBinder<BEAN> extends Binder<BEAN> {
         protected BeanBindingImpl(BeanBinder<BEAN> binder,
                 HasValue<FIELDVALUE> field,
                 Converter<FIELDVALUE, TARGET> converter,
-                ValidationStatusHandler statusHandler) {
+                BindingValidationStatusHandler statusHandler) {
             super(binder, field, converter, statusHandler);
         }
 
@@ -216,7 +216,7 @@ public class BeanBinder<BEAN> extends Binder<BEAN> {
 
         @Override
         public BeanBindingBuilder<BEAN, TARGET> withValidationStatusHandler(
-                ValidationStatusHandler handler) {
+                BindingValidationStatusHandler handler) {
             return (BeanBindingBuilder<BEAN, TARGET>) super.withValidationStatusHandler(
                     handler);
         }
@@ -377,7 +377,7 @@ public class BeanBinder<BEAN> extends Binder<BEAN> {
     @Override
     protected <FIELDVALUE, TARGET> BeanBindingImpl<BEAN, FIELDVALUE, TARGET> createBinding(
             HasValue<FIELDVALUE> field, Converter<FIELDVALUE, TARGET> converter,
-            ValidationStatusHandler handler) {
+            BindingValidationStatusHandler handler) {
         Objects.requireNonNull(field, "field cannot be null");
         Objects.requireNonNull(converter, "converter cannot be null");
         return new BeanBindingImpl<>(this, field, converter, handler);

--- a/server/src/main/java/com/vaadin/data/BinderValidationStatus.java
+++ b/server/src/main/java/com/vaadin/data/BinderValidationStatus.java
@@ -45,14 +45,14 @@ import com.vaadin.data.validator.BeanValidator;
  * @see BinderValidationStatusHandler
  * @see Binder#setValidationStatusHandler(BinderStatusHandler)
  * @see Binder#validate()
- * @see ValidationStatus
+ * @see BindingValidationStatus
  *
  * @since 8.0
  */
 public class BinderValidationStatus<BEAN> implements Serializable {
 
     private final Binder<BEAN> binder;
-    private final List<ValidationStatus<?>> bindingStatuses;
+    private final List<BindingValidationStatus<?>> bindingStatuses;
     private final List<ValidationResult> binderStatuses;
 
     /**
@@ -72,7 +72,7 @@ public class BinderValidationStatus<BEAN> implements Serializable {
             Binder<BEAN> source) {
         return new BinderValidationStatus<>(source,
                 source.getBindings().stream()
-                        .map(b -> ValidationStatus.createUnresolvedStatus(b))
+                        .map(b -> BindingValidationStatus.createUnresolvedStatus(b))
                         .collect(Collectors.toList()),
                 Collections.emptyList());
     }
@@ -89,7 +89,7 @@ public class BinderValidationStatus<BEAN> implements Serializable {
      *            the validation results for binder level validation
      */
     public BinderValidationStatus(Binder<BEAN> source,
-            List<ValidationStatus<?>> bindingStatuses,
+            List<BindingValidationStatus<?>> bindingStatuses,
             List<ValidationResult> binderStatuses) {
         Objects.requireNonNull(binderStatuses,
                 "binding statuses cannot be null");
@@ -118,7 +118,7 @@ public class BinderValidationStatus<BEAN> implements Serializable {
     public boolean hasErrors() {
         return binderStatuses.stream().filter(ValidationResult::isError)
                 .findAny().isPresent()
-                || bindingStatuses.stream().filter(ValidationStatus::isError)
+                || bindingStatuses.stream().filter(BindingValidationStatus::isError)
                         .findAny().isPresent();
     }
 
@@ -153,7 +153,7 @@ public class BinderValidationStatus<BEAN> implements Serializable {
      *
      * @return the field validation statuses
      */
-    public List<ValidationStatus<?>> getFieldValidationStatuses() {
+    public List<BindingValidationStatus<?>> getFieldValidationStatuses() {
         return bindingStatuses;
     }
 
@@ -179,8 +179,8 @@ public class BinderValidationStatus<BEAN> implements Serializable {
      *
      * @return a list of failed field level validation statuses
      */
-    public List<ValidationStatus<?>> getFieldValidationErrors() {
-        return bindingStatuses.stream().filter(ValidationStatus::isError)
+    public List<BindingValidationStatus<?>> getFieldValidationErrors() {
+        return bindingStatuses.stream().filter(BindingValidationStatus::isError)
                 .collect(Collectors.toList());
     }
 

--- a/server/src/main/java/com/vaadin/data/BinderValidationStatusHandler.java
+++ b/server/src/main/java/com/vaadin/data/BinderValidationStatusHandler.java
@@ -15,9 +15,7 @@
  */
 package com.vaadin.data;
 
-import java.io.Serializable;
-import java.util.function.Consumer;
-
+import com.vaadin.event.SerializableEventListener;
 import com.vaadin.ui.AbstractComponent;
 
 /**
@@ -37,7 +35,7 @@ import com.vaadin.ui.AbstractComponent;
  *
  * @see BinderValidationStatus
  * @see Binder#validate()
- * @see ValidationStatus
+ * @see BindingValidationStatus
  *
  * @param <BEAN>
  *            the bean type of binder
@@ -46,6 +44,14 @@ import com.vaadin.ui.AbstractComponent;
  */
 @FunctionalInterface
 public interface BinderValidationStatusHandler<BEAN>
-        extends Consumer<BinderValidationStatus<BEAN>>, Serializable {
+        extends SerializableEventListener {
+
+    /**
+     * Invoked when the validation status has changed in binder.
+     *
+     * @param statusChange
+     *            the changed status
+     */
+    void statusChange(BinderValidationStatus<BEAN> statusChange);
 
 }

--- a/server/src/main/java/com/vaadin/data/BindingValidationStatus.java
+++ b/server/src/main/java/com/vaadin/data/BindingValidationStatus.java
@@ -28,7 +28,7 @@ import com.vaadin.data.Binder.BindingBuilder;
  * associated with a ValidationResult {@link #getResult}.
  * <p>
  * Use
- * {@link BindingBuilder#withValidationStatusHandler(ValidationStatusHandler)}
+ * {@link BindingBuilder#withValidationStatusHandler(BindingValidationStatusHandler)}
  * to register a handler for field level validation status changes.
  *
  * @author Vaadin Ltd
@@ -38,19 +38,19 @@ import com.vaadin.data.Binder.BindingBuilder;
  *            status changed, matches the field type unless a converter has been
  *            set
  *
- * @see BindingBuilder#withValidationStatusHandler(ValidationStatusHandler)
+ * @see BindingBuilder#withValidationStatusHandler(BindingValidationStatusHandler)
  * @see Binding#validate()
- * @see ValidationStatusHandler
+ * @see BindingValidationStatusHandler
  * @see BinderValidationStatus
  *
  * @since 8.0
  */
-public class ValidationStatus<TARGET> implements Serializable {
+public class BindingValidationStatus<TARGET> implements Serializable {
 
     /**
      * Status of the validation.
      * <p>
-     * The status is the part of {@link ValidationStatus} which indicates
+     * The status is the part of {@link BindingValidationStatus} which indicates
      * whether the validation failed or not, or whether it is in unresolved
      * state (e.g. after clear or reset).
      */
@@ -84,9 +84,9 @@ public class ValidationStatus<TARGET> implements Serializable {
      *            the target data type of the binding for which the validation
      *            status was reset
      */
-    public static <TARGET> ValidationStatus<TARGET> createUnresolvedStatus(
+    public static <TARGET> BindingValidationStatus<TARGET> createUnresolvedStatus(
             Binding<?, TARGET> source) {
-        return new ValidationStatus<>(source, Status.UNRESOLVED, null);
+        return new BindingValidationStatus<>(source, Status.UNRESOLVED, null);
     }
 
     /**
@@ -98,7 +98,7 @@ public class ValidationStatus<TARGET> implements Serializable {
      * @param result
      *            the result of the validation
      */
-    public ValidationStatus(Binding<?, TARGET> source,
+    public BindingValidationStatus(Binding<?, TARGET> source,
             ValidationResult result) {
         this(source, result.isError() ? Status.ERROR : Status.OK, result);
     }
@@ -116,7 +116,7 @@ public class ValidationStatus<TARGET> implements Serializable {
      * @param result
      *            the related result, may be {@code null}
      */
-    public ValidationStatus(Binding<?, TARGET> source, Status status,
+    public BindingValidationStatus(Binding<?, TARGET> source, Status status,
             ValidationResult result) {
         Objects.requireNonNull(source, "Event source may not be null");
         Objects.requireNonNull(status, "Status may not be null");

--- a/server/src/main/java/com/vaadin/data/BindingValidationStatusHandler.java
+++ b/server/src/main/java/com/vaadin/data/BindingValidationStatusHandler.java
@@ -15,14 +15,12 @@
  */
 package com.vaadin.data;
 
-import java.io.Serializable;
-import java.util.function.Consumer;
-
 import com.vaadin.data.Binder.BindingBuilder;
+import com.vaadin.event.SerializableEventListener;
 import com.vaadin.ui.AbstractComponent;
 
 /**
- * Handler for {@link ValidationStatus} changes.
+ * Handler for {@link BindingValidationStatus} changes.
  * <p>
  * {@link BindingBuilder#withValidationStatusHandler(withValidationStatusHandler)
  * Register} an instance of this class to be able to override the default
@@ -33,13 +31,20 @@ import com.vaadin.ui.AbstractComponent;
  * @author Vaadin Ltd
  *
  * @see BindingBuilder#withValidationStatusHandler(withValidationStatusHandler)
- * @see ValidationStatus
+ * @see BindingValidationStatus
  *
  * @since 8.0
  *
  */
 @FunctionalInterface
-public interface ValidationStatusHandler
-        extends Consumer<ValidationStatus<?>>, Serializable {
+public interface BindingValidationStatusHandler
+        extends SerializableEventListener {
 
+    /**
+     * Invoked when the validation status has changed in a binding.
+     *
+     * @param statusChange
+     *            the changed status
+     */
+    public void statusChange(BindingValidationStatus<?> statusChange);
 }

--- a/server/src/main/java/com/vaadin/data/HasValue.java
+++ b/server/src/main/java/com/vaadin/data/HasValue.java
@@ -20,8 +20,8 @@ import java.lang.reflect.Method;
 import java.util.EventObject;
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
+import com.vaadin.event.SerializableEventListener;
 import com.vaadin.shared.Registration;
 import com.vaadin.ui.Component;
 import com.vaadin.util.ReflectTools;
@@ -140,11 +140,12 @@ public interface HasValue<V> extends Serializable {
      * @see Registration
      */
     @FunctionalInterface
-    public interface ValueChangeListener<V>
-            extends Consumer<ValueChangeEvent<V>>, Serializable {
+    public interface ValueChangeListener<V> extends SerializableEventListener {
+
+        /** For internal use only. Might be removed in the future. */
         @Deprecated
         public static final Method VALUE_CHANGE_METHOD = ReflectTools
-                .findMethod(ValueChangeListener.class, "accept",
+                .findMethod(ValueChangeListener.class, "valueChange",
                         ValueChangeEvent.class);
 
         /**
@@ -154,8 +155,7 @@ public interface HasValue<V> extends Serializable {
          * @param event
          *            the received event, not null
          */
-        @Override
-        public void accept(ValueChangeEvent<V> event);
+        public void valueChange(ValueChangeEvent<V> event);
     }
 
     /**
@@ -263,7 +263,7 @@ public interface HasValue<V> extends Serializable {
      * <p>
      * This is just a shorthand for resetting the value, see the methods
      * {@link #setValue(Object)} and {@link #getEmptyValue()}.
-     * 
+     *
      * @see #setValue(Object)
      * @see #getEmptyValue()
      */

--- a/server/src/main/java/com/vaadin/data/StatusChangeListener.java
+++ b/server/src/main/java/com/vaadin/data/StatusChangeListener.java
@@ -15,21 +15,24 @@
  */
 package com.vaadin.data;
 
-import java.io.Serializable;
+import com.vaadin.event.SerializableEventListener;
 
 /**
- * Listener interface for {@link StatusChangeEvent}s.
- * 
- * @see StatusChangeEvent
+ * Listener interface for status change events from binder.
+ *
  * @author Vaadin Ltd
  *
+ * @since 8.0
+ *
+ * @see StatusChangeEvent
+ * @see Binder#addStatusChangeListener(StatusChangeListener)
  */
 @FunctionalInterface
-public interface StatusChangeListener extends Serializable {
+public interface StatusChangeListener extends SerializableEventListener {
 
     /**
      * Notifies the listener about status change {@code event}.
-     * 
+     *
      * @param event
      *            a status change event, not null
      */

--- a/server/src/main/java/com/vaadin/data/ValidationException.java
+++ b/server/src/main/java/com/vaadin/data/ValidationException.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  */
 public class ValidationException extends Exception {
 
-    private final List<ValidationStatus<?>> fieldValidationErrors;
+    private final List<BindingValidationStatus<?>> fieldValidationErrors;
     private final List<ValidationResult> beanValidationErrors;
 
     /**
@@ -44,7 +44,7 @@ public class ValidationException extends Exception {
      * @param beanValidationErrors
      *            binder validation errors list
      */
-    public ValidationException(List<ValidationStatus<?>> fieldValidationErrors,
+    public ValidationException(List<BindingValidationStatus<?>> fieldValidationErrors,
             List<ValidationResult> beanValidationErrors) {
         super("Validation has failed for some fields");
         this.fieldValidationErrors = Collections
@@ -74,7 +74,7 @@ public class ValidationException extends Exception {
      *
      * @return binding validation errors list
      */
-    public List<ValidationStatus<?>> getFieldValidationErrors() {
+    public List<BindingValidationStatus<?>> getFieldValidationErrors() {
         return fieldValidationErrors;
     }
 

--- a/server/src/main/java/com/vaadin/event/selection/MultiSelectionListener.java
+++ b/server/src/main/java/com/vaadin/event/selection/MultiSelectionListener.java
@@ -15,23 +15,39 @@
  */
 package com.vaadin.event.selection;
 
-import java.io.Serializable;
-import java.util.function.Consumer;
+import java.lang.reflect.Method;
+
+import com.vaadin.event.SerializableEventListener;
+import com.vaadin.util.ReflectTools;
 
 /**
- * Listens to changes from a {@link com.vaadin.data.SelectionModel.Multi}.
+ * A listener for listening for selection changes from a multiselection
+ * component.
  *
  * @author Vaadin Ltd
  *
  * @since 8.0
  *
  * @param <T>
- *            the data type of the selection model
+ *            the type of the selected item
+ *
+ * @see SelectionModel.Multi
+ * @see MultiSelectionEvent
  */
 @FunctionalInterface
-public interface MultiSelectionListener<T>
-        extends Consumer<MultiSelectionEvent<T>>, Serializable {
-    @Override
-    // Explicitly defined to make reflection logic happy
-    void accept(MultiSelectionEvent<T> event);
+public interface MultiSelectionListener<T> extends SerializableEventListener {
+
+    /** For internal use only. Might be removed in the future. */
+    @Deprecated
+    static final Method SELECTION_CHANGE_METHOD = ReflectTools.findMethod(
+            MultiSelectionListener.class, "selectionChange",
+            MultiSelectionEvent.class);
+
+    /**
+     * Invoked when the selection has changed by the user or programmatically.
+     *
+     * @param event
+     *            the selection event, never {@code null}
+     */
+    public void selectionChange(MultiSelectionEvent<T> event);
 }

--- a/server/src/main/java/com/vaadin/event/selection/SelectionListener.java
+++ b/server/src/main/java/com/vaadin/event/selection/SelectionListener.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.event.selection;
 
-import com.vaadin.server.SerializableConsumer;
+import com.vaadin.event.SerializableEventListener;
 
 /**
  * A listener for {@code SelectionEvent}.
@@ -33,7 +33,14 @@ import com.vaadin.server.SerializableConsumer;
  * @since 8.0
  */
 @FunctionalInterface
-public interface SelectionListener<T>
-        extends SerializableConsumer<SelectionEvent<T>> {
+public interface SelectionListener<T> extends SerializableEventListener {
+
+    /**
+     * Invoked when the selection has changed by user or programmatically.
+     *
+     * @param event
+     *            the selection event
+     */
+    public void selectionChange(SelectionEvent<T> event);
 
 }

--- a/server/src/main/java/com/vaadin/event/selection/SingleSelectionListener.java
+++ b/server/src/main/java/com/vaadin/event/selection/SingleSelectionListener.java
@@ -15,25 +15,39 @@
  */
 package com.vaadin.event.selection;
 
-import java.io.Serializable;
-import java.util.function.Consumer;
+import java.lang.reflect.Method;
+
+import com.vaadin.event.SerializableEventListener;
+import com.vaadin.util.ReflectTools;
 
 /**
- * A listener for {@code SingleSelectionEvent}.
+ * A listener for listening to selection changes on a single selection
+ * component.
  *
  * @author Vaadin Ltd.
+ *
+ * @since 8.0
  *
  * @param <T>
  *            the type of the selected item
  *
+ * @see SelectionModel.Single
  * @see SingleSelectionEvent
- *
- * @since 8.0
  */
 @FunctionalInterface
-public interface SingleSelectionListener<T>
-        extends Consumer<SingleSelectionEvent<T>>, Serializable {
+public interface SingleSelectionListener<T> extends SerializableEventListener {
 
-    @Override
-    public void accept(SingleSelectionEvent<T> event);
+    /** For internal use only. Might be removed in the future. */
+    @Deprecated
+    static final Method SELECTION_CHANGE_METHOD = ReflectTools.findMethod(
+            SingleSelectionListener.class, "selectionChange",
+            SingleSelectionEvent.class);
+
+    /**
+     * Invoked when selection has been changed by the user or programmatically.
+     *
+     * @param event
+     *            the selection event
+     */
+    public void selectionChange(SingleSelectionEvent<T> event);
 }

--- a/server/src/main/java/com/vaadin/ui/AbstractField.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractField.java
@@ -16,7 +16,6 @@
 
 package com.vaadin.ui;
 
-import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Objects;
 
@@ -29,7 +28,6 @@ import com.vaadin.shared.Registration;
 import com.vaadin.ui.Component.Focusable;
 import com.vaadin.ui.declarative.DesignAttributeHandler;
 import com.vaadin.ui.declarative.DesignContext;
-import com.vaadin.util.ReflectTools;
 
 /**
  * An abstract implementation of a field, or a {@code Component} allowing user
@@ -49,10 +47,6 @@ import com.vaadin.util.ReflectTools;
  */
 public abstract class AbstractField<T> extends AbstractComponent
         implements HasValue<T>, Focusable {
-
-    @Deprecated
-    private static final Method VALUE_CHANGE_METHOD = ReflectTools.findMethod(
-            ValueChangeListener.class, "accept", ValueChangeEvent.class);
 
     @Override
     public void setValue(T value) {
@@ -90,7 +84,7 @@ public abstract class AbstractField<T> extends AbstractComponent
     public Registration addValueChangeListener(
             ValueChangeListener<T> listener) {
         return addListener(ValueChangeEvent.class, listener,
-                VALUE_CHANGE_METHOD);
+                ValueChangeListener.VALUE_CHANGE_METHOD);
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/AbstractMultiSelect.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractMultiSelect.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.ui;
 
-import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -45,7 +44,6 @@ import com.vaadin.shared.ui.ListingJsonConstants;
 import com.vaadin.shared.ui.abstractmultiselect.AbstractMultiSelectState;
 import com.vaadin.ui.declarative.DesignContext;
 import com.vaadin.ui.declarative.DesignException;
-import com.vaadin.util.ReflectTools;
 
 import elemental.json.JsonObject;
 
@@ -122,11 +120,6 @@ public abstract class AbstractMultiSelect<T> extends AbstractListing<T>
         }
     }
 
-    @Deprecated
-    private static final Method SELECTION_CHANGE_METHOD = ReflectTools
-            .findMethod(MultiSelectionListener.class, "accept",
-                    MultiSelectionEvent.class);
-
     /**
      * The item enabled status provider. It is up to the implementing class to
      * support this or not.
@@ -156,7 +149,7 @@ public abstract class AbstractMultiSelect<T> extends AbstractListing<T>
     public Registration addSelectionListener(
             MultiSelectionListener<T> listener) {
         return addListener(MultiSelectionEvent.class, listener,
-                SELECTION_CHANGE_METHOD);
+                MultiSelectionListener.SELECTION_CHANGE_METHOD);
     }
 
     @Override
@@ -231,7 +224,7 @@ public abstract class AbstractMultiSelect<T> extends AbstractListing<T>
     @Override
     public Registration addValueChangeListener(
             HasValue.ValueChangeListener<Set<T>> listener) {
-        return addSelectionListener(event -> listener.accept(
+        return addSelectionListener(event -> listener.valueChange(
                 new ValueChangeEvent<>(this, event.isUserOriginated())));
     }
 

--- a/server/src/main/java/com/vaadin/ui/AbstractSingleSelect.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractSingleSelect.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.ui;
 
-import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -37,7 +36,6 @@ import com.vaadin.shared.data.selection.SelectionServerRpc;
 import com.vaadin.shared.ui.AbstractSingleSelectState;
 import com.vaadin.ui.declarative.DesignContext;
 import com.vaadin.ui.declarative.DesignException;
-import com.vaadin.util.ReflectTools;
 
 import elemental.json.Json;
 
@@ -56,11 +54,6 @@ import elemental.json.Json;
  */
 public abstract class AbstractSingleSelect<T> extends AbstractListing<T>
         implements SingleSelect<T> {
-
-    @Deprecated
-    private static final Method SELECTION_CHANGE_METHOD = ReflectTools
-            .findMethod(SingleSelectionListener.class, "accept",
-                    SingleSelectionEvent.class);
 
     /**
      * Creates a new {@code AbstractListing} with a default data communicator.
@@ -106,7 +99,7 @@ public abstract class AbstractSingleSelect<T> extends AbstractListing<T>
     public Registration addSelectionListener(
             SingleSelectionListener<T> listener) {
         return addListener(SingleSelectionEvent.class, listener,
-                SELECTION_CHANGE_METHOD);
+                SingleSelectionListener.SELECTION_CHANGE_METHOD);
     }
 
     /**
@@ -168,7 +161,7 @@ public abstract class AbstractSingleSelect<T> extends AbstractListing<T>
     @Override
     public Registration addValueChangeListener(
             HasValue.ValueChangeListener<T> listener) {
-        return addSelectionListener(event -> listener.accept(
+        return addSelectionListener(event -> listener.valueChange(
                 new ValueChangeEvent<>(this, event.isUserOriginated())));
     }
 

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -559,7 +559,7 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
     public Registration addValueChangeListener(
             HasValue.ValueChangeListener<T> listener) {
         return addSelectionListener(event -> {
-            listener.accept(new ValueChangeEvent<>(event.getComponent(), this,
+            listener.valueChange(new ValueChangeEvent<>(event.getComponent(), this,
                     event.isUserOriginated()));
         });
     }

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -49,8 +48,8 @@ import com.vaadin.data.BinderValidationStatus;
 import com.vaadin.data.Listing;
 import com.vaadin.data.SelectionModel;
 import com.vaadin.event.ConnectorEvent;
-import com.vaadin.event.ConnectorEventListener;
 import com.vaadin.event.ContextClickEvent;
+import com.vaadin.event.SerializableEventListener;
 import com.vaadin.event.selection.MultiSelectionListener;
 import com.vaadin.event.selection.SelectionListener;
 import com.vaadin.event.selection.SingleSelectionListener;
@@ -125,7 +124,7 @@ public class Grid<T> extends AbstractListing<T>
 
     @Deprecated
     private static final Method ITEM_CLICK_METHOD = ReflectTools
-            .findMethod(ItemClickListener.class, "accept", ItemClick.class);
+            .findMethod(ItemClickListener.class, "itemClick", ItemClick.class);
 
     @Deprecated
     private static final Method COLUMN_VISIBILITY_METHOD = ReflectTools
@@ -260,7 +259,7 @@ public class Grid<T> extends AbstractListing<T>
         @Override
         public default Registration addSelectionListener(
                 SelectionListener<T> listener) {
-            return addSingleSelectionListener(e -> listener.accept(e));
+            return addSingleSelectionListener(e -> listener.selectionChange(e));
         }
 
         /**
@@ -303,7 +302,7 @@ public class Grid<T> extends AbstractListing<T>
         @Override
         public default Registration addSelectionListener(
                 SelectionListener<T> listener) {
-            return addMultiSelectionListener(e -> listener.accept(e));
+            return addMultiSelectionListener(e -> listener.selectionChange(e));
         }
 
         /**
@@ -482,8 +481,7 @@ public class Grid<T> extends AbstractListing<T>
      * @see Registration
      */
     @FunctionalInterface
-    public interface ItemClickListener<T>
-            extends Consumer<ItemClick<T>>, ConnectorEventListener {
+    public interface ItemClickListener<T> extends SerializableEventListener {
         /**
          * Invoked when this listener receives a item click event from a Grid to
          * which it has been added.
@@ -491,8 +489,7 @@ public class Grid<T> extends AbstractListing<T>
          * @param event
          *            the received event, not null
          */
-        @Override
-        public void accept(ItemClick<T> event);
+        public void itemClick(ItemClick<T> event);
     }
 
     /**
@@ -3648,9 +3645,9 @@ public class Grid<T> extends AbstractListing<T>
         for (Column<T, ?> column : getColumns()) {
             Object value = column.valueProvider.apply(item);
             tableRow.appendElement("td")
-                    .append((Optional.ofNullable(value).map(Object::toString)
+                    .append(Optional.ofNullable(value).map(Object::toString)
                             .map(DesignFormatter::encodeForTextNode)
-                            .orElse("")));
+                            .orElse(""));
         }
     }
 

--- a/server/src/main/java/com/vaadin/ui/components/grid/EditorImpl.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/EditorImpl.java
@@ -50,7 +50,7 @@ public class EditorImpl<T> extends AbstractGridExtension<T>
             implements BinderValidationStatusHandler<T> {
 
         @Override
-        public void accept(BinderValidationStatus<T> status) {
+        public void statusChange(BinderValidationStatus<T> status) {
             boolean ok = status.isOk();
             if (saving) {
                 rpc.confirmSave(ok);

--- a/server/src/main/java/com/vaadin/ui/components/grid/MultiSelectionModelImpl.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/MultiSelectionModelImpl.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.ui.components.grid;
 
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -35,7 +34,6 @@ import com.vaadin.shared.data.selection.GridMultiSelectServerRpc;
 import com.vaadin.shared.ui.grid.MultiSelectionModelState;
 import com.vaadin.ui.Grid.MultiSelectionModel;
 import com.vaadin.ui.MultiSelect;
-import com.vaadin.util.ReflectTools;
 
 /**
  * Multiselection model for grid.
@@ -121,11 +119,6 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
             onDeselectAll(true);
         }
     }
-
-    @Deprecated
-    private static final Method SELECTION_CHANGE_METHOD = ReflectTools
-            .findMethod(MultiSelectionListener.class, "accept",
-                    MultiSelectionEvent.class);
 
     private Set<T> selection = new LinkedHashSet<>();
 
@@ -247,7 +240,7 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
     public Registration addMultiSelectionListener(
             MultiSelectionListener<T> listener) {
         return addListener(MultiSelectionEvent.class, listener,
-                SELECTION_CHANGE_METHOD);
+                MultiSelectionListener.SELECTION_CHANGE_METHOD);
     }
 
     @Override
@@ -296,7 +289,8 @@ public class MultiSelectionModelImpl<T> extends AbstractSelectionModel<T>
             @Override
             public Registration addValueChangeListener(
                     com.vaadin.data.HasValue.ValueChangeListener<Set<T>> listener) {
-                return addSelectionListener(event -> listener.accept(event));
+                return addSelectionListener(
+                        event -> listener.valueChange(event));
             }
 
             @Override

--- a/server/src/main/java/com/vaadin/ui/components/grid/SingleSelectionModelImpl.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/SingleSelectionModelImpl.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.ui.components.grid;
 
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -31,7 +30,6 @@ import com.vaadin.shared.ui.grid.SingleSelectionModelState;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Grid.SingleSelectionModel;
 import com.vaadin.ui.SingleSelect;
-import com.vaadin.util.ReflectTools;
 
 /**
  * Single selection model for grid.
@@ -44,10 +42,6 @@ import com.vaadin.util.ReflectTools;
  */
 public class SingleSelectionModelImpl<T> extends AbstractSelectionModel<T>
         implements SingleSelectionModel<T> {
-
-    private static final Method SELECTION_CHANGE_METHOD = ReflectTools
-            .findMethod(SingleSelectionListener.class, "accept",
-                    SingleSelectionEvent.class);
 
     private T selectedItem = null;
 
@@ -83,7 +77,7 @@ public class SingleSelectionModelImpl<T> extends AbstractSelectionModel<T>
     public Registration addSingleSelectionListener(
             SingleSelectionListener<T> listener) {
         return addListener(SingleSelectionEvent.class, listener,
-                SELECTION_CHANGE_METHOD);
+                SingleSelectionListener.SELECTION_CHANGE_METHOD);
     }
 
     @Override
@@ -250,7 +244,7 @@ public class SingleSelectionModelImpl<T> extends AbstractSelectionModel<T>
                     com.vaadin.data.HasValue.ValueChangeListener<T> listener) {
                 return SingleSelectionModelImpl.this.addSingleSelectionListener(
                         (SingleSelectionListener<T>) event -> listener
-                                .accept(event));
+                                .valueChange(event));
             }
 
             @Override

--- a/server/src/test/java/com/vaadin/data/BeanBinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BeanBinderTest.java
@@ -198,7 +198,7 @@ public class BeanBinderTest
 
     private void assertInvalid(HasValue<?> field, String message) {
         BinderValidationStatus<?> status = binder.validate();
-        List<ValidationStatus<?>> errors = status.getFieldValidationErrors();
+        List<BindingValidationStatus<?>> errors = status.getFieldValidationErrors();
         assertEquals(1, errors.size());
         assertSame(field, errors.get(0).getField());
         assertEquals(message, errors.get(0).getMessage().get());

--- a/server/src/test/java/com/vaadin/data/BinderBookOfVaadinTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderBookOfVaadinTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import com.vaadin.data.Binder.Binding;
 import com.vaadin.data.Binder.BindingBuilder;
-import com.vaadin.data.ValidationStatus.Status;
+import com.vaadin.data.BindingValidationStatus.Status;
 import com.vaadin.data.util.converter.Converter;
 import com.vaadin.data.util.converter.StringToIntegerConverter;
 import com.vaadin.data.util.converter.ValueContext;
@@ -375,7 +375,7 @@ public class BinderBookOfVaadinTest {
         departing.setValue(before);
         returning.setValue(after);
 
-        ValidationStatus<LocalDate> result = returnBinding.validate();
+        BindingValidationStatus<LocalDate> result = returnBinding.validate();
         Assert.assertFalse(result.isError());
         Assert.assertNull(departing.getComponentError());
 
@@ -426,7 +426,7 @@ public class BinderBookOfVaadinTest {
     @Test
     public void withBindingStatusHandlerExample() {
         Label nameStatus = new Label();
-        AtomicReference<ValidationStatus<?>> statusCapture = new AtomicReference<>();
+        AtomicReference<BindingValidationStatus<?>> statusCapture = new AtomicReference<>();
 
         String msg = "Full name must contain at least three characters";
         binder.forField(field).withValidator(name -> name.length() >= 3, msg)
@@ -444,7 +444,7 @@ public class BinderBookOfVaadinTest {
         Assert.assertTrue(nameStatus.isVisible());
         Assert.assertEquals(msg, nameStatus.getValue());
         Assert.assertNotNull(statusCapture.get());
-        ValidationStatus<?> status = statusCapture.get();
+        BindingValidationStatus<?> status = statusCapture.get();
         Assert.assertEquals(Status.ERROR, status.getStatus());
         Assert.assertEquals(msg, status.getMessage().get());
         Assert.assertEquals(field, status.getField());
@@ -652,7 +652,7 @@ public class BinderBookOfVaadinTest {
             formStatusLabel.setVisible(!errorMessage.isEmpty());
 
             // Let the default handler show messages for each field
-            defaultHandler.accept(status);
+            defaultHandler.statusChange(status);
         });
 
         final String bindingMessage = "uneven";

--- a/server/src/test/java/com/vaadin/data/BinderConverterValidatorTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderConverterValidatorTest.java
@@ -98,11 +98,11 @@ public class BinderConverterValidatorTest
         binding.bind(Person::getFirstName, Person::setFirstName);
 
         BinderValidationStatus<Person> status = binder.validate();
-        List<ValidationStatus<?>> errors = status.getFieldValidationErrors();
+        List<BindingValidationStatus<?>> errors = status.getFieldValidationErrors();
 
         assertEquals(1, errors.size());
 
-        ValidationStatus<?> validationStatus = errors.stream().findFirst()
+        BindingValidationStatus<?> validationStatus = errors.stream().findFirst()
                 .get();
         String msg = validationStatus.getMessage().get();
         assertEquals(msg1, msg);
@@ -167,7 +167,7 @@ public class BinderConverterValidatorTest
     }
 
     private void assertValidationErrors(
-            List<ValidationStatus<?>> validationErrors,
+            List<BindingValidationStatus<?>> validationErrors,
             String... errorMessages) {
         assertEquals(errorMessages.length, validationErrors.size());
         for (int i = 0; i < errorMessages.length; i++) {
@@ -258,7 +258,7 @@ public class BinderConverterValidatorTest
         Person person = new Person();
         binder.setBean(person);
 
-        List<ValidationStatus<?>> errors = binder.validate()
+        List<BindingValidationStatus<?>> errors = binder.validate()
                 .getFieldValidationErrors();
         assertEquals(0, errors.size());
     }
@@ -275,10 +275,10 @@ public class BinderConverterValidatorTest
         Person person = new Person();
         binder.setBean(person);
 
-        List<ValidationStatus<?>> errors = binder.validate()
+        List<BindingValidationStatus<?>> errors = binder.validate()
                 .getFieldValidationErrors();
         assertEquals(1, errors.size());
-        ValidationStatus<?> error = errors.get(0);
+        BindingValidationStatus<?> error = errors.get(0);
         assertEquals(msg, error.getMessage().get());
         assertEquals(nameField, error.getField());
     }
@@ -296,11 +296,11 @@ public class BinderConverterValidatorTest
         Person person = new Person();
         binder.setBean(person);
 
-        List<ValidationStatus<?>> errors = binder.validate()
+        List<BindingValidationStatus<?>> errors = binder.validate()
                 .getFieldValidationErrors();
         assertEquals(1, errors.size());
 
-        ValidationStatus<?> error = errors.get(0);
+        BindingValidationStatus<?> error = errors.get(0);
 
         assertEquals(msg1, error.getMessage().get());
         assertEquals(nameField, error.getField());
@@ -570,10 +570,10 @@ public class BinderConverterValidatorTest
             binder.writeBean(person);
             Assert.fail();
         } catch (ValidationException exception) {
-            List<ValidationStatus<?>> validationErrors = exception
+            List<BindingValidationStatus<?>> validationErrors = exception
                     .getFieldValidationErrors();
             Assert.assertEquals(2, validationErrors.size());
-            ValidationStatus<?> error = validationErrors.get(0);
+            BindingValidationStatus<?> error = validationErrors.get(0);
             Assert.assertEquals(nameField, error.getField());
             Assert.assertEquals(msg, error.getMessage().get());
 

--- a/server/src/test/java/com/vaadin/data/BinderValidationStatusTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderValidationStatusTest.java
@@ -24,14 +24,14 @@ import org.junit.Test;
 
 import com.vaadin.data.Binder.Binding;
 import com.vaadin.data.Binder.BindingBuilder;
-import com.vaadin.data.ValidationStatus.Status;
+import com.vaadin.data.BindingValidationStatus.Status;
 import com.vaadin.tests.data.bean.Person;
 import com.vaadin.ui.Label;
 
 public class BinderValidationStatusTest
         extends BinderTestBase<Binder<Person>, Person> {
 
-    protected final static ValidationStatusHandler NOOP = event -> {
+    protected final static BindingValidationStatusHandler NOOP = event -> {
     };
 
     @Before
@@ -48,7 +48,7 @@ public class BinderValidationStatusTest
 
     @Test
     public void bindingWithStatusHandler_handlerGetsEvents() {
-        AtomicReference<ValidationStatus<?>> statusCapture = new AtomicReference<>();
+        AtomicReference<BindingValidationStatus<?>> statusCapture = new AtomicReference<>();
         BindingBuilder<Person, String> binding = binder.forField(nameField)
                 .withValidator(notEmpty).withValidationStatusHandler(evt -> {
                     Assert.assertNull(statusCapture.get());
@@ -63,7 +63,7 @@ public class BinderValidationStatusTest
         binder.validate();
 
         Assert.assertNotNull(statusCapture.get());
-        ValidationStatus<?> evt = statusCapture.get();
+        BindingValidationStatus<?> evt = statusCapture.get();
         Assert.assertEquals(Status.ERROR, evt.getStatus());
         Assert.assertEquals(EMPTY_ERROR_MESSAGE, evt.getMessage().get());
         Assert.assertEquals(nameField, evt.getField());
@@ -235,13 +235,13 @@ public class BinderValidationStatusTest
 
         Assert.assertNull(nameField.getComponentError());
 
-        List<ValidationStatus<?>> bindingStatuses = status
+        List<BindingValidationStatus<?>> bindingStatuses = status
                 .getFieldValidationStatuses();
         Assert.assertNotNull(bindingStatuses);
         Assert.assertEquals(1, status.getFieldValidationErrors().size());
         Assert.assertEquals(2, bindingStatuses.size());
 
-        ValidationStatus<?> r = bindingStatuses.get(0);
+        BindingValidationStatus<?> r = bindingStatuses.get(0);
         Assert.assertTrue(r.isError());
         Assert.assertEquals(EMPTY_ERROR_MESSAGE, r.getMessage().get());
         Assert.assertEquals(nameField, r.getField());
@@ -328,13 +328,13 @@ public class BinderValidationStatusTest
 
         Assert.assertNull(nameField.getComponentError());
 
-        List<ValidationStatus<?>> bindingStatuses = status
+        List<BindingValidationStatus<?>> bindingStatuses = status
                 .getFieldValidationStatuses();
         Assert.assertNotNull(bindingStatuses);
         Assert.assertEquals(1, status.getFieldValidationErrors().size());
         Assert.assertEquals(2, bindingStatuses.size());
 
-        ValidationStatus<?> r = bindingStatuses.get(0);
+        BindingValidationStatus<?> r = bindingStatuses.get(0);
         Assert.assertTrue(r.isError());
         Assert.assertEquals(EMPTY_ERROR_MESSAGE, r.getMessage().get());
         Assert.assertEquals(nameField, r.getField());
@@ -497,7 +497,7 @@ public class BinderValidationStatusTest
         nameField.setValue("foo");
         binder.validate();
 
-        List<ValidationStatus<?>> results = capture.get()
+        List<BindingValidationStatus<?>> results = capture.get()
                 .getFieldValidationStatuses();
         Assert.assertNotNull(results);
         Assert.assertEquals(1, results.size());

--- a/server/src/test/java/com/vaadin/tests/components/grid/GridMultiSelectionModelTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/grid/GridMultiSelectionModelTest.java
@@ -602,7 +602,7 @@ public class GridMultiSelectionModelTest {
                 });
         Assert.assertSame(registration, actualRegistration);
 
-        selectionListener.get().accept(new MultiSelectionEvent<>(grid,
+        selectionListener.get().selectionChange(new MultiSelectionEvent<>(grid,
                 model.asMultiSelect(), Collections.emptySet(), true));
 
         Assert.assertEquals(grid, event.get().getComponent());

--- a/server/src/test/java/com/vaadin/tests/components/grid/GridSingleSelectionModelTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/grid/GridSingleSelectionModelTest.java
@@ -313,7 +313,7 @@ public class GridSingleSelectionModelTest {
                 });
         Assert.assertSame(registration, actualRegistration);
 
-        selectionListener.get().accept(new SingleSelectionEvent<>(grid,
+        selectionListener.get().selectionChange(new SingleSelectionEvent<>(grid,
                 select.asSingleSelect(), true));
 
         Assert.assertEquals(grid, event.get().getComponent());

--- a/server/src/test/java/com/vaadin/ui/AbstractFieldTest.java
+++ b/server/src/test/java/com/vaadin/ui/AbstractFieldTest.java
@@ -58,7 +58,7 @@ public class AbstractFieldTest extends EasyMockSupport {
 
     @Test
     public void valueChangeListenerInvoked() {
-        l.accept(EasyMock.capture(capture));
+        l.valueChange(EasyMock.capture(capture));
         replayAll();
 
         field.setValue("foo");
@@ -72,7 +72,7 @@ public class AbstractFieldTest extends EasyMockSupport {
 
     @Test
     public void valueChangeListenerInvokedFromClient() {
-        l.accept(EasyMock.capture(capture));
+        l.valueChange(EasyMock.capture(capture));
         replayAll();
 
         field.setValue("foo");

--- a/server/src/test/java/com/vaadin/ui/AbstractMultiSelectTest.java
+++ b/server/src/test/java/com/vaadin/ui/AbstractMultiSelectTest.java
@@ -318,7 +318,7 @@ public class AbstractMultiSelectTest<S extends AbstractMultiSelect<String> & Lis
 
         Assert.assertSame(registration, actualRegistration);
 
-        selectionListener.get().accept(new MultiSelectionEvent<>(select,
+        selectionListener.get().selectionChange(new MultiSelectionEvent<>(select,
                 Mockito.mock(Set.class), true));
 
         Assert.assertEquals(select, event.get().getComponent());

--- a/server/src/test/java/com/vaadin/ui/AbstractSingleSelectTest.java
+++ b/server/src/test/java/com/vaadin/ui/AbstractSingleSelectTest.java
@@ -269,7 +269,7 @@ public class AbstractSingleSelectTest {
         Assert.assertSame(registration, actualRegistration);
 
         selectionListener.get()
-                .accept(new SingleSelectionEvent<>(select, true));
+                .selectionChange(new SingleSelectionEvent<>(select, true));
 
         Assert.assertEquals(select, event.get().getComponent());
         Assert.assertEquals(value, event.get().getValue());

--- a/uitest/src/main/java/com/vaadin/tests/components/abstractfield/AbstractFieldTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/abstractfield/AbstractFieldTest.java
@@ -88,7 +88,7 @@ public abstract class AbstractFieldTest<T extends AbstractField<V>, V>
         private ValueChangeListener<V> valueChangeListener = new ValueChangeListener<V>() {
 
             @Override
-            public void accept(ValueChangeEvent<V> event) {
+            public void valueChange(ValueChangeEvent<V> event) {
                 log(event.getClass().getSimpleName() + ", new value: "
                         + formatValue(event.getValue()));
             }

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/LenientMode.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/LenientMode.java
@@ -72,7 +72,7 @@ public class LenientMode extends TestBase
     }
 
     @Override
-    public void accept(ValueChangeEvent<LocalDate> event) {
+    public void valueChange(ValueChangeEvent<LocalDate> event) {
         getMainWindow().showNotification("New value" + event.getValue());
     }
 

--- a/uitest/src/main/java/com/vaadin/tests/components/table/HeaderFooterClickLeftRightMiddle.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/HeaderFooterClickLeftRightMiddle.java
@@ -50,7 +50,7 @@ public class HeaderFooterClickLeftRightMiddle extends AbstractTestUIWithLog {
                     };
 
                     @Override
-                    public void accept(ValueChangeEvent<Boolean> event) {
+                    public void valueChange(ValueChangeEvent<Boolean> event) {
                         if (table.getListeners(HeaderClickEvent.class)
                                 .isEmpty()) {
                             table.addHeaderClickListener(headerClickListener);
@@ -80,7 +80,7 @@ public class HeaderFooterClickLeftRightMiddle extends AbstractTestUIWithLog {
                     };
 
                     @Override
-                    public void accept(ValueChangeEvent<Boolean> event) {
+                    public void valueChange(ValueChangeEvent<Boolean> event) {
                         if (table.getListeners(FooterClickEvent.class)
                                 .isEmpty()) {
                             table.addFooterClickListener(footerClickListener);


### PR DESCRIPTION
Touched event listeners are:
- SelectionListener
- MultiSelectionListener
- SingleSelectionListener
- ValueChangeListener
- ItemClickListener
- BindingValidationStatusHandler
- BinderValidationStatusHandler
- StatusChangeListener

Part of vaadin/framework8-issues#264
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/7985)
<!-- Reviewable:end -->
