### PR TITLE
Improve Grid extendability

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -4723,7 +4723,7 @@ public class Grid extends AbstractFocusable implements SelectionNotifier,
                     Type type = null;
                     try {
                         type = (getState(false).getClass()
-                                .getDeclaredField(diffStateKey)
+                                .getField(diffStateKey)
                                 .getGenericType());
                     } catch (NoSuchFieldException e) {
                         e.printStackTrace();
@@ -4764,7 +4764,7 @@ public class Grid extends AbstractFocusable implements SelectionNotifier,
                     Type type = null;
                     try {
                         type = (getState(false).getClass()
-                                .getDeclaredField(diffStateKey)
+                                .getField(diffStateKey)
                                 .getGenericType());
                     } catch (NoSuchFieldException e) {
                         e.printStackTrace();


### PR DESCRIPTION
Find GridState field type using getField() instead of getDeclaredField() so that the field could be found in superclass as well.

Tests for Grid column reordering and Grid column visibility should prove if this patch works.

 Fixes #8342

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8343)
<!-- Reviewable:end -->
