### PR TITLE
Adds more meaningful methods to populate selects and Grid

### DIFF
--- a/server/src/main/java/com/vaadin/ui/AbstractMultiSelect.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractMultiSelect.java
@@ -24,12 +24,14 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jsoup.nodes.Element;
 
 import com.vaadin.data.HasValue;
 import com.vaadin.data.SelectionModel;
 import com.vaadin.data.SelectionModel.Multi;
+import com.vaadin.data.provider.BackEndDataProvider;
 import com.vaadin.data.provider.DataGenerator;
 import com.vaadin.event.selection.MultiSelectionEvent;
 import com.vaadin.event.selection.MultiSelectionListener;
@@ -209,6 +211,55 @@ public abstract class AbstractMultiSelect<T> extends AbstractListing<T>
         updateSelection(copy, new LinkedHashSet<>(getSelectedItems()));
     }
 
+    /**
+     * Sets the options available in this select.
+     * <p>
+     * By default options are displayed using their {@link Object#toString()}.
+     * You can override this using {@link ItemCaptionGenerator} and/or
+     * {@link IconGenerator}.
+     *
+     *
+     * @param options
+     *            the options to be available in this select
+     */
+    public void setOptions(T... options) {
+        setItems(options);
+    }
+
+    /**
+     * Sets the options available in this select.
+     * <p>
+     * By default options are displayed using their {@link Object#toString()}.
+     * You can override this using {@link ItemCaptionGenerator} and/or
+     * {@link IconGenerator}.
+     *
+     * @param options
+     *            the options to be available in this select
+     */
+    public void setOptions(Collection<T> options) {
+        setItems(options);
+    }
+
+    /**
+     * Sets the options available in this select.
+     * <p>
+     * By default options are displayed using their {@link Object#toString()}.
+     * You can override this using {@link ItemCaptionGenerator} and/or
+     * {@link IconGenerator}.
+     * <p>
+     * Note, that this is just a shorthand for {@link #setOptions(Collection)},
+     * that <b>collects objects in the stream to a list</b>. Thus, using this
+     * method, instead of its array and Collection variations, doesn't save any
+     * memory. If you have a large data set to bind, using a lazy data provider
+     * is recommended. See {@link BackEndDataProvider} for more info.
+     *
+     * @param options
+     *            the options to be available in this select
+     */
+    public void setOptions(Stream<T> options) {
+        setItems(options);
+    }
+
     @Override
     public Set<T> getEmptyValue() {
         return Collections.emptySet();
@@ -228,9 +279,9 @@ public abstract class AbstractMultiSelect<T> extends AbstractListing<T>
     @Override
     public Registration addValueChangeListener(
             HasValue.ValueChangeListener<Set<T>> listener) {
-        return addSelectionListener(event -> listener.valueChange(
-                new ValueChangeEvent<>(this, event.getOldValue(),
-                        event.isUserOriginated())));
+        return addSelectionListener(
+                event -> listener.valueChange(new ValueChangeEvent<>(this,
+                        event.getOldValue(), event.isUserOriginated())));
     }
 
     /**

--- a/server/src/main/java/com/vaadin/ui/AbstractSingleSelect.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractSingleSelect.java
@@ -22,11 +22,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jsoup.nodes.Element;
 
 import com.vaadin.data.HasValue;
 import com.vaadin.data.SelectionModel.Single;
+import com.vaadin.data.provider.BackEndDataProvider;
 import com.vaadin.data.provider.DataCommunicator;
 import com.vaadin.event.selection.SingleSelectionEvent;
 import com.vaadin.event.selection.SingleSelectionListener;
@@ -149,12 +151,61 @@ public abstract class AbstractSingleSelect<T> extends AbstractListing<T>
         setSelectedItem(value);
     }
 
+    /**
+     * Sets the options available in this select.
+     * <p>
+     * By default options are displayed using their {@link Object#toString()}.
+     * You can override this using {@link ItemCaptionGenerator} and/or
+     * {@link IconGenerator}.
+     *
+     *
+     * @param options
+     *            the options to be available in this select
+     */
+    public void setOptions(T... options) {
+        setItems(options);
+    }
+
+    /**
+     * Sets the options available in this select.
+     * <p>
+     * By default options are displayed using their {@link Object#toString()}.
+     * You can override this using {@link ItemCaptionGenerator} and/or
+     * {@link IconGenerator}.
+     *
+     * @param options
+     *            the options to be available in this select
+     */
+    public void setOptions(Collection<T> options) {
+        setItems(options);
+    }
+
+    /**
+     * Sets the options available in this select.
+     * <p>
+     * By default options are displayed using their {@link Object#toString()}.
+     * You can override this using {@link ItemCaptionGenerator} and/or
+     * {@link IconGenerator}.
+     * <p>
+     * Note, that this is just a shorthand for {@link #setOptions(Collection)},
+     * that <b>collects objects in the stream to a list</b>. Thus, using this
+     * method, instead of its array and Collection variations, doesn't save any
+     * memory. If you have a large data set to bind, using a lazy data provider
+     * is recommended. See {@link BackEndDataProvider} for more info.
+     *
+     * @param options
+     *            the options to be available in this select
+     */
+    public void setOptions(Stream<T> options) {
+        setItems(options);
+    }
+
     @Override
     public Registration addValueChangeListener(
             HasValue.ValueChangeListener<T> listener) {
-        return addSelectionListener(event -> listener.valueChange(
-                new ValueChangeEvent<>(this, event.getOldValue(),
-                        event.isUserOriginated())));
+        return addSelectionListener(
+                event -> listener.valueChange(new ValueChangeEvent<>(this,
+                        event.getOldValue(), event.isUserOriginated())));
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -44,6 +44,7 @@ import org.jsoup.select.Elements;
 import com.vaadin.data.Binder;
 import com.vaadin.data.HasDataProvider;
 import com.vaadin.data.ValueProvider;
+import com.vaadin.data.provider.BackEndDataProvider;
 import com.vaadin.data.provider.DataCommunicator;
 import com.vaadin.data.provider.DataProvider;
 import com.vaadin.data.provider.Query;
@@ -122,8 +123,8 @@ import elemental.json.JsonValue;
  * @param <T>
  *            the grid bean type
  */
-public class Grid<T> extends AbstractListing<T>
-        implements HasComponents, HasDataProvider<T>, SortNotifier<Grid.Column<T, ?>> {
+public class Grid<T> extends AbstractListing<T> implements HasComponents,
+        HasDataProvider<T>, SortNotifier<Grid.Column<T, ?>> {
 
     @Deprecated
     private static final Method COLUMN_REORDER_METHOD = ReflectTools.findMethod(
@@ -787,8 +788,8 @@ public class Grid<T> extends AbstractListing<T>
         private String userId;
 
         /**
-         * Constructs a new Column configuration with given renderer and
-         * value provider.
+         * Constructs a new Column configuration with given renderer and value
+         * provider.
          *
          * @param valueProvider
          *            the function to get values from items
@@ -2825,6 +2826,66 @@ public class Grid<T> extends AbstractListing<T>
      */
     public List<SortOrder<Column<T, ?>>> getSortOrder() {
         return Collections.unmodifiableList(sortOrder);
+    }
+
+    /**
+     * Sets the objects to be represented as rows in the Grid.
+     * <p>
+     * The given objects will be rendered as rows in the Grid, based on how the
+     * Grid has been configured. In case the Grid is used as a selection
+     * component, the given objects are also the values of the selection.
+     *
+     * @see #addColumn(ValueProvider)
+     *
+     * @param rows
+     *            the objects to be represented as rows in the Grid
+     */
+    public void setRows(T... rows) {
+        setItems(rows);
+    }
+
+    /**
+     * Sets the objects to be represented as rows in the Grid.
+     * <p>
+     * The given objects will be rendered as rows in the Grid, based on how the
+     * Grid has been configured. In case the Grid is used as a selection
+     * component, the given objects are also the values of the selection.
+     * <p>
+     * The provided collection instance may be used as-is. Subsequent
+     * modification of the collection might cause inconsistent data to be shown
+     * in the component unless it is explicitly instructed to read the data
+     * again.
+     *
+     * @see #addColumn(ValueProvider)
+     *
+     * @param rows
+     *            the objects to be represented as rows in the Grid
+     */
+    public void setRows(Collection<T> rows) {
+        setItems(rows);
+    }
+
+    /**
+     * Sets the objects to be represented as rows in the Grid.
+     * <p>
+     * The given objects will be rendered as rows in the Grid, based on how the
+     * Grid has been configured. In case the Grid is used as a selection
+     * component, the given objects are also the values of the selection.
+     * <p>
+     * Note, that this is just a shorthand for {@link #setRows(Collection)},
+     * that <b>collects objects in the stream to a list</b>. Thus, using this
+     * method, instead of its array and Collection variations, doesn't save any
+     * memory. If you have a large data set to bind, using a lazy data provider
+     * is recommended. See {@link BackEndDataProvider} for more info.
+     *
+     *
+     * @see #addColumn(ValueProvider)
+     *
+     * @param rows
+     *            the objects to be represented as rows in the Grid
+     */
+    public void setRows(Stream<T> rows) {
+        setItems(rows);
     }
 
     @Override


### PR DESCRIPTION
This adds more meaningful methods to populate options in selects and rows in Grid. Methods also contain more domain specific documentation for users than there can be in HasItems interface.

See discussion in https://github.com/vaadin/framework8-issues/issues/412

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8270)
<!-- Reviewable:end -->
