### PR TITLE
Fix DataCommunicator - clear KeyMapper when DataProvider is replaced

### DIFF
--- a/server/src/main/java/com/vaadin/data/provider/DataCommunicator.java
+++ b/server/src/main/java/com/vaadin/data/provider/DataCommunicator.java
@@ -460,6 +460,7 @@ public class DataCommunicator<T, F> extends AbstractExtension {
         Objects.requireNonNull(dataProvider, "data provider cannot be null");
         this.dataProvider = dataProvider;
         detachDataProviderListener();
+        getKeyMapper().removeAll();
         /*
          * This introduces behavior which influence on the client-server
          * communication: now the very first response to the client will always

--- a/server/src/main/java/com/vaadin/ui/AbstractListing.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractListing.java
@@ -380,23 +380,18 @@ public abstract class AbstractListing<T> extends AbstractComponent
         setItemIconGenerator(
                 new DeclarativeIconGenerator<>(getItemIconGenerator()));
 
-        List<T> readItems = readItems(design, context);
-        if (!readItems.isEmpty() && this instanceof Listing) {
-            ((Listing<T, ?>) this).setItems(readItems);
-        }
+        readItems(design, context);
     }
 
     /**
-     * Reads the data source items from the {@code design}.
+     * Reads the data source items from the {@code design} and puts them into the data provider.
      *
      * @param design
      *            The element to obtain the state from
      * @param context
      *            The DesignContext instance used for parsing the design
-     *
-     * @return the items read from the design
      */
-    protected abstract List<T> readItems(Element design, DesignContext context);
+    protected abstract void readItems(Element design, DesignContext context);
 
     /**
      * Reads an Item from a design and inserts it into the data source.

--- a/server/src/main/java/com/vaadin/ui/AbstractMultiSelect.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractMultiSelect.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import com.vaadin.data.Listing;
 import org.jsoup.nodes.Element;
 
 import com.vaadin.data.HasValue;
@@ -423,14 +424,16 @@ public abstract class AbstractMultiSelect<T> extends AbstractListing<T>
     }
 
     @Override
-    protected List<T> readItems(Element design, DesignContext context) {
+    protected void readItems(Element design, DesignContext context) {
         Set<T> selected = new HashSet<>();
         List<T> items = design.children().stream()
                 .map(child -> readItem(child, selected, context))
                 .collect(Collectors.toList());
+        if (!items.isEmpty() && this instanceof Listing) {
+            ((Listing<T, ?>) this).setItems(items);
+        }
         deselectAll();
         selected.forEach(this::select);
-        return items;
     }
 
     /**

--- a/server/src/main/java/com/vaadin/ui/AbstractSingleSelect.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractSingleSelect.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.vaadin.data.Listing;
 import org.jsoup.nodes.Element;
 
 import com.vaadin.data.HasValue;
@@ -329,13 +330,15 @@ public abstract class AbstractSingleSelect<T> extends AbstractListing<T>
     }
 
     @Override
-    protected List<T> readItems(Element design, DesignContext context) {
+    protected void readItems(Element design, DesignContext context) {
         Set<T> selected = new HashSet<>();
         List<T> items = design.children().stream()
                 .map(child -> readItem(child, selected, context))
                 .collect(Collectors.toList());
+        if (!items.isEmpty() && this instanceof Listing) {
+            ((Listing<T, ?>) this).setItems(items);
+        }
         selected.forEach(this::setValue);
-        return items;
     }
 
     /**

--- a/server/src/main/java/com/vaadin/ui/CheckBoxGroup.java
+++ b/server/src/main/java/com/vaadin/ui/CheckBoxGroup.java
@@ -167,9 +167,9 @@ public class CheckBoxGroup<T> extends AbstractMultiSelect<T>
     }
 
     @Override
-    protected List<T> readItems(Element design, DesignContext context) {
+    protected void readItems(Element design, DesignContext context) {
         setItemEnabledProvider(new DeclarativeItemEnabledProvider<>());
-        return super.readItems(design, context);
+        super.readItems(design, context);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -612,9 +612,9 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
     }
 
     @Override
-    protected List<T> readItems(Element design, DesignContext context) {
+    protected void readItems(Element design, DesignContext context) {
         setStyleGenerator(new DeclarativeStyleGenerator<>(getStyleGenerator()));
-        return super.readItems(design, context);
+        super.readItems(design, context);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -2898,8 +2898,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
     }
 
     @Override
-    protected List<T> readItems(Element design, DesignContext context) {
-        return Collections.emptyList();
+    protected void readItems(Element design, DesignContext context) {
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/RadioButtonGroup.java
+++ b/server/src/main/java/com/vaadin/ui/RadioButtonGroup.java
@@ -236,9 +236,9 @@ public class RadioButtonGroup<T> extends AbstractSingleSelect<T>
     }
 
     @Override
-    protected List<T> readItems(Element design, DesignContext context) {
+    protected void readItems(Element design, DesignContext context) {
         setItemEnabledProvider(new DeclarativeItemEnabledProvider<>());
-        return super.readItems(design, context);
+        super.readItems(design, context);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/server/src/test/java/com/vaadin/data/provider/ReplaceDataProviderTest.java
+++ b/server/src/test/java/com/vaadin/data/provider/ReplaceDataProviderTest.java
@@ -1,0 +1,106 @@
+package com.vaadin.data.provider;
+
+import com.vaadin.server.SerializablePredicate;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class ReplaceDataProviderTest {
+
+    public static class BeanWithEquals extends Bean{
+
+        BeanWithEquals(int id) {
+            super(id);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            BeanWithEquals that = (BeanWithEquals) o;
+
+            return id == that.id;
+        }
+
+        @Override
+        public int hashCode() {
+            return id;
+        }
+    }
+
+    public static class Bean {
+        protected final int id;
+        private final String fluff;
+
+        Bean(int id) {
+            this.id = id;
+            this.fluff = "Fluff #" + id;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        @SuppressWarnings("unused")
+        public String getFluff() {
+            return fluff;
+        }
+
+    }
+
+    @Test
+    public void testBeanEquals() {
+        doTest(BeanWithEquals::new);
+    }
+
+    @Test
+    public void testBeanSame() {
+        doTest(Bean::new);
+    }
+
+    private <SOME_BEAN> void doTest(IntFunction<SOME_BEAN> beanConstructor) {
+
+        DataCommunicator<SOME_BEAN, SerializablePredicate<SOME_BEAN>> dataCommunicator
+                = new DataCommunicator<>();
+
+        List<SOME_BEAN> beans1 = createCollection(beanConstructor);
+
+        ListDataProvider<SOME_BEAN> dataProvider = new ListDataProvider<>(beans1);
+
+        dataCommunicator.setDataProvider(dataProvider);
+        dataCommunicator.pushData(1, beans1.stream());
+
+        SOME_BEAN bean1_17 = beans1.get(17);
+        String key1_17 = dataCommunicator.getKeyMapper().key(bean1_17);
+
+        assertSame(bean1_17, dataCommunicator.getKeyMapper().get(key1_17));
+
+        List<SOME_BEAN> beans2 = createCollection(beanConstructor);
+
+        dataProvider = new ListDataProvider<>(beans2);
+        dataCommunicator.setDataProvider(dataProvider);
+        dataCommunicator.pushData(1, beans2.stream());
+
+
+        SOME_BEAN bean2_17 = beans2.get(17);
+        String key2_17 = dataCommunicator.getKeyMapper().key(bean2_17);
+
+        assertSame(bean2_17, dataCommunicator.getKeyMapper().get(key2_17));
+        assertNotEquals(key2_17,key1_17);
+        assertNull(dataCommunicator.getKeyMapper().get(key1_17));
+    }
+
+    private <SOME_BEAN> List<SOME_BEAN> createCollection(IntFunction<SOME_BEAN> beanConstructor) {
+        return IntStream.range(1, 100)
+                .mapToObj(beanConstructor)
+                .collect(Collectors.toList());
+    }
+}

--- a/server/src/test/java/com/vaadin/ui/AbstractListingTest.java
+++ b/server/src/test/java/com/vaadin/ui/AbstractListingTest.java
@@ -40,9 +40,8 @@ public class AbstractListingTest {
         }
 
         @Override
-        protected List<String> readItems(Element design,
+        protected void readItems(Element design,
                 DesignContext context) {
-            return null;
         }
 
         @Override

--- a/server/src/test/java/com/vaadin/ui/AbstractSingleSelectTest.java
+++ b/server/src/test/java/com/vaadin/ui/AbstractSingleSelectTest.java
@@ -60,9 +60,8 @@ public class AbstractSingleSelectTest {
         }
 
         @Override
-        protected List<Person> readItems(Element design,
+        protected void readItems(Element design,
                 DesignContext context) {
-            return null;
         }
 
         @Override
@@ -254,9 +253,8 @@ public class AbstractSingleSelectTest {
             }
 
             @Override
-            protected List<String> readItems(Element design,
+            protected void readItems(Element design,
                     DesignContext context) {
-                return null;
             }
         };
 


### PR DESCRIPTION
Fix DataCommunicator - clear KeyMapper when DataProvider is replaced

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8119)
<!-- Reviewable:end -->
