### PR TITLE
Unify container wrapping

### DIFF
--- a/server/src/main/java/com/vaadin/data/provider/BackEndDataProvider.java
+++ b/server/src/main/java/com/vaadin/data/provider/BackEndDataProvider.java
@@ -18,8 +18,6 @@ package com.vaadin.data.provider;
 import java.util.Collections;
 import java.util.List;
 
-import com.vaadin.server.SerializableBiFunction;
-
 /**
  * A data provider that lazy loads items from a back end.
  *
@@ -74,43 +72,4 @@ public interface BackEndDataProvider<T, F> extends DataProvider<T, F> {
         return false;
     }
 
-    /**
-     * Wraps this data provider to create a data provider that supports
-     * programmatically setting a filter that will be combined with a filter
-     * provided through the query.
-     *
-     * @see #withConfigurableFilter()
-     *
-     * @param filterCombiner
-     *            a callback for combining and the configured filter with the
-     *            filter from the query to get a filter to pass to the wrapped
-     *            provider. Will only be called if the query contains a filter.
-     *
-     * @return a data provider with a configurable filter, not <code>null</code>
-     */
-    public default <C> ConfigurableFilterDataProvider<T, C, F> withConfigurableFilter(
-            SerializableBiFunction<F, C, F> filterCombiner) {
-        return new ConfigurableFilterDataProviderWrapper<T, C, F>(this) {
-            @Override
-            protected F combineFilters(F configuredFilter, C queryFilter) {
-                return filterCombiner.apply(configuredFilter, queryFilter);
-            }
-        };
-    }
-
-    /**
-     * Wraps this data provider to create a data provider that supports
-     * programmatically setting a filter but no filtering through the query.
-     *
-     * @see #withConfigurableFilter(SerializableBiFunction)
-     *
-     * @return a data provider with a configurable filter, not <code>null</code>
-     */
-    public default ConfigurableFilterDataProvider<T, Void, F> withConfigurableFilter() {
-        return withConfigurableFilter((configuredFilter, queryFilter) -> {
-            assert queryFilter == null : "Filter from Void query must be null";
-
-            return configuredFilter;
-        });
-    }
 }

--- a/server/src/main/java/com/vaadin/data/provider/DataProvider.java
+++ b/server/src/main/java/com/vaadin/data/provider/DataProvider.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import com.vaadin.data.HasDataProvider;
 import com.vaadin.data.HasFilterableDataProvider;
+import com.vaadin.server.SerializableBiFunction;
 import com.vaadin.server.SerializableFunction;
 import com.vaadin.shared.Registration;
 
@@ -105,9 +106,9 @@ public interface DataProvider<T, F> extends Serializable {
     Registration addDataProviderListener(DataProviderListener listener);
 
     /**
-     * Convert the data provider to use a different filter type. It is used for
-     * adapting this data provider to a filter type provided by a Component such
-     * as ComboBox.
+     * Wraps this data provider to create a data provider that uses a different
+     * filter type. This can be used for adapting this data provider to a filter
+     * type provided by a Component such as ComboBox.
      * <p>
      * For example receiving a String from ComboBox and making a Predicate based
      * on it:
@@ -116,7 +117,7 @@ public interface DataProvider<T, F> extends Serializable {
      * DataProvider&lt;Person, Predicate&lt;Person&gt;&gt; dataProvider;
      * // ComboBox uses String as the filter type
      * DataProvider&lt;Person, String&gt; wrappedProvider = dataProvider
-     *         .convertFilter(filterText -&gt; {
+     *         .withConvertedFilter(filterText -&gt; {
      *             Predicate&lt;Person&gt; predicate = person -&gt; person.getName()
      *                     .startsWith(filterText);
      *             return predicate;
@@ -124,18 +125,71 @@ public interface DataProvider<T, F> extends Serializable {
      * comboBox.setDataProvider(wrappedProvider);
      * </pre>
      *
-     * @param mapper
-     *            the mapper from new filter type to old filter type; not null
+     * @param filterConverter
+     *            callback that converts the filter in the query of the wrapped
+     *            data provider into a filter supported by this data provider.
+     *            Will only be called if the query contains a filter. Not
+     *            <code>null</code>
      *
-     * @param <M>
-     *            the filter type to map from; typically provided by a Component
+     * @param <C>
+     *            the filter type that the wrapped data provider accepts;
+     *            typically provided by a Component
      *
-     * @return wrapped data provider
+     * @return wrapped data provider, not <code>null</code>
      */
-    public default <M> DataProvider<T, M> convertFilter(
-            SerializableFunction<M, F> mapper) {
-        Objects.requireNonNull(mapper, "Filter mapper can't be null");
-        return DataProviderWrapper.convert(this, mapper);
+    public default <C> DataProvider<T, C> withConvertedFilter(
+            SerializableFunction<C, F> filterConverter) {
+        Objects.requireNonNull(filterConverter,
+                "Filter converter can't be null");
+        return new DataProviderWrapper<T, C, F>(this) {
+            @Override
+            protected F getFilter(Query<T, C> query) {
+                return query.getFilter().map(filterConverter).orElse(null);
+            }
+        };
+    }
+
+    /**
+     * Wraps this data provider to create a data provider that supports
+     * programmatically setting a filter that will be combined with a filter
+     * provided through the query.
+     *
+     * @see #withConfigurableFilter()
+     * @see ConfigurableFilterDataProvider#setFilter(Object)
+     *
+     * @param filterCombiner
+     *            a callback for combining and the configured filter with the
+     *            filter from the query to get a filter to pass to the wrapped
+     *            provider. Will only be called if the query contains a filter.
+     *            Not <code>null</code>
+     *
+     * @return a data provider with a configurable filter, not <code>null</code>
+     */
+    public default <C> ConfigurableFilterDataProvider<T, C, F> withConfigurableFilter(
+            SerializableBiFunction<F, C, F> filterCombiner) {
+        return new ConfigurableFilterDataProviderWrapper<T, C, F>(this) {
+            @Override
+            protected F combineFilters(F configuredFilter, C queryFilter) {
+                return filterCombiner.apply(configuredFilter, queryFilter);
+            }
+        };
+    }
+
+    /**
+     * Wraps this data provider to create a data provider that supports
+     * programmatically setting a filter but no filtering through the query.
+     *
+     * @see #withConfigurableFilter(SerializableBiFunction)
+     * @see ConfigurableFilterDataProvider#setFilter(Object)
+     *
+     * @return a data provider with a configurable filter, not <code>null</code>
+     */
+    public default ConfigurableFilterDataProvider<T, Void, F> withConfigurableFilter() {
+        return withConfigurableFilter((configuredFilter, queryFilter) -> {
+            assert queryFilter == null : "Filter from Void query must be null";
+
+            return configuredFilter;
+        });
     }
 
     /**

--- a/server/src/main/java/com/vaadin/data/provider/DataProviderWrapper.java
+++ b/server/src/main/java/com/vaadin/data/provider/DataProviderWrapper.java
@@ -18,7 +18,6 @@ package com.vaadin.data.provider;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import com.vaadin.server.SerializableFunction;
 import com.vaadin.shared.Registration;
 
 /**
@@ -90,36 +89,4 @@ public abstract class DataProviderWrapper<T, F, M>
      * @return filter for the modified Query
      */
     protected abstract M getFilter(Query<T, F> query);
-
-    /**
-     * Creates a data provider wrapper with filter type mapping. The mapper
-     * function will be applied to a query filter if it is present.
-     *
-     * @see DataProvider#convertFilter(SerializableFunction)
-     *
-     * @param dataProvider
-     *            the underlying data provider
-     * @param mapper
-     *            the function to map from one filter type to another
-     *
-     * @param <T>
-     *            data provider data type
-     * @param <F>
-     *            wrapper query filter type
-     * @param <M>
-     *            underlying data provider filter type
-     *
-     * @return wrapped data provider with filter conversion
-     */
-    public static <T, F, M> DataProvider<T, F> convert(
-            DataProvider<T, M> dataProvider,
-            SerializableFunction<F, M> mapper) {
-        return new DataProviderWrapper<T, F, M>(dataProvider) {
-
-            @Override
-            protected M getFilter(Query<T, F> query) {
-                return query.getFilter().map(mapper).orElse(null);
-            }
-        };
-    }
 }

--- a/server/src/main/java/com/vaadin/data/provider/ListDataProvider.java
+++ b/server/src/main/java/com/vaadin/data/provider/ListDataProvider.java
@@ -402,7 +402,7 @@ public class ListDataProvider<T>
             SerializableBiPredicate<T, Q> predicate) {
         Objects.requireNonNull(predicate, "Predicate cannot be null");
 
-        return convertFilter(
+        return withConvertedFilter(
                 filterValue -> item -> predicate.test(item, filterValue));
     }
 

--- a/server/src/test/java/com/vaadin/data/provider/DataProviderTestBase.java
+++ b/server/src/test/java/com/vaadin/data/provider/DataProviderTestBase.java
@@ -163,7 +163,7 @@ public abstract class DataProviderTestBase<D extends DataProvider<StrBean, Seria
     @Test
     public void filteringListDataProvider_convertFilter() {
         DataProvider<StrBean, String> strFilterDataProvider = dataProvider
-                .convertFilter(
+                .withConvertedFilter(
                         text -> strBean -> strBean.getValue().contains(text));
         Assert.assertEquals("Only one item should match 'Xyz'", 1,
                 strFilterDataProvider.size(new Query<>("Xyz")));

--- a/server/src/test/java/com/vaadin/tests/server/component/combobox/ComboBoxFilteringTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/combobox/ComboBoxFilteringTest.java
@@ -155,7 +155,7 @@ public class ComboBoxFilteringTest {
 
         // Filters by last name, regardless of the item caption generator
         ListDataProvider<Person> ldp = DataProvider.create(getPersonArray());
-        comboBox.setDataProvider(ldp.convertFilter(
+        comboBox.setDataProvider(ldp.withConvertedFilter(
                 text -> person -> person.getLastName().contains(text)));
 
         checkFiltering("u", "ab", 3, 1);
@@ -170,7 +170,7 @@ public class ComboBoxFilteringTest {
         ldp.setFilter(person -> person.getFirstName().contains("nr"));
 
         // Same as above, but only showing a subset of the persons
-        comboBox.setDataProvider(ldp.convertFilter(
+        comboBox.setDataProvider(ldp.withConvertedFilter(
                 text -> person -> person.getLastName().contains(text)));
 
         checkFiltering("t", "Engel", 2, 1);


### PR DESCRIPTION
* Method names unified to withXyzFilter
* withConfigurableFilter moved to DataProvider
* Remove DataProviderWrapper.convert since it does the same as
DataProvider.withConvertedFilter
* Make javadocs slightly more consistent
* Make type parameters consistent

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8312)
<!-- Reviewable:end -->
