### PR TITLE
Patameterize the ValueChangeListeners for rebuilt fields (#8369)

### DIFF
--- a/server/src/main/java/com/vaadin/ui/DateField.java
+++ b/server/src/main/java/com/vaadin/ui/DateField.java
@@ -68,7 +68,7 @@ public class DateField extends AbstractLocalDateField {
      * @param valueChangeListener
      *            the value change listener, not {@code null}
      */
-    public DateField(ValueChangeListener valueChangeListener) {
+    public DateField(ValueChangeListener<LocalDate> valueChangeListener) {
         super();
         addValueChangeListener(valueChangeListener);
     }
@@ -86,7 +86,7 @@ public class DateField extends AbstractLocalDateField {
      *            the value change listener, not {@code null}
      */
     public DateField(String caption,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<LocalDate> valueChangeListener) {
         this(valueChangeListener);
         setCaption(caption);
     }
@@ -106,7 +106,7 @@ public class DateField extends AbstractLocalDateField {
      *            the value change listener, not {@code null}
      */
     public DateField(String caption, LocalDate value,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<LocalDate> valueChangeListener) {
         this(caption, value);
         addValueChangeListener(valueChangeListener);
     }

--- a/server/src/main/java/com/vaadin/ui/DateTimeField.java
+++ b/server/src/main/java/com/vaadin/ui/DateTimeField.java
@@ -69,7 +69,8 @@ public class DateTimeField extends AbstractLocalDateTimeField {
      * @param valueChangeListener
      *            the value change listener, not {@code null}
      */
-    public DateTimeField(ValueChangeListener valueChangeListener) {
+    public DateTimeField(
+            ValueChangeListener<LocalDateTime> valueChangeListener) {
         super();
         addValueChangeListener(valueChangeListener);
     }
@@ -87,7 +88,7 @@ public class DateTimeField extends AbstractLocalDateTimeField {
      *            the value change listener, not {@code null}
      */
     public DateTimeField(String caption,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<LocalDateTime> valueChangeListener) {
         this(valueChangeListener);
         setCaption(caption);
     }
@@ -107,7 +108,7 @@ public class DateTimeField extends AbstractLocalDateTimeField {
      *            the value change listener, not {@code null}
      */
     public DateTimeField(String caption, LocalDateTime value,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<LocalDateTime> valueChangeListener) {
         this(caption, value);
         addValueChangeListener(valueChangeListener);
     }

--- a/server/src/main/java/com/vaadin/ui/InlineDateField.java
+++ b/server/src/main/java/com/vaadin/ui/InlineDateField.java
@@ -68,14 +68,14 @@ public class InlineDateField extends AbstractLocalDateField {
      * @param valueChangeListener
      *            the value change listener, not {@code null}
      */
-    public InlineDateField(ValueChangeListener valueChangeListener) {
+    public InlineDateField(ValueChangeListener<LocalDate> valueChangeListener) {
         super();
         addValueChangeListener(valueChangeListener);
     }
 
     /**
-     * Constructs a new {@code InlineDateField} with the given caption and a value
-     * change listener.
+     * Constructs a new {@code InlineDateField} with the given caption and a
+     * value change listener.
      * <p>
      * The listener is called when the value of this {@code InlineDateField} is
      * changed either by the user or programmatically.
@@ -86,7 +86,7 @@ public class InlineDateField extends AbstractLocalDateField {
      *            the value change listener, not {@code null}
      */
     public InlineDateField(String caption,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<LocalDate> valueChangeListener) {
         this(valueChangeListener);
         setCaption(caption);
     }
@@ -106,7 +106,7 @@ public class InlineDateField extends AbstractLocalDateField {
      *            the value change listener, not {@code null}
      */
     public InlineDateField(String caption, LocalDate value,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<LocalDate> valueChangeListener) {
         this(caption, value);
         addValueChangeListener(valueChangeListener);
     }

--- a/server/src/main/java/com/vaadin/ui/InlineDateTimeField.java
+++ b/server/src/main/java/com/vaadin/ui/InlineDateTimeField.java
@@ -60,25 +60,27 @@ public class InlineDateTimeField extends AbstractLocalDateTimeField {
     }
 
     /**
-     * Constructs a new {@code InlineDateTimeField} with a value change listener.
+     * Constructs a new {@code InlineDateTimeField} with a value change
+     * listener.
      * <p>
-     * The listener is called when the value of this {@code InlineDateTimeField} is
-     * changed either by the user or programmatically.
+     * The listener is called when the value of this {@code InlineDateTimeField}
+     * is changed either by the user or programmatically.
      *
      * @param valueChangeListener
      *            the value change listener, not {@code null}
      */
-    public InlineDateTimeField(ValueChangeListener valueChangeListener) {
+    public InlineDateTimeField(
+            ValueChangeListener<LocalDateTime> valueChangeListener) {
         super();
         addValueChangeListener(valueChangeListener);
     }
 
     /**
-     * Constructs a new {@code InlineDateTimeField} with the given caption and a value
-     * change listener.
+     * Constructs a new {@code InlineDateTimeField} with the given caption and a
+     * value change listener.
      * <p>
-     * The listener is called when the value of this {@code InlineDateTimeField} is
-     * changed either by the user or programmatically.
+     * The listener is called when the value of this {@code InlineDateTimeField}
+     * is changed either by the user or programmatically.
      *
      * @param caption
      *            the caption for the field
@@ -86,17 +88,17 @@ public class InlineDateTimeField extends AbstractLocalDateTimeField {
      *            the value change listener, not {@code null}
      */
     public InlineDateTimeField(String caption,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<LocalDateTime> valueChangeListener) {
         this(valueChangeListener);
         setCaption(caption);
     }
 
     /**
-     * Constructs a new {@code InlineDateTimeField} with the given caption, initial
-     * text contents and a value change listener.
+     * Constructs a new {@code InlineDateTimeField} with the given caption,
+     * initial text contents and a value change listener.
      * <p>
-     * The listener is called when the value of this {@code InlineDateTimeField} is
-     * changed either by the user or programmatically.
+     * The listener is called when the value of this {@code InlineDateTimeField}
+     * is changed either by the user or programmatically.
      *
      * @param caption
      *            the caption for the field
@@ -106,7 +108,7 @@ public class InlineDateTimeField extends AbstractLocalDateTimeField {
      *            the value change listener, not {@code null}
      */
     public InlineDateTimeField(String caption, LocalDateTime value,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<LocalDateTime> valueChangeListener) {
         this(caption, value);
         addValueChangeListener(valueChangeListener);
     }

--- a/server/src/main/java/com/vaadin/ui/PasswordField.java
+++ b/server/src/main/java/com/vaadin/ui/PasswordField.java
@@ -69,8 +69,8 @@ public class PasswordField extends TextField {
      * @param valueChangeListener
      *            the value change listener, not {@code null}
      */
-    public PasswordField(ValueChangeListener valueChangeListener) {
-        addValueChangeListener(valueChangeListener);
+    public PasswordField(ValueChangeListener<String> valueChangeListener) {
+        super(valueChangeListener);
     }
 
     /**
@@ -86,9 +86,8 @@ public class PasswordField extends TextField {
      *            the value change listener, not {@code null}
      */
     public PasswordField(String caption,
-            ValueChangeListener valueChangeListener) {
-        this(valueChangeListener);
-        setCaption(caption);
+            ValueChangeListener<String> valueChangeListener) {
+        super(caption, valueChangeListener);
     }
 
     /**
@@ -106,9 +105,8 @@ public class PasswordField extends TextField {
      *            the value change listener, not {@code null}
      */
     public PasswordField(String caption, String value,
-            ValueChangeListener valueChangeListener) {
-        this(caption, value);
-        addValueChangeListener(valueChangeListener);
+            ValueChangeListener<String> valueChangeListener) {
+        super(caption, value, valueChangeListener);
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/RichTextArea.java
+++ b/server/src/main/java/com/vaadin/ui/RichTextArea.java
@@ -89,7 +89,7 @@ public class RichTextArea extends AbstractField<String>
      * @param valueChangeListener
      *            the value change listener, not {@code null}
      */
-    public RichTextArea(ValueChangeListener valueChangeListener) {
+    public RichTextArea(ValueChangeListener<String> valueChangeListener) {
         addValueChangeListener(valueChangeListener);
     }
 
@@ -106,7 +106,7 @@ public class RichTextArea extends AbstractField<String>
      *            the value change listener, not {@code null}
      */
     public RichTextArea(String caption,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<String> valueChangeListener) {
         this(valueChangeListener);
         setCaption(caption);
     }
@@ -126,7 +126,7 @@ public class RichTextArea extends AbstractField<String>
      *            the value change listener, not {@code null}
      */
     public RichTextArea(String caption, String value,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<String> valueChangeListener) {
         this(caption, value);
         addValueChangeListener(valueChangeListener);
     }

--- a/server/src/main/java/com/vaadin/ui/TextArea.java
+++ b/server/src/main/java/com/vaadin/ui/TextArea.java
@@ -79,7 +79,7 @@ public class TextArea extends AbstractTextField {
      * @param valueChangeListener
      *            the value change listener, not {@code null}
      */
-    public TextArea(ValueChangeListener valueChangeListener) {
+    public TextArea(ValueChangeListener<String> valueChangeListener) {
         addValueChangeListener(valueChangeListener);
     }
 
@@ -95,7 +95,8 @@ public class TextArea extends AbstractTextField {
      * @param valueChangeListener
      *            the value change listener, not {@code null}
      */
-    public TextArea(String caption, ValueChangeListener valueChangeListener) {
+    public TextArea(String caption,
+            ValueChangeListener<String> valueChangeListener) {
         this(valueChangeListener);
         setCaption(caption);
     }
@@ -115,7 +116,7 @@ public class TextArea extends AbstractTextField {
      *            the value change listener, not {@code null}
      */
     public TextArea(String caption, String value,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<String> valueChangeListener) {
         this(caption, value);
         addValueChangeListener(valueChangeListener);
     }

--- a/server/src/main/java/com/vaadin/ui/TextField.java
+++ b/server/src/main/java/com/vaadin/ui/TextField.java
@@ -72,7 +72,7 @@ public class TextField extends AbstractTextField {
      * @param valueChangeListener
      *            the value change listener, not {@code null}
      */
-    public TextField(ValueChangeListener valueChangeListener) {
+    public TextField(ValueChangeListener<String> valueChangeListener) {
         addValueChangeListener(valueChangeListener);
     }
 
@@ -88,7 +88,8 @@ public class TextField extends AbstractTextField {
      * @param valueChangeListener
      *            the value change listener, not {@code null}
      */
-    public TextField(String caption, ValueChangeListener valueChangeListener) {
+    public TextField(String caption,
+            ValueChangeListener<String> valueChangeListener) {
         this(valueChangeListener);
         setCaption(caption);
     }
@@ -108,7 +109,7 @@ public class TextField extends AbstractTextField {
      *            the value change listener, not {@code null}
      */
     public TextField(String caption, String value,
-            ValueChangeListener valueChangeListener) {
+            ValueChangeListener<String> valueChangeListener) {
         this(caption, value);
         addValueChangeListener(valueChangeListener);
     }


### PR DESCRIPTION
Listeners are now defined with the correct type parameter for
each field type so the event.getValue() is what one would expect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8388)
<!-- Reviewable:end -->
