### PR TITLE
Fix the upload test for IE11 (at least).

### DIFF
--- a/uitest/src/main/java/com/vaadin/tests/components/upload/TestFileUpload.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/upload/TestFileUpload.java
@@ -53,6 +53,7 @@ public class TestFileUpload extends TestBase implements Receiver {
                 baos.reset();
             }
         });
+        u.setImmediateMode(false);
 
         addComponent(log);
         addComponent(u);


### PR DESCRIPTION
The upload test should use an Upload in non-immediate mode because the
file name is written in-line into the Upload text input and the button
is used to upload a file without showing a file chooser dialog. The test
for upload in immediate mode works for Chrome (no file chooser window
issue) but it doesn't work for IE11 (at least, may be the same issue for
FF).
So the test UI is just updated to use non-immediate mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8035)
<!-- Reviewable:end -->
