### PR TITLE
Fix toggling of WeekNumbers for DateTimeField. (#8405)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VAbstractCalendarPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractCalendarPanel.java
@@ -630,8 +630,9 @@ public abstract class VAbstractCalendarPanel<R extends Enum<R>>
 
     public void setShowISOWeekNumbers(boolean showISOWeekNumbers) {
         this.showISOWeekNumbers = showISOWeekNumbers;
-        if(initialRenderDone) {
-            renderCalendar();
+        if (initialRenderDone && isBelowMonth(resolution)) {
+            clearCalendarBody(false);
+            buildCalendarBody();
         }
     }
 

--- a/client/src/main/java/com/vaadin/client/ui/VAbstractCalendarPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractCalendarPanel.java
@@ -630,6 +630,9 @@ public abstract class VAbstractCalendarPanel<R extends Enum<R>>
 
     public void setShowISOWeekNumbers(boolean showISOWeekNumbers) {
         this.showISOWeekNumbers = showISOWeekNumbers;
+        if(initialRenderDone) {
+            renderCalendar();
+        }
     }
 
     /**

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCalendarPanel.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCalendarPanel.java
@@ -533,8 +533,10 @@ public class VCalendarPanel extends FocusableFlexTable implements
 
     public void setShowISOWeekNumbers(boolean showISOWeekNumbers) {
         this.showISOWeekNumbers = showISOWeekNumbers;
-        if(initialRenderDone) {
-            renderCalendar();
+        if (initialRenderDone && getResolution()
+                .getCalendarField() >= Resolution.DAY.getCalendarField()) {
+            clearCalendarBody(false);
+            buildCalendarBody();
         }
     }
 

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCalendarPanel.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCalendarPanel.java
@@ -533,6 +533,9 @@ public class VCalendarPanel extends FocusableFlexTable implements
 
     public void setShowISOWeekNumbers(boolean showISOWeekNumbers) {
         this.showISOWeekNumbers = showISOWeekNumbers;
+        if(initialRenderDone) {
+            renderCalendar();
+        }
     }
 
     /**

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/DateTimeFieldWeekDays.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/DateTimeFieldWeekDays.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.datefield;
+
+import java.time.LocalDateTime;
+import java.util.Locale;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.CheckBox;
+import com.vaadin.ui.DateTimeField;
+import com.vaadin.ui.HorizontalLayout;
+
+public class DateTimeFieldWeekDays extends AbstractTestUI {
+
+    private static final Locale localeFI = new Locale("fi", "FI");
+
+    @Override
+    protected void setup(VaadinRequest request) {
+
+        DateTimeField dateTimeField = new DateTimeField();
+        dateTimeField.setValue(LocalDateTime.of(1999, 12, 1, 12, 00));
+        dateTimeField.setShowISOWeekNumbers(true);
+        dateTimeField.setLocale(localeFI);
+
+        CheckBox weekNumbersToggle = new CheckBox("Toggle week numbers",
+                dateTimeField.isShowISOWeekNumbers());
+        weekNumbersToggle.addValueChangeListener(
+                e -> dateTimeField.setShowISOWeekNumbers(e.getValue()));
+
+        Button toEnglish = new Button("Change locale",
+                click -> dateTimeField.setLocale(Locale.ENGLISH));
+        toEnglish.setId("english");
+        Button toFinnish = new Button("Change locale",
+                click -> dateTimeField.setLocale(localeFI));
+        toFinnish.setId("finnish");
+
+        addComponent(dateTimeField);
+        addComponent(weekNumbersToggle);
+        addComponent(new HorizontalLayout(toEnglish, toFinnish));
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateTimeFieldWeekDaysTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateTimeFieldWeekDaysTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.datefield;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import com.vaadin.testbench.By;
+import com.vaadin.testbench.customelements.DateTimeFieldElement;
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.CheckBoxElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class DateTimeFieldWeekDaysTest extends SingleBrowserTest {
+
+    @Test
+    public void testFiLocale_weekNumbersVisible() {
+        openTestURL();
+
+        openPopupAndValidateWeekNumbers();
+    }
+
+    @Test
+    public void testToggleWeekNumbers_rederedCorrectly() {
+        openTestURL();
+
+        openPopupAndValidateWeekNumbers();
+
+        $(CheckBoxElement.class).first().click();
+
+        Assert.assertFalse("Checkbox is selected even though should be unselected.", $(CheckBoxElement.class).first().isChecked());
+
+        openPopupAndValidateNoWeeknumbers();
+    }
+
+    @Test
+    public void testLocaleChangeToEnglish_removesWeekNumbers() {
+        openTestURL();
+
+        openPopupAndValidateWeekNumbers();
+
+        $(ButtonElement.class).id("english").click();
+
+        openPopupAndValidateNoWeeknumbers();
+    }
+
+    @Test
+    public void testChangeBackToFinnish_weekNumbersVisible() {
+        openTestURL();
+
+        $(ButtonElement.class).id("english").click();
+
+        openPopupAndValidateNoWeeknumbers();
+
+        $(ButtonElement.class).id("finnish").click();
+
+        openPopupAndValidateWeekNumbers();
+    }
+
+    private void openPopupAndValidateWeekNumbers() {
+        WebElement popupButton = $(DateTimeFieldElement.class).first()
+                .findElement(By.className("v-datefield-button"));
+        // Open date popup
+        popupButton.click();
+
+        waitUntil(ExpectedConditions.visibilityOfElementLocated(
+                org.openqa.selenium.By.className("v-datefield-popup")));
+
+        Assert.assertFalse("No week numbers found for date field!",
+                findElements(
+                        By.className("v-datefield-calendarpanel-weeknumber"))
+                        .isEmpty());
+        // Close popup
+        popupButton.click();
+    }
+
+    private void openPopupAndValidateNoWeeknumbers() {
+        WebElement popupButton = $(DateTimeFieldElement.class).first()
+                .findElement(By.className("v-datefield-button"));
+        // Open date popup
+        popupButton.click();
+
+        waitUntil(ExpectedConditions.visibilityOfElementLocated(
+                org.openqa.selenium.By.className("v-datefield-popup")));
+
+        Assert.assertTrue("Week numbers still found in calendar popup!",
+                findElements(
+                        By.className("v-datefield-calendarpanel-weeknumber"))
+                        .isEmpty());
+        // Close popup
+        popupButton.click();
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateTimeFieldWeekDaysTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateTimeFieldWeekDaysTest.java
@@ -36,7 +36,7 @@ public class DateTimeFieldWeekDaysTest extends SingleBrowserTest {
     }
 
     @Test
-    public void testToggleWeekNumbers_rederedCorrectly() {
+    public void testToggleWeekNumbers_renderedCorrectly() {
         openTestURL();
 
         openPopupAndValidateWeekNumbers();


### PR DESCRIPTION
Fix togging of week numbers in calendar popup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8468)
<!-- Reviewable:end -->
