### PR TITLE
Make it easy to invoke ServerRpc methods as part of unit tests

### DIFF
--- a/server/src/main/java/com/vaadin/server/ServerRpcManager.java
+++ b/server/src/main/java/com/vaadin/server/ServerRpcManager.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.vaadin.shared.Connector;
 import com.vaadin.shared.communication.ServerRpc;
 
 /**
@@ -164,6 +163,30 @@ public class ServerRpcManager<T extends ServerRpc> implements Serializable {
 
     private static Logger getLogger() {
         return Logger.getLogger(ServerRpcManager.class.getName());
+    }
+
+    /**
+     * Returns an RPC proxy for a given client to server RPC interface for the
+     * given component or extension.
+     *
+     * @param connector
+     *            the connector for which to the RPC proxy
+     * @param rpcInterface
+     *            the RPC interface type
+     *
+     * @return a server RPC handler which can be used to invoke RPC methods
+     * @since 8.0
+     */
+    public static <T extends ServerRpc> T getRpcProxy(ClientConnector connector,
+            final Class<T> rpcInterface) {
+
+        @SuppressWarnings("unchecked")
+        ServerRpcManager<T> rpcManager = (ServerRpcManager<T>) connector
+                .getRpcManager(rpcInterface.getName());
+        if (rpcManager == null) {
+            return null;
+        }
+        return rpcManager.getImplementation();
     }
 
 }

--- a/server/src/test/java/com/vaadin/tests/server/component/combobox/ComboBoxFilteringTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/combobox/ComboBoxFilteringTest.java
@@ -29,12 +29,12 @@ import com.vaadin.data.provider.DataCommunicator;
 import com.vaadin.data.provider.DataProvider;
 import com.vaadin.data.provider.ListDataProvider;
 import com.vaadin.server.ClientMethodInvocation;
+import com.vaadin.server.ServerRpcManager;
 import com.vaadin.shared.ui.combobox.ComboBoxServerRpc;
 import com.vaadin.tests.data.bean.Address;
 import com.vaadin.tests.data.bean.Person;
 import com.vaadin.tests.data.bean.Sex;
 import com.vaadin.ui.ComboBox;
-import com.vaadin.ui.ComponentTest;
 
 /**
  * Test for ComboBox data providers and filtering.
@@ -229,7 +229,7 @@ public class ComboBoxFilteringTest {
         // Discard any currently pending RPC calls
         dataCommunicator.retrievePendingRpcCalls();
 
-        ComponentTest.getRpcProxy(comboBox, ComboBoxServerRpc.class)
+        ServerRpcManager.getRpcProxy(comboBox, ComboBoxServerRpc.class)
                 .setFilter(filter);
         dataCommunicator.beforeClientResponse(true);
 

--- a/server/src/test/java/com/vaadin/ui/AbstractMultiSelectTest.java
+++ b/server/src/test/java/com/vaadin/ui/AbstractMultiSelectTest.java
@@ -41,6 +41,7 @@ import org.mockito.Mockito;
 import com.vaadin.data.HasValue.ValueChangeEvent;
 import com.vaadin.event.selection.MultiSelectionEvent;
 import com.vaadin.event.selection.MultiSelectionListener;
+import com.vaadin.server.ServerRpcManager;
 import com.vaadin.shared.Registration;
 import com.vaadin.shared.data.selection.MultiSelectServerRpc;
 
@@ -69,7 +70,7 @@ public class AbstractMultiSelectTest<S extends AbstractMultiSelect<String>> {
         selectToTest.deselectAll();
         // Intentional deviation from upcoming selection order
         selectToTest.setItems("3", "2", "1", "5", "8", "7", "4", "6");
-        rpc = ComponentTest.getRpcProxy(selectToTest,
+        rpc = ServerRpcManager.getRpcProxy(selectToTest,
                 MultiSelectServerRpc.class);
 
         values = new ArrayList<>();

--- a/server/src/test/java/com/vaadin/ui/CheckBoxTest.java
+++ b/server/src/test/java/com/vaadin/ui/CheckBoxTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.server.ServerRpcManager;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.checkbox.CheckBoxServerRpc;
 import com.vaadin.tests.util.MockUI;
@@ -50,13 +51,13 @@ public class CheckBoxTest {
             userOriginated.set(e.isUserOriginated());
         });
         ComponentTest.syncToClient(cb);
-        ComponentTest.getRpcProxy(cb, CheckBoxServerRpc.class).setChecked(true,
-                new MouseEventDetails());
+        ServerRpcManager.getRpcProxy(cb, CheckBoxServerRpc.class)
+                .setChecked(true, new MouseEventDetails());
         Assert.assertTrue(userOriginated.get());
         userOriginated.set(false);
         ComponentTest.syncToClient(cb);
-        ComponentTest.getRpcProxy(cb, CheckBoxServerRpc.class).setChecked(false,
-                new MouseEventDetails());
+        ServerRpcManager.getRpcProxy(cb, CheckBoxServerRpc.class)
+                .setChecked(false, new MouseEventDetails());
         Assert.assertTrue(userOriginated.get());
     }
 

--- a/server/src/test/java/com/vaadin/ui/ComboBoxTest.java
+++ b/server/src/test/java/com/vaadin/ui/ComboBoxTest.java
@@ -17,6 +17,7 @@ package com.vaadin.ui;
 
 import org.junit.Test;
 
+import com.vaadin.server.ServerRpcManager;
 import com.vaadin.shared.data.selection.SelectionServerRpc;
 import com.vaadin.tests.util.MockUI;
 
@@ -38,7 +39,7 @@ public class ComboBoxTest {
         // Emulate selection of "one"
         String oneKey = comboBox.getDataCommunicator().getKeyMapper()
                 .key("one");
-        ComponentTest.getRpcProxy(comboBox, SelectionServerRpc.class)
+        ServerRpcManager.getRpcProxy(comboBox, SelectionServerRpc.class)
                 .select(oneKey);
 
         ComponentTest.assertEncodedStateProperties(comboBox,

--- a/server/src/test/java/com/vaadin/ui/ComponentTest.java
+++ b/server/src/test/java/com/vaadin/ui/ComponentTest.java
@@ -15,15 +15,12 @@
  */
 package com.vaadin.ui;
 
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
 
 import org.junit.Assert;
 
 import com.vaadin.server.ClientConnector;
-import com.vaadin.server.ServerRpcManager;
-import com.vaadin.shared.communication.ServerRpc;
 
 import elemental.json.JsonObject;
 
@@ -68,29 +65,6 @@ public class ComponentTest {
         component.getUI().getSession().getCommunicationManager()
                 .encodeState(component, component.getState());
 
-    }
-
-    /**
-     * Gets the server rpc handler registered for a component.
-     *
-     * @param component
-     *            the component which listens to the RPC
-     * @param serverRpcClass
-     *            the server RPC class
-     * @return the server RPC handler
-     */
-    public static <T extends ServerRpc> T getRpcProxy(Component component,
-            Class<T> serverRpcClass) {
-        try {
-            ServerRpcManager<?> rpcManager = component
-                    .getRpcManager(serverRpcClass.getName());
-            Method method = ServerRpcManager.class
-                    .getDeclaredMethod("getImplementation");
-            method.setAccessible(true);
-            return serverRpcClass.cast(method.invoke(rpcManager));
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     /**

--- a/server/src/test/java/com/vaadin/ui/RadioButtonGroupTest.java
+++ b/server/src/test/java/com/vaadin/ui/RadioButtonGroupTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import com.vaadin.data.SelectionModel.Multi;
 import com.vaadin.data.provider.DataProvider;
+import com.vaadin.server.ServerRpcManager;
 import com.vaadin.shared.data.selection.SelectionServerRpc;
 
 public class RadioButtonGroupTest {
@@ -65,7 +66,7 @@ public class RadioButtonGroupTest {
             Assert.assertTrue(event.isUserOriginated());
         });
 
-        SelectionServerRpc rpc = ComponentTest.getRpcProxy(radioButtonGroup,
+        SelectionServerRpc rpc = ServerRpcManager.getRpcProxy(radioButtonGroup,
                 SelectionServerRpc.class);
 
         rpc.select(getItemKey("First"));

--- a/server/src/test/java/com/vaadin/ui/RichTextAreaTest.java
+++ b/server/src/test/java/com/vaadin/ui/RichTextAreaTest.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.ui;
 
-import static com.vaadin.ui.ComponentTest.getRpcProxy;
 import static com.vaadin.ui.ComponentTest.isDirty;
 import static com.vaadin.ui.ComponentTest.syncToClient;
 import static com.vaadin.ui.ComponentTest.updateDiffState;
@@ -24,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.server.ClientConnector;
+import com.vaadin.server.ServerRpcManager;
 import com.vaadin.server.ServerRpcManager.RpcInvocationException;
 import com.vaadin.shared.ui.richtextarea.RichTextAreaServerRpc;
 import com.vaadin.tests.util.MockUI;
@@ -59,7 +59,8 @@ public class RichTextAreaTest {
 
         // Client thinks the field says "foo" but it won't be updated because
         // the field is readonly
-        getRpcProxy(rta, RichTextAreaServerRpc.class).setText("foo");
+        ServerRpcManager.getRpcProxy(rta, RichTextAreaServerRpc.class)
+                .setText("foo");
 
         // The real value will be sent back as long as the field is marked as
         // dirty and diffstate contains what the client has
@@ -75,7 +76,8 @@ public class RichTextAreaTest {
         rta.setValue("bar");
 
         updateDiffState(rta);
-        getRpcProxy(rta, RichTextAreaServerRpc.class).setText("foo");
+        ServerRpcManager.getRpcProxy(rta, RichTextAreaServerRpc.class)
+                .setText("foo");
         Assert.assertEquals("foo", getDiffStateString(rta, "value"));
     }
 


### PR DESCRIPTION
Executing RPC methods is useful when testing component interaction with
the server. Not only inside the framework as the ComponentTest class allowed
but also when creating add-ons and applications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8346)
<!-- Reviewable:end -->
