### PR TITLE
Add convenience constructors to new components (#598)

### DIFF
--- a/server/src/main/java/com/vaadin/ui/DateField.java
+++ b/server/src/main/java/com/vaadin/ui/DateField.java
@@ -60,6 +60,58 @@ public class DateField extends AbstractLocalDateField {
     }
 
     /**
+     * Constructs a new {@code DateField} with a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code DateField} is
+     * changed either by the user or programmatically.
+     *
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public DateField(ValueChangeListener valueChangeListener) {
+        super();
+        addValueChangeListener(valueChangeListener);
+    }
+
+    /**
+     * Constructs a new {@code DateField} with the given caption and a value
+     * change listener.
+     * <p>
+     * The listener is called when the value of this {@code DateField} is
+     * changed either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public DateField(String caption,
+            ValueChangeListener valueChangeListener) {
+        this(valueChangeListener);
+        setCaption(caption);
+    }
+
+    /**
+     * Constructs a new {@code DateField} with the given caption, initial
+     * text contents and a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code DateField} is
+     * changed either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param value
+     *            the value for the field, not {@code null}
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public DateField(String caption, LocalDate value,
+            ValueChangeListener valueChangeListener) {
+        this(caption, value);
+        addValueChangeListener(valueChangeListener);
+    }
+
+    /**
      * Returns the current placeholder text.
      *
      * @see #setPlaceholder(String)

--- a/server/src/main/java/com/vaadin/ui/DateField.java
+++ b/server/src/main/java/com/vaadin/ui/DateField.java
@@ -158,7 +158,7 @@ public class DateField extends AbstractLocalDateField {
      * Disabling it causes only the button for date selection to be active, thus
      * preventing the user from entering invalid dates.
      *
-     * See {@link http://dev.vaadin.com/ticket/6790}.
+     * See <a href="http://dev.vaadin.com/ticket/6790">issue 6790</a>.
      *
      * @param state
      *            <b>true</b> to enable text field, <b>false</b> to disable it.

--- a/server/src/main/java/com/vaadin/ui/DateTimeField.java
+++ b/server/src/main/java/com/vaadin/ui/DateTimeField.java
@@ -61,6 +61,58 @@ public class DateTimeField extends AbstractLocalDateTimeField {
     }
 
     /**
+     * Constructs a new {@code DateTimeField} with a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code DateTimeField} is
+     * changed either by the user or programmatically.
+     *
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public DateTimeField(ValueChangeListener valueChangeListener) {
+        super();
+        addValueChangeListener(valueChangeListener);
+    }
+
+    /**
+     * Constructs a new {@code DateTimeField} with the given caption and a value
+     * change listener.
+     * <p>
+     * The listener is called when the value of this {@code DateTimeField} is
+     * changed either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public DateTimeField(String caption,
+            ValueChangeListener valueChangeListener) {
+        this(valueChangeListener);
+        setCaption(caption);
+    }
+
+    /**
+     * Constructs a new {@code DateTimeField} with the given caption, initial
+     * text contents and a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code DateTimeField} is
+     * changed either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param value
+     *            the value for the field, not {@code null}
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public DateTimeField(String caption, LocalDateTime value,
+            ValueChangeListener valueChangeListener) {
+        this(caption, value);
+        addValueChangeListener(valueChangeListener);
+    }
+
+    /**
      * Returns the current placeholder text.
      *
      * @see #setPlaceholder(String)

--- a/server/src/main/java/com/vaadin/ui/DateTimeField.java
+++ b/server/src/main/java/com/vaadin/ui/DateTimeField.java
@@ -159,7 +159,7 @@ public class DateTimeField extends AbstractLocalDateTimeField {
      * Disabling it causes only the button for date selection to be active, thus
      * preventing the user from entering invalid dates.
      *
-     * See {@link http://dev.vaadin.com/ticket/6790}.
+     * See <a href="http://dev.vaadin.com/ticket/6790">issue 6790</a>.
      *
      * @param state
      *            <b>true</b> to enable text field, <b>false</b> to disable it.

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -1839,6 +1839,55 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
         });
     }
 
+    /**
+     * Creates a new {@code Grid} using the given caption
+     * 
+     * @param caption
+     *            the caption of the grid
+     */
+    public Grid(String caption) {
+        this();
+        setCaption(caption);
+    }
+
+    /**
+     * Creates a new {@code Grid} using the given caption and
+     * {@code DataProvider}
+     * 
+     * @param caption
+     *            the caption of the grid
+     * @param dataProvider
+     *            the data provider, not {@code null}
+     */
+    public Grid(String caption, DataProvider<T, ?> dataProvider) {
+        this(caption);
+        setDataProvider(dataProvider);
+    }
+
+    /**
+     * Creates a new {@code Grid} using the given {@code DataProvider}
+     * 
+     * @param dataProvider
+     *            the data provider, not {@code null}
+     */
+    public Grid(DataProvider<T, ?> dataProvider) {
+        this();
+        setDataProvider(dataProvider);
+    }
+
+    /**
+     * Creates a new {@code Grid} using the given caption and collection of
+     * items
+     * 
+     * @param caption
+     *            the caption of the grid
+     * @param items
+     *            the data items to use, not {@çode null}
+     */
+    public Grid(String caption, Collection<T> items) {
+        this(caption, DataProvider.ofCollection(items));
+    }
+
     public <V> void fireColumnVisibilityChangeEvent(Column<T, V> column,
             boolean hidden, boolean userOriginated) {
         fireEvent(new ColumnVisibilityChangeEvent(this, column, hidden,

--- a/server/src/main/java/com/vaadin/ui/InlineDateField.java
+++ b/server/src/main/java/com/vaadin/ui/InlineDateField.java
@@ -59,6 +59,58 @@ public class InlineDateField extends AbstractLocalDateField {
         super(caption);
     }
 
+    /**
+     * Constructs a new {@code InlineDateField} with a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code InlineDateField} is
+     * changed either by the user or programmatically.
+     *
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public InlineDateField(ValueChangeListener valueChangeListener) {
+        super();
+        addValueChangeListener(valueChangeListener);
+    }
+
+    /**
+     * Constructs a new {@code InlineDateField} with the given caption and a value
+     * change listener.
+     * <p>
+     * The listener is called when the value of this {@code InlineDateField} is
+     * changed either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public InlineDateField(String caption,
+            ValueChangeListener valueChangeListener) {
+        this(valueChangeListener);
+        setCaption(caption);
+    }
+
+    /**
+     * Constructs a new {@code InlineDateField} with the given caption, initial
+     * text contents and a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code InlineDateField} is
+     * changed either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param value
+     *            the value for the field, not {@code null}
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public InlineDateField(String caption, LocalDate value,
+            ValueChangeListener valueChangeListener) {
+        this(caption, value);
+        addValueChangeListener(valueChangeListener);
+    }
+
     @Override
     protected InlineDateFieldState getState() {
         return (InlineDateFieldState) super.getState();

--- a/server/src/main/java/com/vaadin/ui/InlineDateTimeField.java
+++ b/server/src/main/java/com/vaadin/ui/InlineDateTimeField.java
@@ -59,6 +59,58 @@ public class InlineDateTimeField extends AbstractLocalDateTimeField {
         super(caption);
     }
 
+    /**
+     * Constructs a new {@code InlineDateTimeField} with a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code InlineDateTimeField} is
+     * changed either by the user or programmatically.
+     *
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public InlineDateTimeField(ValueChangeListener valueChangeListener) {
+        super();
+        addValueChangeListener(valueChangeListener);
+    }
+
+    /**
+     * Constructs a new {@code InlineDateTimeField} with the given caption and a value
+     * change listener.
+     * <p>
+     * The listener is called when the value of this {@code InlineDateTimeField} is
+     * changed either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public InlineDateTimeField(String caption,
+            ValueChangeListener valueChangeListener) {
+        this(valueChangeListener);
+        setCaption(caption);
+    }
+
+    /**
+     * Constructs a new {@code InlineDateTimeField} with the given caption, initial
+     * text contents and a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code InlineDateTimeField} is
+     * changed either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param value
+     *            the value for the field, not {@code null}
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public InlineDateTimeField(String caption, LocalDateTime value,
+            ValueChangeListener valueChangeListener) {
+        this(caption, value);
+        addValueChangeListener(valueChangeListener);
+    }
+
     @Override
     protected InlineDateTimeFieldState getState() {
         return (InlineDateTimeFieldState) super.getState();

--- a/server/src/main/java/com/vaadin/ui/PasswordField.java
+++ b/server/src/main/java/com/vaadin/ui/PasswordField.java
@@ -42,7 +42,7 @@ public class PasswordField extends TextField {
      * @param caption
      *            the caption for the field
      * @param value
-     *            the value for the field
+     *            the value for the field, not {@code null}
      */
     public PasswordField(String caption, String value) {
         setValue(value);
@@ -58,6 +58,57 @@ public class PasswordField extends TextField {
     public PasswordField(String caption) {
         this();
         setCaption(caption);
+    }
+
+    /**
+     * Constructs a new {@code PasswordField} with a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code PasswordField} is
+     * changed either by the user or programmatically.
+     *
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public PasswordField(ValueChangeListener valueChangeListener) {
+        addValueChangeListener(valueChangeListener);
+    }
+
+    /**
+     * Constructs a new {@code PasswordField} with the given caption and a value
+     * change listener.
+     * <p>
+     * The listener is called when the value of this {@code PasswordField} is
+     * changed either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public PasswordField(String caption,
+            ValueChangeListener valueChangeListener) {
+        this(valueChangeListener);
+        setCaption(caption);
+    }
+
+    /**
+     * Constructs a new {@code PasswordField} with the given caption, initial
+     * text contents and a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code PasswordField} is
+     * changed either by the user or programmatically.
+     * 
+     * @param caption
+     *            the caption for the field
+     * @param value
+     *            the value for the field, not {@code null}
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public PasswordField(String caption, String value,
+            ValueChangeListener valueChangeListener) {
+        this(caption, value);
+        addValueChangeListener(valueChangeListener);
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/RichTextArea.java
+++ b/server/src/main/java/com/vaadin/ui/RichTextArea.java
@@ -18,6 +18,7 @@ package com.vaadin.ui;
 
 import java.util.Objects;
 
+import elemental.json.Json;
 import org.jsoup.nodes.Element;
 
 import com.vaadin.shared.ui.ValueChangeMode;
@@ -25,8 +26,6 @@ import com.vaadin.shared.ui.richtextarea.RichTextAreaClientRpc;
 import com.vaadin.shared.ui.richtextarea.RichTextAreaServerRpc;
 import com.vaadin.shared.ui.richtextarea.RichTextAreaState;
 import com.vaadin.ui.declarative.DesignContext;
-
-import elemental.json.Json;
 
 /**
  * A simple RichTextArea to edit HTML format text.
@@ -74,11 +73,62 @@ public class RichTextArea extends AbstractField<String>
      * @param caption
      *            the caption for the editor.
      * @param value
-     *            the initial text content of the editor.
+     *            the initial text content of the editor, not {@code null}
      */
     public RichTextArea(String caption, String value) {
         this(caption);
         setValue(value);
+    }
+
+    /**
+     * Constructs a new {@code RichTextArea} with a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code TextField} is
+     * changed either by the user or programmatically.
+     *
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public RichTextArea(ValueChangeListener valueChangeListener) {
+        addValueChangeListener(valueChangeListener);
+    }
+
+    /**
+     * Constructs a new {@code RichTextArea} with the given caption and a value
+     * change listener.
+     * <p>
+     * The listener is called when the value of this {@code TextField} is
+     * changed either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public RichTextArea(String caption,
+            ValueChangeListener valueChangeListener) {
+        this(valueChangeListener);
+        setCaption(caption);
+    }
+
+    /**
+     * Constructs a new {@code RichTextArea} with the given caption, initial
+     * text contents and a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code RichTextArea} is
+     * changed either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param value
+     *            the value for the field, not {@code null}
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public RichTextArea(String caption, String value,
+            ValueChangeListener valueChangeListener) {
+        this(caption, value);
+        addValueChangeListener(valueChangeListener);
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/TextArea.java
+++ b/server/src/main/java/com/vaadin/ui/TextArea.java
@@ -63,12 +63,61 @@ public class TextArea extends AbstractTextField {
      * @param caption
      *            the caption for the field
      * @param value
-     *            the value for the field
+     *            the value for the field, not {@code null}
      */
     public TextArea(String caption, String value) {
         this(caption);
         setValue(value);
+    }
 
+    /**
+     * Constructs a new {@code TextArea} with a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code TextArea} is changed
+     * either by the user or programmatically.
+     *
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public TextArea(ValueChangeListener valueChangeListener) {
+        addValueChangeListener(valueChangeListener);
+    }
+
+    /**
+     * Constructs a new {@code TextArea} with the given caption and a value
+     * change listener.
+     * <p>
+     * The listener is called when the value of this {@code TextArea} is changed
+     * either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public TextArea(String caption, ValueChangeListener valueChangeListener) {
+        this(valueChangeListener);
+        setCaption(caption);
+    }
+
+    /**
+     * Constructs a new {@code TextArea} with the given caption, initial text
+     * contents and a value change listener.
+     * <p>
+     * The listener is called when the value of this {@code TextArea} is changed
+     * either by the user or programmatically.
+     *
+     * @param caption
+     *            the caption for the field
+     * @param value
+     *            the value for the field, not {@code null}
+     * @param valueChangeListener
+     *            the value change listener, not {@code null}
+     */
+    public TextArea(String caption, String value,
+            ValueChangeListener valueChangeListener) {
+        this(caption, value);
+        addValueChangeListener(valueChangeListener);
     }
 
     @Override

--- a/server/src/test/java/com/vaadin/ui/DateFieldConstructorTest.java
+++ b/server/src/test/java/com/vaadin/ui/DateFieldConstructorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.ui;
+
+import java.time.LocalDate;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.data.HasValue;
+import com.vaadin.shared.ui.datefield.DateResolution;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class DateFieldConstructorTest {
+
+    @Test
+    public void initiallyEmpty() {
+        DateField dateField = new DateField();
+        Assert.assertTrue(dateField.isEmpty());
+        Assert.assertEquals(DateResolution.DAY, dateField.getResolution());
+    }
+
+    @Test
+    public void testValueConstructor_emptyAfterClear() {
+        DateField dateField = new DateField(null, LocalDate.now());
+        Assert.assertEquals(DateResolution.DAY, dateField.getResolution());
+        Assert.assertFalse(dateField.isEmpty());
+
+        dateField.clear();
+        Assert.assertTrue(dateField.isEmpty());
+    }
+
+    @Test
+    public void testValueChangeListener_eventOnValueChange() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        DateField dateField = new DateField(valueChangeListener);
+        Assert.assertEquals(DateResolution.DAY, dateField.getResolution());
+
+        dateField.setValue(LocalDate.now());
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+
+    @Test
+    public void testCaptionValueListener() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        DateField dateField = new DateField("Caption", LocalDate.now(),
+                valueChangeListener);
+        Assert.assertEquals(DateResolution.DAY, dateField.getResolution());
+
+        verify(valueChangeListener, never())
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+        dateField.setValue(LocalDate.now().plusDays(1));
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+}

--- a/server/src/test/java/com/vaadin/ui/DateTimeFieldConstructorTest.java
+++ b/server/src/test/java/com/vaadin/ui/DateTimeFieldConstructorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.ui;
+
+import java.time.LocalDateTime;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.data.HasValue;
+import com.vaadin.shared.ui.datefield.DateTimeResolution;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class DateTimeFieldConstructorTest {
+
+    @Test
+    public void initiallyEmpty() {
+        DateTimeField dateTimeField = new DateTimeField();
+        Assert.assertTrue(dateTimeField.isEmpty());
+        Assert.assertEquals(DateTimeResolution.MINUTE, dateTimeField.getResolution());
+    }
+
+    @Test
+    public void testValueConstructor_emptyAfterClear() {
+        DateTimeField dateTimeField = new DateTimeField(null, LocalDateTime.now());
+        Assert.assertFalse(dateTimeField.isEmpty());
+        Assert.assertEquals(DateTimeResolution.MINUTE, dateTimeField.getResolution());
+
+        dateTimeField.clear();
+        Assert.assertTrue(dateTimeField.isEmpty());
+    }
+
+    @Test
+    public void testValueChangeListener_eventOnValueChange() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        DateTimeField dateTimeField = new DateTimeField(valueChangeListener);
+        Assert.assertEquals(DateTimeResolution.MINUTE, dateTimeField.getResolution());
+
+        dateTimeField.setValue(LocalDateTime.now());
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+
+    @Test
+    public void testCaptionValueListener() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        DateTimeField dateTimeField = new DateTimeField("Caption",
+                LocalDateTime.now(),
+                valueChangeListener);
+        Assert.assertEquals(DateTimeResolution.MINUTE, dateTimeField.getResolution());
+
+        verify(valueChangeListener, never())
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+        dateTimeField.setValue(LocalDateTime.now().plusDays(1));
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+}

--- a/server/src/test/java/com/vaadin/ui/InlineDateFieldConstructorTest.java
+++ b/server/src/test/java/com/vaadin/ui/InlineDateFieldConstructorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.ui;
+
+import java.time.LocalDate;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.data.HasValue;
+import com.vaadin.shared.ui.datefield.DateResolution;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class InlineDateFieldConstructorTest {
+
+    @Test
+    public void initiallyEmpty() {
+        InlineDateField dateField = new InlineDateField();
+        Assert.assertTrue(dateField.isEmpty());
+        Assert.assertEquals(DateResolution.DAY, dateField.getResolution());
+    }
+
+    @Test
+    public void testValueConstructor_emptyAfterClear() {
+        InlineDateField dateField = new InlineDateField(null, LocalDate.now());
+        Assert.assertEquals(DateResolution.DAY, dateField.getResolution());
+        Assert.assertFalse(dateField.isEmpty());
+
+        dateField.clear();
+        Assert.assertTrue(dateField.isEmpty());
+    }
+
+    @Test
+    public void testValueChangeListener_eventOnValueChange() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        InlineDateField dateField = new InlineDateField(valueChangeListener);
+        Assert.assertEquals(DateResolution.DAY, dateField.getResolution());
+
+        dateField.setValue(LocalDate.now());
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+
+    @Test
+    public void testCaptionValueListener() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        InlineDateField dateField = new InlineDateField("Caption",
+                LocalDate.now(), valueChangeListener);
+        Assert.assertEquals(DateResolution.DAY, dateField.getResolution());
+
+        verify(valueChangeListener, never())
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+        dateField.setValue(LocalDate.now().plusDays(1));
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+}

--- a/server/src/test/java/com/vaadin/ui/InlineDateTimeFieldConstructorTest.java
+++ b/server/src/test/java/com/vaadin/ui/InlineDateTimeFieldConstructorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.ui;
+
+import java.time.LocalDateTime;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.data.HasValue;
+import com.vaadin.shared.ui.datefield.DateTimeResolution;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class InlineDateTimeFieldConstructorTest {
+
+    @Test
+    public void initiallyEmpty() {
+        InlineDateTimeField dateTimeField = new InlineDateTimeField();
+        Assert.assertTrue(dateTimeField.isEmpty());
+        Assert.assertEquals(DateTimeResolution.MINUTE,
+                dateTimeField.getResolution());
+    }
+
+    @Test
+    public void testValueConstructor_emptyAfterClear() {
+        InlineDateTimeField dateTimeField = new InlineDateTimeField(null,
+                LocalDateTime.now());
+        Assert.assertFalse(dateTimeField.isEmpty());
+        Assert.assertEquals(DateTimeResolution.MINUTE,
+                dateTimeField.getResolution());
+
+        dateTimeField.clear();
+        Assert.assertTrue(dateTimeField.isEmpty());
+    }
+
+    @Test
+    public void testValueChangeListener_eventOnValueChange() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        InlineDateTimeField dateTimeField = new InlineDateTimeField(
+                valueChangeListener);
+        Assert.assertEquals(DateTimeResolution.MINUTE,
+                dateTimeField.getResolution());
+
+        dateTimeField.setValue(LocalDateTime.now());
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+
+    @Test
+    public void testCaptionValueListener() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        InlineDateTimeField dateTimeField = new InlineDateTimeField("Caption",
+                LocalDateTime.now(), valueChangeListener);
+        Assert.assertEquals(DateTimeResolution.MINUTE,
+                dateTimeField.getResolution());
+
+        verify(valueChangeListener, never())
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+        dateTimeField.setValue(LocalDateTime.now().plusDays(1));
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+}

--- a/server/src/test/java/com/vaadin/ui/PasswordFieldConstructorTest.java
+++ b/server/src/test/java/com/vaadin/ui/PasswordFieldConstructorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.data.HasValue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class PasswordFieldConstructorTest {
+
+    @Test
+    public void initiallyEmpty() {
+        PasswordField passwordField = new PasswordField();
+        Assert.assertTrue(passwordField.isEmpty());
+    }
+
+    @Test
+    public void testValueConstructor_emptyAfterClear() {
+        PasswordField passwordField = new PasswordField(null, "foobar");
+        Assert.assertFalse(passwordField.isEmpty());
+
+        passwordField.clear();
+        Assert.assertTrue(passwordField.isEmpty());
+    }
+
+    @Test
+    public void testValueChangeListener_eventOnValueChange() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        PasswordField passwordField = new PasswordField(valueChangeListener);
+
+        passwordField.setValue("value change");
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+
+    @Test
+    public void testCaptionValueListener() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        PasswordField passwordField = new PasswordField("Caption", "Initial value",
+                valueChangeListener);
+
+        verify(valueChangeListener, never())
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+        passwordField.setValue("value change");
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+}

--- a/server/src/test/java/com/vaadin/ui/RichTextAreaConstructorTest.java
+++ b/server/src/test/java/com/vaadin/ui/RichTextAreaConstructorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.data.HasValue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class RichTextAreaConstructorTest {
+
+    @Test
+    public void initiallyEmpty() {
+        RichTextArea richTextArea = new RichTextArea();
+        Assert.assertTrue(richTextArea.isEmpty());
+    }
+
+    @Test
+    public void testValueConstructor_emptyAfterClear() {
+        RichTextArea richTextArea = new RichTextArea(null, "foobar");
+        Assert.assertFalse(richTextArea.isEmpty());
+
+        richTextArea.clear();
+        Assert.assertTrue(richTextArea.isEmpty());
+    }
+
+    @Test
+    public void testValueChangeListener_eventOnValueChange() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        RichTextArea richTextArea = new RichTextArea(valueChangeListener);
+
+        richTextArea.setValue("value change");
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+
+    @Test
+    public void testCaptionValueListener() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        RichTextArea richTextArea = new RichTextArea("Caption", "Initial value",
+                valueChangeListener);
+
+        verify(valueChangeListener, never())
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+        richTextArea.setValue("value change");
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+}

--- a/server/src/test/java/com/vaadin/ui/TextAreaConstructorTest.java
+++ b/server/src/test/java/com/vaadin/ui/TextAreaConstructorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.data.HasValue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class TextAreaConstructorTest {
+
+    @Test
+    public void initiallyEmpty() {
+        TextArea textArea = new TextArea();
+        Assert.assertTrue(textArea.isEmpty());
+    }
+
+    @Test
+    public void testValueConstructor_emptyAfterClear() {
+        TextArea textArea = new TextArea(null, "foobar");
+        Assert.assertFalse(textArea.isEmpty());
+
+        textArea.clear();
+        Assert.assertTrue(textArea.isEmpty());
+    }
+
+    @Test
+    public void testValueChangeListener_eventOnValueChange() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        TextArea textArea = new TextArea(valueChangeListener);
+
+        textArea.setValue("value change");
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+
+    @Test
+    public void testCaptionValueListener() {
+        HasValue.ValueChangeListener valueChangeListener = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        TextArea textArea = new TextArea("Caption", "Initial value",
+                valueChangeListener);
+
+        verify(valueChangeListener, never())
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+        textArea.setValue("value change");
+
+        verify(valueChangeListener)
+                .valueChange(Mockito.any(HasValue.ValueChangeEvent.class));
+
+    }
+}


### PR DESCRIPTION
Add convenience constructors similar to the ones in Vaadin 7 to 'all' 
reimplemented components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8351)
<!-- Reviewable:end -->
