### PR TITLE
Fix toggling of WeekNumbers for PopupDateField. (#8405)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VCalendarPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCalendarPanel.java
@@ -531,6 +531,9 @@ public class VCalendarPanel extends FocusableFlexTable implements
 
     public void setShowISOWeekNumbers(boolean showISOWeekNumbers) {
         this.showISOWeekNumbers = showISOWeekNumbers;
+        if(initialRenderDone) {
+            renderCalendar();
+        }
     }
 
     /**

--- a/client/src/main/java/com/vaadin/client/ui/VCalendarPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCalendarPanel.java
@@ -531,8 +531,10 @@ public class VCalendarPanel extends FocusableFlexTable implements
 
     public void setShowISOWeekNumbers(boolean showISOWeekNumbers) {
         this.showISOWeekNumbers = showISOWeekNumbers;
-        if(initialRenderDone) {
-            renderCalendar();
+        if (initialRenderDone && getResolution()
+                .getCalendarField() >= Resolution.DAY.getCalendarField()) {
+            clearCalendarBody(false);
+            buildCalendarBody();
         }
     }
 

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/PopupDateFieldWeekDays.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/PopupDateFieldWeekDays.java
@@ -1,0 +1,59 @@
+package com.vaadin.tests.components.datefield;
+
+import java.util.Date;
+import java.util.Locale;
+
+import com.vaadin.data.Property;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.CheckBox;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.PopupDateField;
+
+public class PopupDateFieldWeekDays extends AbstractTestUI {
+
+    private static final Locale localeFI = new Locale("fi", "FI");
+
+    @Override
+    protected void setup(VaadinRequest request) {
+
+        final PopupDateField dateTimeField = new PopupDateField();
+        dateTimeField.setValue(new Date(1999, 12, 1, 12, 00));
+        dateTimeField.setShowISOWeekNumbers(true);
+        dateTimeField.setLocale(localeFI);
+
+        final CheckBox weekNumbersToggle = new CheckBox("Toggle week numbers",
+                dateTimeField.isShowISOWeekNumbers());
+        weekNumbersToggle
+                .addValueChangeListener(new Property.ValueChangeListener() {
+                    @Override
+                    public void valueChange(Property.ValueChangeEvent event) {
+                        dateTimeField.setShowISOWeekNumbers(
+                                weekNumbersToggle.getValue());
+                    }
+                });
+
+        Button toEnglish = new Button("Change locale",
+                new Button.ClickListener() {
+                    @Override
+                    public void buttonClick(Button.ClickEvent event) {
+                        dateTimeField.setLocale(Locale.ENGLISH);
+                    }
+                });
+        toEnglish.setId("english");
+        Button toFinnish = new Button("Change locale",
+                new Button.ClickListener() {
+                    @Override
+                    public void buttonClick(Button.ClickEvent event) {
+                        dateTimeField.setLocale(localeFI);
+
+                    }
+                });
+        toFinnish.setId("finnish");
+
+        addComponent(dateTimeField);
+        addComponent(weekNumbersToggle);
+        addComponent(new HorizontalLayout(toEnglish, toFinnish));
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/PopupDateFieldWeekDaysTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/PopupDateFieldWeekDaysTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.datefield;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import com.vaadin.testbench.By;
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.CheckBoxElement;
+import com.vaadin.testbench.elements.PopupDateFieldElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class PopupDateFieldWeekDaysTest extends SingleBrowserTest {
+
+    @Test
+    public void testFiLocale_weekNumbersVisible() {
+        openTestURL();
+
+        openPopupAndValidateWeekNumbers();
+    }
+
+    @Test
+    public void testToggleWeekNumbers_rederedCorrectly() {
+        openTestURL();
+
+        openPopupAndValidateWeekNumbers();
+
+        $(CheckBoxElement.class).first().click();
+
+        Assert.assertFalse(
+                "Checkbox is selected even though should be unselected.",
+                $(CheckBoxElement.class).first().getValue().equals("true"));
+
+        openPopupAndValidateNoWeeknumbers();
+    }
+
+    @Test
+    public void testLocaleChangeToEnglish_removesWeekNumbers() {
+        openTestURL();
+
+        openPopupAndValidateWeekNumbers();
+
+        $(ButtonElement.class).id("english").click();
+
+        openPopupAndValidateNoWeeknumbers();
+    }
+
+    @Test
+    public void testChangeBackToFinnish_weekNumbersVisible() {
+        openTestURL();
+
+        $(ButtonElement.class).id("english").click();
+
+        openPopupAndValidateNoWeeknumbers();
+
+        $(ButtonElement.class).id("finnish").click();
+
+        openPopupAndValidateWeekNumbers();
+    }
+
+    private void openPopupAndValidateWeekNumbers() {
+        WebElement popupButton = $(PopupDateFieldElement.class).first()
+                .findElement(By.className("v-datefield-button"));
+        // Open date popup
+        popupButton.click();
+
+        waitUntil(ExpectedConditions.visibilityOfElementLocated(
+                org.openqa.selenium.By.className("v-datefield-popup")));
+
+        Assert.assertFalse("No week numbers found for date field!",
+                findElements(
+                        By.className("v-datefield-calendarpanel-weeknumber"))
+                                .isEmpty());
+        // Close popup
+        popupButton.click();
+    }
+
+    private void openPopupAndValidateNoWeeknumbers() {
+        WebElement popupButton = $(PopupDateFieldElement.class).first()
+                .findElement(By.className("v-datefield-button"));
+        // Open date popup
+        popupButton.click();
+
+        waitUntil(ExpectedConditions.visibilityOfElementLocated(
+                org.openqa.selenium.By.className("v-datefield-popup")));
+
+        Assert.assertTrue("Week numbers still found in calendar popup!",
+                findElements(
+                        By.className("v-datefield-calendarpanel-weeknumber"))
+                                .isEmpty());
+        // Close popup
+        popupButton.click();
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/PopupDateFieldWeekDaysTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/PopupDateFieldWeekDaysTest.java
@@ -36,7 +36,7 @@ public class PopupDateFieldWeekDaysTest extends SingleBrowserTest {
     }
 
     @Test
-    public void testToggleWeekNumbers_rederedCorrectly() {
+    public void testToggleWeekNumbers_renderedCorrectly() {
         openTestURL();
 
         openPopupAndValidateWeekNumbers();


### PR DESCRIPTION
Fix togging of week numbers inside PopupDateField calendar popup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8469)
<!-- Reviewable:end -->
