### PR TITLE
Set focus when click on RadioButton via JS.

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VCheckBoxGroup.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCheckBoxGroup.java
@@ -29,6 +29,7 @@ import com.google.gwt.user.client.ui.FocusWidget;
 import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.client.ApplicationConnection;
+import com.vaadin.client.BrowserInfo;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.widgets.FocusableFlowPanelComposite;
 import com.vaadin.shared.Registration;
@@ -134,7 +135,11 @@ public class VCheckBoxGroup extends FocusableFlowPanelComposite
                 // checkbox is disabled
                 return;
             }
-
+            if (BrowserInfo.get().isWebkit() || BrowserInfo.get().isIE11()) {
+                // Webkit does not focus non-text input elements on click
+                // (#11854)
+                source.setFocus(true);
+            }
             Boolean selected = source.getValue();
 
             JsonObject item = optionsToItems.get(source);

--- a/client/src/main/java/com/vaadin/client/ui/VRadioButtonGroup.java
+++ b/client/src/main/java/com/vaadin/client/ui/VRadioButtonGroup.java
@@ -152,7 +152,7 @@ public class VRadioButtonGroup extends FocusableFlowPanelComposite
                 // radiobutton is disabled
                 return;
             }
-            if (BrowserInfo.get().isWebkit()) {
+            if (BrowserInfo.get().isWebkit() || BrowserInfo.get().isIE11()) {
                 // Webkit does not focus non-text input elements on click
                 // (#11854)
                 source.setFocus(true);


### PR DESCRIPTION
Sending click even in JS to a RadioButton in RadioButtonGroup doesn't
trigger focus event for RadioButtonGroup in IE11. Fix it.
Same fix for CheckBoxGroup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8062)
<!-- Reviewable:end -->
