### PR TITLE
Make Grid add columns based on bean properties

### DIFF
--- a/documentation/components/components-grid.asciidoc
+++ b/documentation/components/components-grid.asciidoc
@@ -42,7 +42,7 @@ cell style generator.
 [[components.grid.data]]
 == Binding to Data
 
-[classname]#Grid# is normally used by binding it to a ,
+[classname]#Grid# is normally used by binding it to a data provider,
 described in
 <<dummy/../../../framework/datamodel/datamodel-providers.asciidoc#datamodel.dataproviders,"Showing Many Items in a Listing">>.
 By default, it is bound to List of items. You can set the items with the
@@ -96,7 +96,7 @@ grid.setSelectionMode(SelectionMode.MULTI);
 grid.addSelectionListener(event -> {
     Set<Person> selected = event.getAllSelectedItems();
     Notification.show(selected.size() + " items selected");
-}
+});
 ----
 
 Programmatically selecting the value is possible via [methodname]#select(T)#.
@@ -214,7 +214,7 @@ selectionModel.addMultiSelectionListener(event -> {
     // Allow deleting only if there's any selected
     deleteSelected.setEnabled(
          event.getNewSelection().size() > 0);
-};
+});
 ----
 
 
@@ -241,7 +241,7 @@ and column.
 [source, java]
 ----
 grid.addCellClickListener(event ->
-    Notification.show("Value: " + event.getItem());
+    Notification.show("Value: " + event.getItem()));
 ----
 
 The clicked grid cell is also automatically focused.
@@ -255,15 +255,11 @@ well as disable cell focus, in a custom theme. See <<components.grid.css>>.
 [[components.grid.columns]]
 == Configuring Columns
 
-Columns are normally defined in the container data source. The
-[methodname]#addColumn()# method can be used to add columns to [classname]#Grid#.
+The [methodname]#addColumn()# method can be used to add columns to [classname]#Grid#.
 
-Column configuration is defined in [classname]#Grid.Column# objects, which can
-be obtained from the grid with [methodname]#getColumns()#.
+Column configuration is defined in [classname]#Grid.Column# objects, which are returned by `addColumn` and can also be obtained from the grid with [methodname]#getColumns()#.
 
-The setter methods in [classname]#Column# have _fluent API_, so you can easily chain
-the configuration calls for columns if you want to.
-
+The setter methods in [classname]#Column# have _fluent API_, so you can easily chain the configuration calls for columns if you want to.
 
 [source, java]
 ----
@@ -274,6 +270,22 @@ grid.addColumn(Person:getBirthDate, new DateRenderer())
 ----
 
 In the following, we describe the basic column configuration.
+
+[[components.grid.columns.automatic]]
+=== Automatically Adding Columns
+
+You can configure `Grid` to automatically add columns based on the properties in a bean.
+To do this, you need to pass the `Class` of the bean type to the constructor when creating a grid.
+You can then further configure the columns based on the bean property name.
+
+[source, java]
+----
+Grid<Person> grid = new Grid<>(Person.class);
+
+grid.getColumn("birthDate").setWidth("100px");
+
+grid.setItems(people);
+----
 
 [[components.grid.columns.order]]
 === Column Order
@@ -424,7 +436,7 @@ grid.addColumn(person -> "Delete",
       new ButtonRenderer(clickEvent -> {
           people.remove(clickEvent.getValue());
           grid.setItems(people);
-    });
+    }));
 ----
 
 [classname]#ImageRenderer#:: Renders the cell as an image.

--- a/server/src/main/java/com/vaadin/data/BeanPropertySet.java
+++ b/server/src/main/java/com/vaadin/data/BeanPropertySet.java
@@ -32,10 +32,11 @@ import java.util.stream.Stream;
 
 import com.vaadin.data.util.BeanUtil;
 import com.vaadin.server.Setter;
+import com.vaadin.shared.util.SharedUtil;
 import com.vaadin.util.ReflectTools;
 
 /**
- * A {@link BinderPropertySet} that uses reflection to find bean properties.
+ * A {@link PropertySet} that uses reflection to find bean properties.
  *
  * @author Vaadin Ltd
  *
@@ -44,7 +45,7 @@ import com.vaadin.util.ReflectTools;
  * @param <T>
  *            the type of the bean
  */
-public class BeanBinderPropertySet<T> implements BinderPropertySet<T> {
+public class BeanPropertySet<T> implements PropertySet<T> {
 
     /**
      * Serialized form of a property set. When deserialized, the property set
@@ -52,7 +53,7 @@ public class BeanBinderPropertySet<T> implements BinderPropertySet<T> {
      * existing cached instance or creates a new one.
      *
      * @see #readResolve()
-     * @see BeanBinderPropertyDefinition#writeReplace()
+     * @see BeanPropertyDefinition#writeReplace()
      */
     private static class SerializedPropertySet implements Serializable {
         private final Class<?> beanType;
@@ -77,7 +78,7 @@ public class BeanBinderPropertySet<T> implements BinderPropertySet<T> {
      * definition is then fetched from the property set.
      *
      * @see #readResolve()
-     * @see BeanBinderPropertySet#writeReplace()
+     * @see BeanPropertySet#writeReplace()
      */
     private static class SerializedPropertyDefinition implements Serializable {
         private final Class<?> beanType;
@@ -102,14 +103,13 @@ public class BeanBinderPropertySet<T> implements BinderPropertySet<T> {
         }
     }
 
-    private static class BeanBinderPropertyDefinition<T, V>
-            implements BinderPropertyDefinition<T, V> {
+    private static class BeanPropertyDefinition<T, V>
+            implements PropertyDefinition<T, V> {
 
         private final PropertyDescriptor descriptor;
-        private final BeanBinderPropertySet<T> propertySet;
+        private final BeanPropertySet<T> propertySet;
 
-        public BeanBinderPropertyDefinition(
-                BeanBinderPropertySet<T> propertySet,
+        public BeanPropertyDefinition(BeanPropertySet<T> propertySet,
                 PropertyDescriptor descriptor) {
             this.propertySet = propertySet;
             this.descriptor = descriptor;
@@ -156,7 +156,12 @@ public class BeanBinderPropertySet<T> implements BinderPropertySet<T> {
         }
 
         @Override
-        public BeanBinderPropertySet<T> getPropertySet() {
+        public String getCaption() {
+            return SharedUtil.propertyIdToHumanFriendly(getName());
+        }
+
+        @Override
+        public BeanPropertySet<T> getPropertySet() {
             return propertySet;
         }
 
@@ -171,21 +176,21 @@ public class BeanBinderPropertySet<T> implements BinderPropertySet<T> {
         }
     }
 
-    private static final ConcurrentMap<Class<?>, BeanBinderPropertySet<?>> instances = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<Class<?>, BeanPropertySet<?>> instances = new ConcurrentHashMap<>();
 
     private final Class<T> beanType;
 
-    private final Map<String, BinderPropertyDefinition<T, ?>> definitions;
+    private final Map<String, PropertyDefinition<T, ?>> definitions;
 
-    private BeanBinderPropertySet(Class<T> beanType) {
+    private BeanPropertySet(Class<T> beanType) {
         this.beanType = beanType;
 
         try {
             definitions = BeanUtil.getBeanPropertyDescriptors(beanType).stream()
-                    .filter(BeanBinderPropertySet::hasNonObjectReadMethod)
-                    .map(descriptor -> new BeanBinderPropertyDefinition<>(this,
+                    .filter(BeanPropertySet::hasNonObjectReadMethod)
+                    .map(descriptor -> new BeanPropertyDefinition<>(this,
                             descriptor))
-                    .collect(Collectors.toMap(BinderPropertyDefinition::getName,
+                    .collect(Collectors.toMap(PropertyDefinition::getName,
                             Function.identity()));
         } catch (IntrospectionException e) {
             throw new IllegalArgumentException(
@@ -196,28 +201,28 @@ public class BeanBinderPropertySet<T> implements BinderPropertySet<T> {
     }
 
     /**
-     * Gets a {@link BeanBinderPropertySet} for the given bean type.
+     * Gets a {@link BeanPropertySet} for the given bean type.
      *
      * @param beanType
      *            the bean type to get a property set for, not <code>null</code>
-     * @return the bean binder property set, not <code>null</code>
+     * @return the bean property set, not <code>null</code>
      */
     @SuppressWarnings("unchecked")
-    public static <T> BinderPropertySet<T> get(Class<? extends T> beanType) {
+    public static <T> PropertySet<T> get(Class<? extends T> beanType) {
         Objects.requireNonNull(beanType, "Bean type cannot be null");
 
         // Cache the reflection results
-        return (BinderPropertySet<T>) instances.computeIfAbsent(beanType,
-                BeanBinderPropertySet::new);
+        return (PropertySet<T>) instances.computeIfAbsent(beanType,
+                BeanPropertySet::new);
     }
 
     @Override
-    public Stream<BinderPropertyDefinition<T, ?>> getProperties() {
+    public Stream<PropertyDefinition<T, ?>> getProperties() {
         return definitions.values().stream();
     }
 
     @Override
-    public Optional<BinderPropertyDefinition<T, ?>> getProperty(String name) {
+    public Optional<PropertyDefinition<T, ?>> getProperty(String name) {
         return Optional.ofNullable(definitions.get(name));
     }
 

--- a/server/src/main/java/com/vaadin/data/BeanValidationBinder.java
+++ b/server/src/main/java/com/vaadin/data/BeanValidationBinder.java
@@ -56,7 +56,7 @@ public class BeanValidationBinder<BEAN> extends Binder<BEAN> {
     @Override
     protected BindingBuilder<BEAN, ?> configureBinding(
             BindingBuilder<BEAN, ?> binding,
-            BinderPropertyDefinition<BEAN, ?> definition) {
+            PropertyDefinition<BEAN, ?> definition) {
         return binding.withValidator(
                 new BeanValidator(beanType, definition.getName()));
     }

--- a/server/src/main/java/com/vaadin/data/PropertyDefinition.java
+++ b/server/src/main/java/com/vaadin/data/PropertyDefinition.java
@@ -21,17 +21,17 @@ import java.util.Optional;
 import com.vaadin.server.Setter;
 
 /**
- * A property from a {@link BinderPropertySet}.
+ * A property from a {@link PropertySet}.
  *
  * @author Vaadin Ltd
  * @since
  *
  * @param <T>
- *            the type of the binder property set
+ *            the type of the property set
  * @param <V>
  *            the property type
  */
-public interface BinderPropertyDefinition<T, V> extends Serializable {
+public interface PropertyDefinition<T, V> extends Serializable {
     /**
      * Gets the value provider that is used for finding the value of this
      * property for a bean.
@@ -62,9 +62,16 @@ public interface BinderPropertyDefinition<T, V> extends Serializable {
     public String getName();
 
     /**
-     * Gets the {@link BinderPropertySet} that this property belongs to.
+     * Gets the human readable caption to show for this property.
      *
-     * @return the binder property set, not <code>null</code>
+     * @return the caption to show, not <code>null</code>
      */
-    public BinderPropertySet<T> getPropertySet();
+    public String getCaption();
+
+    /**
+     * Gets the {@link PropertySet} that this property belongs to.
+     *
+     * @return the property set, not <code>null</code>
+     */
+    public PropertySet<T> getPropertySet();
 }

--- a/server/src/main/java/com/vaadin/data/PropertySet.java
+++ b/server/src/main/java/com/vaadin/data/PropertySet.java
@@ -20,7 +20,8 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * Describes a set of properties that can be used with a {@link Binder}.
+ * Describes a set of properties that can be used for configuration based on
+ * property names instead of setter and getter callbacks.
  *
  * @author Vaadin Ltd
  *
@@ -29,13 +30,13 @@ import java.util.stream.Stream;
  * @param <T>
  *            the type for which the properties are defined
  */
-public interface BinderPropertySet<T> extends Serializable {
+public interface PropertySet<T> extends Serializable {
     /**
      * Gets all known properties as a stream.
      *
      * @return a stream of property names, not <code>null</code>
      */
-    public Stream<BinderPropertyDefinition<T, ?>> getProperties();
+    public Stream<PropertyDefinition<T, ?>> getProperties();
 
     /**
      * Gets the definition for the named property, or an empty optional if there
@@ -46,5 +47,5 @@ public interface BinderPropertySet<T> extends Serializable {
      * @return the property definition, or empty optional if property doesn't
      *         exist
      */
-    public Optional<BinderPropertyDefinition<T, ?>> getProperty(String name);
+    public Optional<PropertyDefinition<T, ?>> getProperty(String name);
 }

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -41,10 +41,13 @@ import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
+import com.vaadin.data.BeanPropertySet;
 import com.vaadin.data.Binder;
 import com.vaadin.data.Binder.Binding;
 import com.vaadin.data.HasDataProvider;
 import com.vaadin.data.HasValue;
+import com.vaadin.data.PropertyDefinition;
+import com.vaadin.data.PropertySet;
 import com.vaadin.data.ValueProvider;
 import com.vaadin.data.provider.DataCommunicator;
 import com.vaadin.data.provider.DataProvider;
@@ -1609,7 +1612,9 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
          *            a setter that stores the component value in the row item
          * @return this column
          *
+         * @see #setEditorBinding(Binding)
          * @see Grid#getEditor()
+         * @see Binder#bind(HasValue, ValueProvider, Setter)
          */
         public <C extends HasValue<V> & Component> Column<T, V> setEditorComponent(
                 C editorComponent, Setter<T, V> setter) {
@@ -1619,6 +1624,47 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
 
             Binding<T, V> binding = getGrid().getEditor().getBinder()
                     .bind(editorComponent, valueProvider::apply, setter);
+
+            return setEditorBinding(binding);
+        }
+
+        /**
+         * Sets a component to use for editing values of this columns in the
+         * editor row. This method can only be used if the column has an
+         * {@link #setId(String) id} and the {@link Grid} has been created using
+         * {@link Grid#Grid(Class)} or some other way that allows finding
+         * properties based on property names.
+         * <p>
+         * This is a shorthand for use in simple cases where no validator or
+         * converter is needed. Use {@link #setEditorBinding(Binding)} to
+         * support more complex cases.
+         * <p>
+         * <strong>Note:</strong> The same component cannot be used for multiple
+         * columns.
+         *
+         * @param editorComponent
+         *            the editor component
+         * @return this column
+         *
+         * @see #setEditorBinding(Binding)
+         * @see Grid#getEditor()
+         * @see Binder#bind(HasValue, String)
+         * @see Grid#Grid(Class)
+         */
+        public <F, C extends HasValue<F> & Component> Column<T, V> setEditorComponent(
+                C editorComponent) {
+            Objects.requireNonNull(editorComponent,
+                    "Editor component cannot be null");
+
+            String propertyName = getId();
+            if (propertyName == null) {
+                throw new IllegalStateException(
+                        "setEditorComponent without a setter can only be used if the column has an id. "
+                                + "Use another setEditorComponent(Component, Setter) or setEditorBinding(Binding) instead.");
+            }
+
+            Binding<T, F> binding = getGrid().getEditor().getBinder()
+                    .bind(editorComponent, propertyName);
 
             return setEditorBinding(binding);
         }
@@ -1851,10 +1897,64 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
 
     private Editor<T> editor;
 
+    private final PropertySet<T> propertySet;
+
     /**
-     * Constructor for the {@link Grid} component.
+     * Creates a new grid without support for creating columns based on property
+     * names. Use an alternative constructor, such as {@link Grid#Grid(Class)},
+     * to create a grid that automatically sets up columns based on the type of
+     * presented data.
+     *
+     * @see #Grid(Class)
+     * @see #withPropertySet(PropertySet)
      */
     public Grid() {
+        this(new PropertySet<T>() {
+            @Override
+            public Stream<PropertyDefinition<T, ?>> getProperties() {
+                // No columns configured by default
+                return Stream.empty();
+            }
+
+            @Override
+            public Optional<PropertyDefinition<T, ?>> getProperty(String name) {
+                throw new IllegalStateException(
+                        "A Grid created without a bean type class literal or a custom property set"
+                                + " doesn't support finding properties by name.");
+            }
+        });
+    }
+
+    /**
+     * Creates a new grid that uses reflection based on the provided bean type
+     * to automatically set up an initial set of columns. All columns will be
+     * configured using the same {@link Object#toString()} renderer that is used
+     * by {@link #addColumn(ValueProvider)}.
+     *
+     * @param beanType
+     *            the bean type to use, not <code>null</code>
+     * @see #Grid()
+     * @see #withPropertySet(PropertySet)
+     */
+    public Grid(Class<T> beanType) {
+        this(BeanPropertySet.get(beanType));
+    }
+
+    /**
+     * Creates a grid using a custom {@link PropertySet} implementation for
+     * configuring the initial columns and resolving property names for
+     * {@link #addColumn(String)} and
+     * {@link Column#setEditorComponent(HasValue)}.
+     *
+     * @see #withPropertySet(PropertySet)
+     *
+     * @param propertySet
+     *            the property set implementation to use, not <code>null</code>.
+     */
+    protected Grid(PropertySet<T> propertySet) {
+        Objects.requireNonNull(propertySet, "propertySet cannot be null");
+        this.propertySet = propertySet;
+
         registerRpc(new GridServerRpcImpl());
 
         setDefaultHeaderRow(appendHeaderRow());
@@ -1882,6 +1982,33 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
                 }
             }
         });
+
+        // Automatically add columns for all available properties
+        propertySet.getProperties().map(PropertyDefinition::getName)
+                .forEach(this::addColumn);
+    }
+
+    /**
+     * Creates a grid using a custom {@link PropertySet} implementation for
+     * creating a default set of columns and for resolving property names with
+     * {@link #addColumn(String)} and
+     * {@link Column#setEditorComponent(HasValue)}.
+     * <p>
+     * This functionality is provided as static method instead of as a public
+     * constructor in order to make it possible to use a custom property set
+     * without creating a subclass while still leaving the public constructors
+     * focused on the common use cases.
+     *
+     * @see Grid#Grid()
+     * @see Grid#Grid(Class)
+     *
+     * @param propertySet
+     *            the property set implementation to use, not <code>null</code>.
+     * @return a new grid using the provided property set, not <code>null</code>
+     */
+    public static <BEAN> Grid<BEAN> withPropertySet(
+            PropertySet<BEAN> propertySet) {
+        return new Grid<>(propertySet);
     }
 
     /**
@@ -1937,6 +2064,37 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
             boolean hidden, boolean userOriginated) {
         fireEvent(new ColumnVisibilityChangeEvent(this, column, hidden,
                 userOriginated));
+    }
+
+    /**
+     * Adds a new column with the given property name. The property name will be
+     * used as the {@link Column#getId() column id} and the
+     * {@link Column#getCaption() column caption} will be set based on the
+     * property definition.
+     * <p>
+     * This method can only be used for a <code>Grid</code> created using
+     * {@link Grid#Grid(Class)} or {@link #withPropertySet(PropertySet)}.
+     *
+     * @param propertyName
+     *            the property name of the new column, not <code>null</code>
+     * @return the newly added column, not <code>null</code>
+     */
+    public Column<T, ?> addColumn(String propertyName) {
+        Objects.requireNonNull(propertyName, "Property name cannot be null");
+
+        if (getColumn(propertyName) != null) {
+            throw new IllegalStateException(
+                    "There is already a column for " + propertyName);
+        }
+
+        PropertyDefinition<T, ?> definition = propertySet
+                .getProperty(propertyName)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Could not resolve property name " + propertyName
+                                + " from " + propertySet));
+
+        return addColumn(definition.getGetter()).setId(definition.getName())
+                .setCaption(definition.getCaption());
     }
 
     /**
@@ -2070,7 +2228,8 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      *
      * @param columnId
      *            the identifier of the column to get
-     * @return the column corresponding to the given column identifier
+     * @return the column corresponding to the given column identifier, or
+     *         <code>null</code> if there is no such column
      */
     public Column<T, ?> getColumn(String columnId) {
         return columnIds.get(columnId);
@@ -2983,7 +3142,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      * @return editor
      */
     protected Editor<T> createEditor() {
-        return new EditorImpl<>();
+        return new EditorImpl<>(propertySet);
     }
 
     private void addExtensionComponent(Component c) {

--- a/server/src/main/java/com/vaadin/ui/components/grid/EditorImpl.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/EditorImpl.java
@@ -27,6 +27,7 @@ import com.vaadin.data.Binder;
 import com.vaadin.data.Binder.Binding;
 import com.vaadin.data.BinderValidationStatus;
 import com.vaadin.data.BinderValidationStatusHandler;
+import com.vaadin.data.PropertySet;
 import com.vaadin.shared.ui.grid.editor.EditorClientRpc;
 import com.vaadin.shared.ui.grid.editor.EditorServerRpc;
 import com.vaadin.shared.ui.grid.editor.EditorState;
@@ -112,8 +113,11 @@ public class EditorImpl<T> extends AbstractGridExtension<T>
 
     /**
      * Constructor for internal implementation of the Editor.
+     *
+     * @param propertySet
+     *            the property set to use for configuring the default binder
      */
-    public EditorImpl() {
+    public EditorImpl(PropertySet<T> propertySet) {
         rpc = getRpcProxy(EditorClientRpc.class);
         registerRpc(new EditorServerRpc() {
 
@@ -142,7 +146,7 @@ public class EditorImpl<T> extends AbstractGridExtension<T>
             }
         });
 
-        setBinder(new Binder<>());
+        setBinder(Binder.withPropertySet(propertySet));
     }
 
     @Override

--- a/server/src/test/java/com/vaadin/data/BeanPropertySetTest.java
+++ b/server/src/test/java/com/vaadin/data/BeanPropertySetTest.java
@@ -32,13 +32,13 @@ import org.junit.Test;
 import com.vaadin.data.provider.bov.Person;
 import com.vaadin.tests.server.ClassesSerializableTest;
 
-public class BeanBinderPropertySetTest {
+public class BeanPropertySetTest {
     @Test
     public void testSerializeDeserialize_propertySet() throws Exception {
-        BinderPropertySet<Person> originalPropertySet = BeanBinderPropertySet
+        PropertySet<Person> originalPropertySet = BeanPropertySet
                 .get(Person.class);
 
-        BinderPropertySet<Person> deserializedPropertySet = ClassesSerializableTest
+        PropertySet<Person> deserializedPropertySet = ClassesSerializableTest
                 .serializeAndDeserialize(originalPropertySet);
 
         Assert.assertSame(
@@ -49,7 +49,7 @@ public class BeanBinderPropertySetTest {
     @Test
     public void testSerializeDeserialize_propertySet_cacheCleared()
             throws Exception {
-        BinderPropertySet<Person> originalPropertySet = BeanBinderPropertySet
+        PropertySet<Person> originalPropertySet = BeanPropertySet
                 .get(Person.class);
 
         ByteArrayOutputStream bs = new ByteArrayOutputStream();
@@ -59,7 +59,7 @@ public class BeanBinderPropertySetTest {
 
         // Simulate deserializing into a different JVM by clearing the instance
         // map
-        Field instancesField = BeanBinderPropertySet.class
+        Field instancesField = BeanPropertySet.class
                 .getDeclaredField("instances");
         instancesField.setAccessible(true);
         Map<?, ?> instances = (Map<?, ?>) instancesField.get(null);
@@ -67,13 +67,12 @@ public class BeanBinderPropertySetTest {
 
         ObjectInputStream in = new ObjectInputStream(
                 new ByteArrayInputStream(data));
-        BinderPropertySet<Person> deserializedPropertySet = (BinderPropertySet<Person>) in
+        PropertySet<Person> deserializedPropertySet = (PropertySet<Person>) in
                 .readObject();
 
         Assert.assertSame(
                 "Deserialized instance should be the same as in the cache",
-                BeanBinderPropertySet.get(Person.class),
-                deserializedPropertySet);
+                BeanPropertySet.get(Person.class), deserializedPropertySet);
         Assert.assertNotSame(
                 "Deserialized instance should not be the same as the original",
                 originalPropertySet, deserializedPropertySet);
@@ -81,11 +80,11 @@ public class BeanBinderPropertySetTest {
 
     @Test
     public void testSerializeDeserialize_propertyDefinition() throws Exception {
-        BinderPropertyDefinition<Person, ?> definition = BeanBinderPropertySet
+        PropertyDefinition<Person, ?> definition = BeanPropertySet
                 .get(Person.class).getProperty("born")
                 .orElseThrow(RuntimeException::new);
 
-        BinderPropertyDefinition<Person, ?> deserializedDefinition = ClassesSerializableTest
+        PropertyDefinition<Person, ?> deserializedDefinition = ClassesSerializableTest
                 .serializeAndDeserialize(definition);
 
         ValueProvider<Person, ?> getter = deserializedDefinition.getGetter();
@@ -97,19 +96,17 @@ public class BeanBinderPropertySetTest {
 
         Assert.assertSame(
                 "Deserialized instance should be the same as in the cache",
-                BeanBinderPropertySet.get(Person.class).getProperty("born")
+                BeanPropertySet.get(Person.class).getProperty("born")
                         .orElseThrow(RuntimeException::new),
                 deserializedDefinition);
     }
 
     @Test
     public void properties() {
-        BinderPropertySet<Person> propertySet = BeanBinderPropertySet
-                .get(Person.class);
+        PropertySet<Person> propertySet = BeanPropertySet.get(Person.class);
 
         Set<String> propertyNames = propertySet.getProperties()
-                .map(BinderPropertyDefinition::getName)
-                .collect(Collectors.toSet());
+                .map(PropertyDefinition::getName).collect(Collectors.toSet());
 
         Assert.assertEquals(new HashSet<>(Arrays.asList("name", "born")),
                 propertyNames);

--- a/server/src/test/java/com/vaadin/data/BinderCustomPropertySetTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderCustomPropertySetTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.data;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -28,7 +29,7 @@ import com.vaadin.ui.TextField;
 
 public class BinderCustomPropertySetTest {
     public static class MapPropertyDefinition
-            implements BinderPropertyDefinition<Map<String, String>, String> {
+            implements PropertyDefinition<Map<String, String>, String> {
 
         private MapPropertySet propertySet;
         private String name;
@@ -65,26 +66,31 @@ public class BinderCustomPropertySetTest {
         }
 
         @Override
-        public BinderPropertySet<Map<String, String>> getPropertySet() {
+        public PropertySet<Map<String, String>> getPropertySet() {
             return propertySet;
+        }
+
+        @Override
+        public String getCaption() {
+            return name.toUpperCase(Locale.ENGLISH);
         }
 
     }
 
     public static class MapPropertySet
-            implements BinderPropertySet<Map<String, String>> {
+            implements PropertySet<Map<String, String>> {
         @Override
-        public Stream<BinderPropertyDefinition<Map<String, String>, ?>> getProperties() {
+        public Stream<PropertyDefinition<Map<String, String>, ?>> getProperties() {
             return Stream.of("one", "two", "three").map(this::createProperty);
         }
 
         @Override
-        public Optional<BinderPropertyDefinition<Map<String, String>, ?>> getProperty(
+        public Optional<PropertyDefinition<Map<String, String>, ?>> getProperty(
                 String name) {
             return Optional.of(createProperty(name));
         }
 
-        private BinderPropertyDefinition<Map<String, String>, ?> createProperty(
+        private PropertyDefinition<Map<String, String>, ?> createProperty(
                 String name) {
             return new MapPropertyDefinition(this, name);
         }

--- a/server/src/test/java/com/vaadin/data/provider/bov/Person.java
+++ b/server/src/test/java/com/vaadin/data/provider/bov/Person.java
@@ -17,13 +17,8 @@ package com.vaadin.data.provider.bov;
 
 import java.io.Serializable;
 
-/**
- * POJO
- *
- * @author Vaadin Ltd
- */
 public class Person implements Serializable {
-    private final String name;
+    private String name;
     private final int born;
 
     public Person(String name, int born) {
@@ -33,6 +28,10 @@ public class Person implements Serializable {
 
     public String getName() {
         return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public int getBorn() {


### PR DESCRIPTION
The property set concept used for Binder is slightly generalized and
used by Grid as well to support similar functionality.

Fixes vaadin/framework8-issues#250

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8392)
<!-- Reviewable:end -->
