### PR TITLE
Binder: added method to refresh bound fields

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1093,7 +1093,7 @@ public class Binder<BEAN> implements Serializable {
         } else {
             doRemoveBean(false);
             this.bean = bean;
-            bindings.forEach(b -> b.initFieldValue(bean));
+            updateBindings(bean);
             // if there has been field value change listeners that trigger
             // validation, need to make sure the validation errors are cleared
             getValidationStatusHandler().statusChange(
@@ -1130,11 +1130,28 @@ public class Binder<BEAN> implements Serializable {
     public void readBean(BEAN bean) {
         Objects.requireNonNull(bean, "bean cannot be null");
         setHasChanges(false);
-        bindings.forEach(binding -> binding.initFieldValue(bean));
+        updateBindings(bean);
 
         getValidationStatusHandler().statusChange(
                 BinderValidationStatus.createUnresolvedStatus(this));
         fireStatusChangeEvent(false);
+    }
+
+    /**
+     * Updates the fields associated to this binder with the values read from the given bean.
+     *
+     * @param bean
+     *            the bean whose property values to read, not null
+     */
+    private void updateBindings(BEAN bean) {
+        bindings.forEach(binding -> binding.initFieldValue(bean));
+    }
+
+    /**
+     * Refreshes the fields associated with the {@link Binder} reading the values from the underlying bean.
+     */
+    public void refresh() {
+        updateBindings(getBean());
     }
 
     /**

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -185,6 +185,37 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         Assert.assertEquals("", nameField.getValue());
     }
 
+    @Test
+    public void refresh() {
+        binder.bind(nameField, Person::getFirstName, Person::setFirstName);
+        binder.forField(ageField).withConverter(new StringToIntegerConverter("")).bind(Person::getAge, Person::setAge);
+
+        Person person = new Person();
+
+        String fooName = "foo";
+        int fooAge = 42;
+        person.setFirstName(fooName);
+        person.setAge(fooAge);
+        binder.setBean(person);
+
+        Assert.assertEquals(fooName, nameField.getValue());
+        Assert.assertEquals(String.valueOf(fooAge), ageField.getValue());
+
+        String barName = "bar";
+        int barAge = 24;
+        person.setFirstName(barName);
+        person.setAge(barAge);
+
+        Assert.assertEquals(fooName, nameField.getValue());
+        Assert.assertEquals(String.valueOf(fooAge), ageField.getValue());
+
+        binder.refresh();
+
+        Assert.assertEquals(barName, nameField.getValue());
+        Assert.assertEquals(String.valueOf(barAge), ageField.getValue());
+
+    }
+
     protected void bindName() {
         binder.bind(nameField, Person::getFirstName, Person::setFirstName);
         binder.setBean(item);


### PR DESCRIPTION
Hi,

I've implemented a `Binder.refresh` method that allows to update all then bound `Field` instances. See issue https://github.com/vaadin/framework/issues/8097 for details.

Thank you,

lorenzo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8098)
<!-- Reviewable:end -->
