### PR TITLE
Use PhantomJS2 for server integration tests

### DIFF
--- a/uitest/integration_tests.xml
+++ b/uitest/integration_tests.xml
@@ -105,14 +105,14 @@
 
     <target name="integration-test-jetty8">
         <antcall target="run-generic-integration-test">
-            <param name="startDelay" value="180" />
+            <param name="startDelay" value="90" />
             <param name="target-server" value="jetty8" />
         </antcall>
     </target>
 
     <target name="integration-test-jetty9">
         <antcall target="run-generic-integration-test">
-            <param name="startDelay" value="180" />
+            <param name="startDelay" value="90" />
             <param name="target-server" value="jetty9" />
         </antcall>
     </target>
@@ -164,7 +164,7 @@
 
     <target name="integration-test-weblogic12">
         <antcall target="run-generic-integration-test">
-            <param name="startDelay" value="360" />
+            <param name="startDelay" value="60" />
             <param name="target-port" value="7001" />
             <param name="target-server" value="weblogic12" />
         </antcall>

--- a/uitest/src/test/java/com/vaadin/tests/integration/AbstractIntegrationTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/integration/AbstractIntegrationTest.java
@@ -18,7 +18,7 @@ package com.vaadin.tests.integration;
 import com.vaadin.testbench.By;
 import com.vaadin.testbench.elements.UIElement;
 import com.vaadin.testbench.parallel.TestNameSuffix;
-import com.vaadin.tests.tb3.PrivateTB3Configuration;
+import com.vaadin.tests.tb3.SingleBrowserTestPhantomJS2;
 
 /**
  * Base class for integration tests. Integration tests use the
@@ -28,7 +28,8 @@ import com.vaadin.tests.tb3.PrivateTB3Configuration;
  * @author Vaadin Ltd
  */
 @TestNameSuffix(property = "server-name")
-public abstract class AbstractIntegrationTest extends PrivateTB3Configuration {
+public abstract class AbstractIntegrationTest
+        extends SingleBrowserTestPhantomJS2 {
     @Override
     protected String getBaseURL() {
         String deploymentUrl = System.getProperty("deployment.url");

--- a/uitest/src/test/java/com/vaadin/tests/integration/AbstractServletIntegrationTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/integration/AbstractServletIntegrationTest.java
@@ -42,8 +42,12 @@ public abstract class AbstractServletIntegrationTest
     @Test
     public void runTest() throws IOException, AssertionError {
         openTestURL();
+        // make sure no fading progress indicator from table update is lingering
+        sleep(2000);
         compareScreen("initial");
         $(TableElement.class).first().getCell(0, 1).click();
+        // without this, table fetch might have a fading progress indicator
+        sleep(2000);
         compareScreen("finland");
     }
 

--- a/uitest/src/test/java/com/vaadin/tests/integration/JSPIntegrationTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/integration/JSPIntegrationTest.java
@@ -27,9 +27,9 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.tests.tb3.PrivateTB3Configuration;
+import com.vaadin.tests.tb3.SingleBrowserTestPhantomJS2;
 
-public class JSPIntegrationTest extends PrivateTB3Configuration {
+public class JSPIntegrationTest extends SingleBrowserTestPhantomJS2 {
 
     final String appRunnerTestUrl = getBaseURL() + "/run/Buttons";
     final String jspUrl = getBaseURL() + "/statictestfiles/vaadinsessions.jsp";


### PR DESCRIPTION
Make server integration tests more reliable and faster by using PhantomJS2 and adjusting delays.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8030)
<!-- Reviewable:end -->
