### PR TITLE
ensure tests will run on non-english operating systems

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -225,7 +225,7 @@
                         </manifest>
                     </archive>
                 </configuration>
-                <!-- Package src/test into a jar so that compatbility-server 
+                <!-- Package src/test into a jar so that compatbility-server
                     can use the same test classes, e.g. test beans -->
                 <executions>
                     <execution>
@@ -239,6 +239,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Duser.language=en -Duser.region=US</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
maven surefire creates a new JVM to execute the tests in. This JVM needs to have english language, as there are tests using bean-validation messages and check the output.
e.g. expected:<[size must be between 3 and 16]> but was:<[muss zwischen 3 und 16 liegen]>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8223)
<!-- Reviewable:end -->
