### PR TITLE
Restore all current instance values after running access tasks

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinService.java
@@ -1860,8 +1860,11 @@ public abstract class VaadinService implements Serializable {
         }
 
         FutureAccess pendingAccess;
+
+        // Dump all current instances, not only the ones dumped by setCurrent
         Map<Class<?>, CurrentInstance> oldInstances = CurrentInstance
-                .setCurrent(session);
+                .getInstances();
+        CurrentInstance.setCurrent(session);
         try {
             while ((pendingAccess = session.getPendingAccessQueue()
                     .poll()) != null) {


### PR DESCRIPTION
Fixes vaadin/framework8-issues#593

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8131)
<!-- Reviewable:end -->
