### PR TITLE
Remove uriFragmentChanged from the public API of UriFragmentManager

### DIFF
--- a/server/src/main/java/com/vaadin/navigator/Navigator.java
+++ b/server/src/main/java/com/vaadin/navigator/Navigator.java
@@ -39,8 +39,6 @@ import java.util.List;
 
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
 import com.vaadin.server.Page;
-import com.vaadin.server.Page.UriFragmentChangedEvent;
-import com.vaadin.server.Page.UriFragmentChangedListener;
 import com.vaadin.shared.Registration;
 import com.vaadin.shared.util.SharedUtil;
 import com.vaadin.ui.Component;
@@ -101,10 +99,10 @@ public class Navigator implements Serializable {
      * This class is mostly for internal use by Navigator, and is only public
      * and static to enable testing.
      */
-    public static class UriFragmentManager
-            implements NavigationStateManager, UriFragmentChangedListener {
+    public static class UriFragmentManager implements NavigationStateManager {
         private final Page page;
         private Navigator navigator;
+        private Registration uriFragmentRegistration;
 
         /**
          * Creates a new URIFragmentManager and attach it to listen to URI
@@ -120,9 +118,10 @@ public class Navigator implements Serializable {
         @Override
         public void setNavigator(Navigator navigator) {
             if (this.navigator == null && navigator != null) {
-                page.addUriFragmentChangedListener(this);
+                uriFragmentRegistration = page.addUriFragmentChangedListener(
+                        event -> navigator.navigateTo(getState()));
             } else if (this.navigator != null && navigator == null) {
-                page.removeUriFragmentChangedListener(this);
+                uriFragmentRegistration.remove();
             }
             this.navigator = navigator;
         }
@@ -140,11 +139,6 @@ public class Navigator implements Serializable {
         @Override
         public void setState(String state) {
             setFragment("!" + state);
-        }
-
-        @Override
-        public void uriFragmentChanged(UriFragmentChangedEvent event) {
-            navigator.navigateTo(getState());
         }
 
         /**

--- a/server/src/test/java/com/vaadin/tests/server/navigator/NavigatorTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/navigator/NavigatorTest.java
@@ -32,14 +32,12 @@ import org.junit.Test;
 
 import com.vaadin.navigator.NavigationStateManager;
 import com.vaadin.navigator.Navigator;
-import com.vaadin.navigator.Navigator.UriFragmentManager;
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
 import com.vaadin.navigator.ViewDisplay;
 import com.vaadin.navigator.ViewProvider;
 import com.vaadin.server.Page;
-import com.vaadin.server.Page.UriFragmentChangedEvent;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.shared.Registration;
 import com.vaadin.tests.server.navigator.ClassBasedViewProviderTest.TestView;
@@ -298,11 +296,9 @@ public class NavigatorTest {
                 page.removeUriFragmentCalled());
         Assert.assertNull("Navigator is not null in UI after destroy",
                 ui.getNavigator());
-        UriFragmentManager manager = (UriFragmentManager) navigator
-                .getStateManager();
 
-        manager.uriFragmentChanged(
-                EasyMock.createMock(UriFragmentChangedEvent.class));
+        page.setUriFragment("foobar", true);
+
         Assert.fail(
                 "Expected null pointer exception after call uriFragmentChanged "
                         + "for destroyed navigator");

--- a/server/src/test/java/com/vaadin/tests/server/navigator/UriFragmentManagerTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/navigator/UriFragmentManagerTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import com.vaadin.navigator.Navigator;
 import com.vaadin.navigator.Navigator.UriFragmentManager;
 import com.vaadin.server.Page;
-import com.vaadin.server.Page.UriFragmentChangedEvent;
 import com.vaadin.shared.Registration;
 
 public class UriFragmentManagerTest {
@@ -62,9 +61,7 @@ public class UriFragmentManagerTest {
         navigator.navigateTo("test");
         control.replay();
 
-        UriFragmentChangedEvent event = new UriFragmentChangedEvent(page,
-                "oldtest");
-        manager.uriFragmentChanged(event);
+        page.setUriFragment("oldtest", true);
     }
 
     @Test


### PR DESCRIPTION
It's an implementation detail that UriFragmentManager uses a
UriFragmentChangedListener, so this shouldn't be exposed in its public
API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8164)
<!-- Reviewable:end -->
