### PR TITLE
Correct DateField smoke test: use explicit locale.

### DIFF
--- a/uitest/src/main/java/com/vaadin/tests/smoke/DateFieldSmoke.java
+++ b/uitest/src/main/java/com/vaadin/tests/smoke/DateFieldSmoke.java
@@ -35,12 +35,17 @@ public class DateFieldSmoke extends AbstractTestUIWithLog {
 
     @Override
     protected void setup(VaadinRequest request) {
+        setLocale(Locale.ENGLISH);
+
         InlineDateField inline = new InlineDateField();
         PopupDateField popup = new PopupDateField();
 
         int year = 2016 - 1900;
         popup.setValue(new Date(year, 11, 28));
         inline.setValue(new Date(year, 11, 29));
+
+        popup.setDateFormat("MM/dd/yy");
+        inline.setDateFormat("MM/dd/yy");
 
         popup.addValueChangeListener(event -> log(
                 "Popup value is : " + FORMAT.format(popup.getValue())));


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8107)
<!-- Reviewable:end -->
