### PR TITLE
Fix userOriginated state for CheckBox ValueChangeEvent from the user

### DIFF
--- a/server/src/main/java/com/vaadin/ui/CheckBox.java
+++ b/server/src/main/java/com/vaadin/ui/CheckBox.java
@@ -60,7 +60,7 @@ public class CheckBox extends AbstractField<Boolean>
 
         if (!newValue.equals(oldValue)) {
             // The event is only sent if the switch state is changed
-            setValue(newValue);
+            setValue(newValue, true);
         }
     };
 
@@ -116,6 +116,25 @@ public class CheckBox extends AbstractField<Boolean>
     public void setValue(Boolean value) {
         Objects.requireNonNull(value, "CheckBox value must not be null");
         super.setValue(value);
+    }
+
+    /**
+     * Sets the value of this CheckBox. If the new value is not equal to
+     * {@code getValue()}, fires a {@link ValueChangeEvent}. Throws
+     * {@code NullPointerException} if the value is null.
+     *
+     * @param value
+     *            the new value, not {@code null}
+     * @param userOriginated
+     *            {@code true} if this event originates from the client,
+     *            {@code false} otherwise.
+     * @throws NullPointerException
+     *             if {@code value} is {@code null}
+     */
+    @Override
+    protected boolean setValue(Boolean value, boolean userOriginated) {
+        Objects.requireNonNull(value, "CheckBox value must not be null");
+        return super.setValue(value, userOriginated);
     }
 
     @Override

--- a/server/src/test/java/com/vaadin/ui/CheckBoxTest.java
+++ b/server/src/test/java/com/vaadin/ui/CheckBoxTest.java
@@ -15,8 +15,14 @@
  */
 package com.vaadin.ui;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.vaadin.shared.MouseEventDetails;
+import com.vaadin.shared.ui.checkbox.CheckBoxServerRpc;
+import com.vaadin.tests.util.MockUI;
 
 public class CheckBoxTest {
     @Test
@@ -32,6 +38,42 @@ public class CheckBoxTest {
         Assert.assertTrue(cb.getValue());
         cb.setValue(false);
         Assert.assertFalse(cb.getValue());
+    }
+
+    @Test
+    public void setValueChangeFromClientIsUserOriginated() {
+        UI ui = new MockUI();
+        CheckBox cb = new CheckBox();
+        ui.setContent(cb);
+        AtomicBoolean userOriginated = new AtomicBoolean(false);
+        cb.addValueChangeListener(e -> {
+            userOriginated.set(e.isUserOriginated());
+        });
+        ComponentTest.syncToClient(cb);
+        ComponentTest.getRpcProxy(cb, CheckBoxServerRpc.class).setChecked(true,
+                new MouseEventDetails());
+        Assert.assertTrue(userOriginated.get());
+        userOriginated.set(false);
+        ComponentTest.syncToClient(cb);
+        ComponentTest.getRpcProxy(cb, CheckBoxServerRpc.class).setChecked(false,
+                new MouseEventDetails());
+        Assert.assertTrue(userOriginated.get());
+    }
+
+    @Test
+    public void setValueChangeFromServerIsNotUserOriginated() {
+        UI ui = new MockUI();
+        CheckBox cb = new CheckBox();
+        ui.setContent(cb);
+        AtomicBoolean userOriginated = new AtomicBoolean(true);
+        cb.addValueChangeListener(e -> {
+            userOriginated.set(e.isUserOriginated());
+        });
+        cb.setValue(true);
+        Assert.assertFalse(userOriginated.get());
+        userOriginated.set(true);
+        cb.setValue(false);
+        Assert.assertFalse(userOriginated.get());
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8383)
<!-- Reviewable:end -->
