### PR TITLE
Fix problem with re-opening the popup (#8446)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VAbstractPopupCalendar.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractPopupCalendar.java
@@ -254,9 +254,9 @@ public abstract class VAbstractPopupCalendar<PANEL extends VAbstractCalendarPane
      * Sets the state of the text field of this component. By default the text
      * field is enabled. Disabling it causes only the button for date selection
      * to be active, thus preventing the user from entering invalid dates. See
-     * {@link http://dev.vaadin.com/ticket/6790}.
+     * <a href="http://dev.vaadin.com/ticket/6790>#6790</a>.
      *
-     * @param state
+     * @param textFieldEnabled
      */
     public void setTextFieldEnabled(boolean textFieldEnabled) {
         this.textFieldEnabled = textFieldEnabled;
@@ -413,7 +413,9 @@ public abstract class VAbstractPopupCalendar<PANEL extends VAbstractCalendarPane
     @Override
     public void onClick(ClickEvent event) {
         if (event.getSource() == calendarToggle && isEnabled()) {
-            if (!preventOpenPopupCalendar) {
+            if (open) {
+                closeCalendarPanel();
+            } else if (!preventOpenPopupCalendar) {
                 openCalendarPanel();
             }
             preventOpenPopupCalendar = false;
@@ -597,7 +599,7 @@ public abstract class VAbstractPopupCalendar<PANEL extends VAbstractCalendarPane
      * and it depends on the current resolution, what is considered inside the
      * range.
      *
-     * @param startDate
+     * @param rangeStart
      *            - the allowed range's start date
      */
     public void setRangeStart(Date rangeStart) {
@@ -608,7 +610,7 @@ public abstract class VAbstractPopupCalendar<PANEL extends VAbstractCalendarPane
      * Sets the end range for this component. The end range is inclusive, and it
      * depends on the current resolution, what is considered inside the range.
      *
-     * @param endDate
+     * @param rangeEnd
      *            - the allowed range's end date
      */
     public void setRangeEnd(Date rangeEnd) {

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VPopupCalendar.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VPopupCalendar.java
@@ -429,7 +429,9 @@ public class VPopupCalendar extends VTextualDate
     @Override
     public void onClick(ClickEvent event) {
         if (event.getSource() == calendarToggle && isEnabled()) {
-            if (!preventOpenPopupCalendar) {
+            if (open) {
+                closeCalendarPanel();
+            } else if (!preventOpenPopupCalendar) {
                 openCalendarPanel();
             }
             preventOpenPopupCalendar = false;

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/DateTimeFieldPopup.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/DateTimeFieldPopup.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.datefield;
+
+import java.time.LocalDateTime;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.DateTimeField;
+
+/**
+ * Test UI for testing the functionality of the popup button.
+ */
+public class DateTimeFieldPopup extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+
+        DateTimeField dateTimeField = new DateTimeField();
+        dateTimeField.setValue(LocalDateTime.of(1999, 12, 1, 12, 00));
+
+        addComponent(dateTimeField);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateTimeFieldPopupTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateTimeFieldPopupTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.datefield;
+
+import org.junit.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import com.vaadin.testbench.By;
+import com.vaadin.testbench.customelements.DateTimeFieldElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class DateTimeFieldPopupTest extends MultiBrowserTest {
+
+    @Test
+    public void testOpenCloseOpen_popupShouldBeOpen() throws Exception {
+        openTestURL();
+
+        WebElement toggleButton = $(DateTimeFieldElement.class).first()
+                .findElement(By.className("v-datefield-button"));
+
+        toggleButton.click();
+
+        assertThatPopupIsVisible();
+
+        toggleButton.click();
+
+        assertThatPopupIsInvisible();
+
+        // We should be able to immediately open the popup from the popup after
+        // clicking the button to close it. (#8446)
+        toggleButton.click();
+
+        assertThatPopupIsVisible();
+    }
+
+    private void assertThatPopupIsVisible() {
+        waitUntil(ExpectedConditions.visibilityOfElementLocated(
+                org.openqa.selenium.By.className("v-datefield-popup")));
+    }
+
+    private void assertThatPopupIsInvisible() {
+        // ExpectedConditions.invisibilityOfElementLocated doesn't work
+        // with PhantomJS when running with a hub:
+        // https://code.google.com/p/selenium/issues/detail?id=5000
+        // so we need to make our own.
+
+        waitUntil(new ExpectedCondition<Boolean>() {
+            @Override
+            public Boolean apply(WebDriver input) {
+                try {
+                    return !(findElement(org.openqa.selenium.By
+                            .className("v-datefield-popup")).isDisplayed());
+                } catch (Exception e) {
+                    return true;
+                }
+            }
+
+            @Override
+            public String toString() {
+                // Timed out after 10 seconds waiting for ...
+                return "popup to not be visible";
+            }
+        });
+    }
+}


### PR DESCRIPTION
Fixed problem that disables opening of popup
after closing it by clicking the datefield-button.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8451)
<!-- Reviewable:end -->
