### PR TITLE
Mention deprecating FontAwesome icons in release notes

### DIFF
--- a/all/src/main/templates/release-notes.html
+++ b/all/src/main/templates/release-notes.html
@@ -146,6 +146,7 @@
             <li>Valo is the only included theme, all other themes have been moved to the <tt>compatiblity-themes</tt> package and are available as a separate dependency</li>
             <li><tt>SharedState</tt> and the getter methods for it have been added to each component, regardless of whether those are used for anything or not</li>
             <li>The old liferay theme (Liferay 6.0 look) has been removed</li>
+            <li>FontAwesome icon constants have been deprecated, and will be moved to <tt>compability-server</tt> before 8.0 final. They will be replaced with <a href="https://vaadin.com/icons">Vaadin icons</a> in an upcoming beta</li>
         </ul>
         <ul><h4>Component specific API changes</h4>
             <li><tt>DateField</tt> replaces old <tt>PopupDateField</tt></li>


### PR DESCRIPTION
Part of #7979

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8039)
<!-- Reviewable:end -->
