### PR TITLE
Allow distinct configurable filter and wrapped filter types

### DIFF
--- a/documentation/datamodel/datamodel-providers.asciidoc
+++ b/documentation/datamodel/datamodel-providers.asciidoc
@@ -402,7 +402,7 @@ DataProvider<Person, Set<String>> personProvider = getPersonProvider();
 
 ConfigurableFilterDataProvider<Person, String, Set<String>> wrapper =
   personProvider.withConfigurableFilter(
-    (Set<String> configuredFilters, String queryFilter) -> {
+    (String queryFilter, Set<String> configuredFilters) -> {
       Set<String> combinedFilters = new HashSet<>();
       combinedFilters.addAll(configuredFilters);
       combinedFilters.add(queryFilter);
@@ -529,7 +529,8 @@ everythingConfigurable.setFilter(
 // For use with ComboBox and separate department filtering
 ConfigurableDataProvider<Person, String, Department> mixed =
   dataProvider.withConfigurableFilter(
-    (department, filterText) -> {
+    // Can be shortened as PersonFilter::new
+    (filterText, department) -> {
       return new PersonFilter(filterText, department);
     }
   );

--- a/server/src/main/java/com/vaadin/data/provider/DataProvider.java
+++ b/server/src/main/java/com/vaadin/data/provider/DataProvider.java
@@ -160,17 +160,18 @@ public interface DataProvider<T, F> extends Serializable {
      * @param filterCombiner
      *            a callback for combining and the configured filter with the
      *            filter from the query to get a filter to pass to the wrapped
-     *            provider. Will only be called if the query contains a filter.
-     *            Not <code>null</code>
+     *            provider. Either parameter might be <code>null</code>, but the
+     *            callback will not be invoked at all if both would be
+     *            <code>null</code>. Not <code>null</code>.
      *
      * @return a data provider with a configurable filter, not <code>null</code>
      */
-    public default <C> ConfigurableFilterDataProvider<T, C, F> withConfigurableFilter(
-            SerializableBiFunction<F, C, F> filterCombiner) {
-        return new ConfigurableFilterDataProviderWrapper<T, C, F>(this) {
+    public default <Q, C> ConfigurableFilterDataProvider<T, Q, C> withConfigurableFilter(
+            SerializableBiFunction<Q, C, F> filterCombiner) {
+        return new ConfigurableFilterDataProviderWrapper<T, Q, C, F>(this) {
             @Override
-            protected F combineFilters(F configuredFilter, C queryFilter) {
-                return filterCombiner.apply(configuredFilter, queryFilter);
+            protected F combineFilters(Q queryFilter, C configuredFilter) {
+                return filterCombiner.apply(queryFilter, configuredFilter);
             }
         };
     }
@@ -185,7 +186,7 @@ public interface DataProvider<T, F> extends Serializable {
      * @return a data provider with a configurable filter, not <code>null</code>
      */
     public default ConfigurableFilterDataProvider<T, Void, F> withConfigurableFilter() {
-        return withConfigurableFilter((configuredFilter, queryFilter) -> {
+        return withConfigurableFilter((queryFilter, configuredFilter) -> {
             assert queryFilter == null : "Filter from Void query must be null";
 
             return configuredFilter;

--- a/server/src/test/java/com/vaadin/data/provider/ConfigurableFilterDataProviderWrapperTest.java
+++ b/server/src/test/java/com/vaadin/data/provider/ConfigurableFilterDataProviderWrapperTest.java
@@ -29,13 +29,19 @@ public class ConfigurableFilterDataProviderWrapperTest {
             StrBean.generateRandomBeans(100));
     private ConfigurableFilterDataProvider<StrBean, Void, SerializablePredicate<StrBean>> configurableVoid = backEndProvider
             .withConfigurableFilter();
-    private ConfigurableFilterDataProvider<StrBean, SerializablePredicate<StrBean>, SerializablePredicate<StrBean>> configurablePredicate = backEndProvider
-            .withConfigurableFilter((configuredFilter, queryFilter) -> item -> {
-                if (configuredFilter != null && !configuredFilter.test(item)) {
+    private ConfigurableFilterDataProvider<StrBean, String, Integer> configurablePredicate = backEndProvider
+            .withConfigurableFilter((queryFilter, configuredFilter) -> item -> {
+                if (queryFilter != null
+                        && !item.getValue().equals(queryFilter)) {
                     return false;
                 }
 
-                return queryFilter.test(item);
+                if (configuredFilter != null
+                        && item.getId() < configuredFilter.intValue()) {
+                    return false;
+                }
+
+                return true;
             });
 
     @Test
@@ -60,9 +66,9 @@ public class ConfigurableFilterDataProviderWrapperTest {
 
     @Test
     public void predicate_setFilter() {
-        configurablePredicate.setFilter(xyzFilter);
+        configurablePredicate.setFilter(Integer.valueOf(50));
 
-        Assert.assertEquals("Set filter should be used", 1,
+        Assert.assertEquals("Set filter should be used", 49,
                 configurablePredicate.size(new Query<>()));
 
         configurablePredicate.setFilter(null);
@@ -74,7 +80,7 @@ public class ConfigurableFilterDataProviderWrapperTest {
     @Test
     public void predicate_queryFilter() {
         Assert.assertEquals("Query filter should be used", 1,
-                configurablePredicate.size(new Query<>(xyzFilter)));
+                configurablePredicate.size(new Query<>("Xyz")));
 
         Assert.assertEquals("null query filter should return all items", 100,
                 configurablePredicate.size(new Query<>()));
@@ -82,15 +88,15 @@ public class ConfigurableFilterDataProviderWrapperTest {
 
     @Test
     public void predicate_combinedFilters() {
-        configurablePredicate.setFilter(item -> item.getValue().equals("Foo"));
+        configurablePredicate.setFilter(Integer.valueOf(50));
 
         Assert.assertEquals("Both filters should be used", 0,
-                configurablePredicate.size(new Query<>(xyzFilter)));
+                configurablePredicate.size(new Query<>("Xyz")));
 
         configurablePredicate.setFilter(null);
 
         Assert.assertEquals("Only zyz filter should be used", 1,
-                configurablePredicate.size(new Query<>(xyzFilter)));
+                configurablePredicate.size(new Query<>("Xyz")));
     }
 
 }


### PR DESCRIPTION
This enables implementing the use case that was already described
towards the end of datamodel-providers.asciidoc.

Also swaps the order of the callback type parameters to make all three
match the order of the ConfigurableFilterDataProvider type parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8322)
<!-- Reviewable:end -->
