### PR TITLE
Revert ComboBoxElement fix that prevented timeouts

### DIFF
--- a/testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
+++ b/testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.testbench.By;
@@ -183,9 +183,10 @@ public class ComboBoxElement extends AbstractSelectElement {
         try {
             getSuggestionPopup().findElement(byNextPage).click();
             return true;
-        } catch (WebDriverException e) {
-            // PhantomJS driver can throw WDE instead of the more specific
-            // NoSuchElementException
+        } catch (NoSuchElementException e) {
+            // TODO PhantomJS driver can throw WebDriverException instead of the
+            // more specific NoSuchElementException, but we cannot catch raw WDE
+            // as that would swallow timeouts
             return false;
         }
     }
@@ -199,9 +200,10 @@ public class ComboBoxElement extends AbstractSelectElement {
         try {
             getSuggestionPopup().findElement(byPrevPage).click();
             return true;
-        } catch (WebDriverException e) {
-            // PhantomJS driver can throw WDE instead of the more specific
-            // NoSuchElementException
+        } catch (NoSuchElementException e) {
+            // TODO PhantomJS driver can throw WebDriverException instead of the
+            // more specific NoSuchElementException, but we cannot catch raw WDE
+            // as that would swallow timeouts
             return false;
         }
     }


### PR DESCRIPTION
This partly reverts #8430.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8444)
<!-- Reviewable:end -->
