### PR TITLE
Add default getEmptyValue for MultiSelect interface (#8420)

### DIFF
--- a/server/src/main/java/com/vaadin/ui/AbstractMultiSelect.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractMultiSelect.java
@@ -216,11 +216,6 @@ public abstract class AbstractMultiSelect<T> extends AbstractListing<T>
         updateSelection(copy, new LinkedHashSet<>(getSelectedItems()));
     }
 
-    @Override
-    public Set<T> getEmptyValue() {
-        return Collections.emptySet();
-    }
-
     /**
      * Adds a value change listener. The listener is called when the selection
      * set of this multi select is changed either by the user or

--- a/server/src/main/java/com/vaadin/ui/MultiSelect.java
+++ b/server/src/main/java/com/vaadin/ui/MultiSelect.java
@@ -136,4 +136,15 @@ public interface MultiSelect<T> extends HasValue<Set<T>>, Serializable {
      */
     public Registration addSelectionListener(
             MultiSelectionListener<T> listener);
+
+    /**
+     * MultiSelect empty value should always be an empty set by default and not
+     * {@code null}.
+     *
+     * @return An empty set, not {@code null}
+     */
+    public default Set<T> getEmptyValue() {
+        return Collections.emptySet();
+    }
+
 }


### PR DESCRIPTION
Added an default implementation for getEmptyValue to the
MultiSelect interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8421)
<!-- Reviewable:end -->
