### PR TITLE
Revert widget-set-testutil parent change

### DIFF
--- a/test/widget-set-testutil/pom.xml
+++ b/test/widget-set-testutil/pom.xml
@@ -2,24 +2,33 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <groupId>com.vaadin</groupId>
     <artifactId>vaadin-test-widget-set-testutil</artifactId>
+    <version>8.0-SNAPSHOT</version>
     <packaging>jar</packaging>
-    
-    <parent>
-        <groupId>com.vaadin</groupId>
-        <artifactId>vaadin-test</artifactId>
-        <version>8.0-SNAPSHOT</version>
-    </parent>
+    <!-- 
+        This module does not inherit the vaadin-test on purpose. It is done 
+        so to allow installing this module as stand-alone and used when running any 
+        of the test modules without requiring everything to be installed. 
+    -->
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <vaadin.version>${project.version}</vaadin.version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-server</artifactId>
+            <version>${vaadin.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench-api</artifactId>
+            <version>${vaadin.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The widget-set-testutil needs to be installed to allow executing any individual test without running the full vaadin-test build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8404)
<!-- Reviewable:end -->
