### PR TITLE
Fix legacy documentation for TwinColSelect

### DIFF
--- a/documentation/components/components-twincolselect.asciidoc
+++ b/documentation/components/components-twincolselect.asciidoc
@@ -24,8 +24,7 @@ clicking on the "&lt;" button.
 image::img/twincolselect-basic.png[width=50%, scaledwidth=80%]
 
 [classname]#TwinColSelect# is always in multi-select mode, so its selection
-is always a collection of the item IDs of the selected items, that is, the items
-in the right column.
+is always a collection of the selected items in the right column.
 
 The selection columns can have their own captions, separate from the overall
 component caption, which is managed by the containing layout. You can set the


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8183)
<!-- Reviewable:end -->
