### PR TITLE
Fix syntax error in pom.xml

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -18,7 +18,6 @@
         <!-- Don't care about coding style for tests -->
         <sonar.skip>true</sonar.skip>
     </properties>
-    </properties>
 
     <repositories>
         <repository>


### PR DESCRIPTION
For some reason, mvn doesn't care about this, but Eclipse does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8165)
<!-- Reviewable:end -->
