### PR TITLE
Fix profiling in vaadin-root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <!-- Dependency unpack directory -->
         <dependency.unpack.directory>${project.build.directory}/dependency-unpack</dependency.unpack.directory>
-        
+
         <jetty.version>9.3.7.v20160115</jetty.version>
         <phantomjs.version>2.1.1</phantomjs.version>
 
@@ -125,13 +125,13 @@
                 <artifactId>vaadin-sass-compiler</artifactId>
                 <version>${vaadin.sass.version}</version>
                 <exclusions>
-                <!-- No need to have the minifier included for development 
-                    mode on-the-fly compilation -->
-                <exclusion>
-                    <groupId>com.yahoo.platform.yui</groupId>
-                    <artifactId>yuicompressor</artifactId>
-                </exclusion>
-            </exclusions>
+                    <!-- No need to have the minifier included for development 
+                        mode on-the-fly compilation -->
+                    <exclusion>
+                        <groupId>com.yahoo.platform.yui</groupId>
+                        <artifactId>yuicompressor</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.carrotsearch</groupId>
@@ -169,10 +169,10 @@
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
                 <exclusions>
-                   <exclusion>
-                       <artifactId>hamcrest-core</artifactId>
-                       <groupId>org.hamcrest</groupId>
-                   </exclusion>
+                    <exclusion>
+                        <artifactId>hamcrest-core</artifactId>
+                        <groupId>org.hamcrest</groupId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -215,10 +215,10 @@
                 <artifactId>mockito-core</artifactId>
                 <version>1.9.5</version>
                 <exclusions>
-                   <exclusion>
-                      <artifactId>hamcrest-core</artifactId>
-                      <groupId>org.hamcrest</groupId>
-                  </exclusion>
+                    <exclusion>
+                        <artifactId>hamcrest-core</artifactId>
+                        <groupId>org.hamcrest</groupId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -567,14 +567,10 @@
 
     <profiles>
         <profile>
-            <!--  Profile is triggered unless apiDiff property is defined:
-                  always except "apicmp" profile which is disjoint with this profile
-            !-->
+            <!-- Default build profile that runs all modules. -->
             <id>default</id>
             <activation>
-                <property>
-                    <name>!apiDiff</name>
-                </property>
+                <activeByDefault>true</activeByDefault>
             </activation>
             <modules>
                 <module>buildhelpers</module>
@@ -606,6 +602,13 @@
             </modules>
         </profile>
         <profile>
+            <id>release-assemblies</id>
+            <modules>
+                <module>liferay</module>
+                <module>all</module>
+            </modules>
+        </profile>
+        <profile>
             <id>release</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -613,6 +616,28 @@
             <properties>
                 <vaadin.plugin.version>${project.version}</vaadin.plugin.version>
             </properties>
+
+            <!-- Release build only builds artifacts that are deployed or 
+                needed by them -->
+            <modules>
+                <module>buildhelpers</module>
+                <module>shared</module>
+                <module>push</module>
+                <module>server</module>
+                <module>client</module>
+                <module>client-compiler</module>
+                <module>client-compiled</module>
+                <module>themes</module>
+                <module>compatibility-server</module>
+                <module>compatibility-client</module>
+                <module>compatibility-client-compiled</module>
+                <module>compatibility-shared</module>
+                <module>compatibility-themes</module>
+                <module>testbench-api</module>
+                <!-- Nexus staging bug needs the last module to be deployed. -->
+                <module>bom</module>
+            </modules>
+
             <build>
                 <plugins>
                     <plugin>
@@ -658,19 +683,12 @@
             </build>
         </profile>
         <profile>
-            <!--  Profile is triggered if apiDiff property is defined:
-                  this profile is disjoint with default profile.
-                  It allows to prevent running build for all available modules 
-                  but restricts a number of modules to specified here only
-                  (which allows to avoid long time compilation for projects 
-                  that are not needed since japicmp works with compiled classes).
-            !-->
+            <!-- This profile is disjoint with default profile. It allows 
+                to prevent running build for all available modules but restricts a number 
+                of modules to specified here only (which allows to avoid long time compilation 
+                for projects that are not needed since japicmp works with compiled classes). 
+                ! -->
             <id>apicmp</id>
-            <activation>
-                <property>
-                    <name>apiDiff</name>
-                </property>
-            </activation>
             <modules>
                 <module>server</module>
                 <module>push</module>
@@ -722,6 +740,8 @@
             </build>
         </profile>
         <profile>
+            <!-- Testing profile for measurement tests. Use along with default 
+                profile -->
             <id>measurements</id>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -591,17 +591,20 @@
                 <module>compatibility-shared</module>
                 <module>compatibility-themes</module>
                 <module>testbench-api</module>
-                <!-- Nexus staging bug needs the last module to be deployed. -->
                 <module>bom</module>
             </modules>
         </profile>
         <profile>
+            <!-- Profile for running integration tests. Vaadin version to 
+                be tested can be defined with property vaadin.version -->
             <id>slowtest</id>
             <modules>
                 <module>test</module>
             </modules>
         </profile>
         <profile>
+            <!-- This profile builds the assembled parts of the Framework 
+                for website release. Should be run after running the release profile -->
             <id>release-assemblies</id>
             <modules>
                 <module>liferay</module>
@@ -609,16 +612,12 @@
             </modules>
         </profile>
         <profile>
+            <!-- Release build only builds artifacts that are deployed or 
+                needed by them -->
             <id>release</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
             <properties>
                 <vaadin.plugin.version>${project.version}</vaadin.plugin.version>
             </properties>
-
-            <!-- Release build only builds artifacts that are deployed or 
-                needed by them -->
             <modules>
                 <module>buildhelpers</module>
                 <module>shared</module>
@@ -743,9 +742,6 @@
             <!-- Testing profile for measurement tests. Use along with default 
                 profile -->
             <id>measurements</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
             <properties>
                 <skipTests>true</skipTests>
             </properties>

--- a/uitest/pom.xml
+++ b/uitest/pom.xml
@@ -326,7 +326,8 @@
                         <categories.include>${categories.include}</categories.include>
                         <categories.exclude>${categories.exclude}</categories.exclude>
                         <useLocalWebDriver>${useLocalWebDriver}</useLocalWebDriver>
-                        <phantomjs.binary.path>${phantomjs.binary}</phantomjs.binary.path>
+                        <!-- PhantomJS binary downloaded by phantomjs-maven-plugin -->
+<!--                        <phantomjs.binary.path>${phantomjs.binary}</phantomjs.binary.path> -->
                     </systemPropertyVariables>
                     <includes>
                         <include>**/AllTB3Tests.java</include>

--- a/uitest/pom.xml
+++ b/uitest/pom.xml
@@ -311,25 +311,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <skip>${skip.uitest.failsafe}</skip>
-                    <includes>
-                        <include>**/AllTB3Tests.java</include>
-                    </includes>
                     <systemPropertyVariables>
                         <!-- Static path for screenshots pointing to submodule -->
                         <com.vaadin.testbench.screenshot.directory>${project.parent.basedir}/tests/screenshots</com.vaadin.testbench.screenshot.directory>
@@ -342,7 +326,11 @@
                         <categories.include>${categories.include}</categories.include>
                         <categories.exclude>${categories.exclude}</categories.exclude>
                         <useLocalWebDriver>${useLocalWebDriver}</useLocalWebDriver>
+                        <phantomjs.binary.path>${phantomjs.binary}</phantomjs.binary.path>
                     </systemPropertyVariables>
+                    <includes>
+                        <include>**/AllTB3Tests.java</include>
+                    </includes>
                 </configuration>
                 <executions>
                     <execution>
@@ -352,6 +340,19 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
         <pluginManagement>
@@ -406,7 +407,7 @@
                                     <id>start-jetty</id>
                                     <phase>pre-integration-test</phase>
                                     <goals>
-                                        <goal>start</goal>
+                                        <!-- <goal>start</goal> -->
                                     </goals>
                                 </execution>
                                 <execution>
@@ -435,19 +436,8 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                         <configuration>
                             <groups>com.vaadin.testcategory.MeasurementTest</groups>
-                            <systemPropertyVariables>
-                                <phantomjs.binary.path>${phantomjs.binary}</phantomjs.binary.path>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/uitest/pom.xml
+++ b/uitest/pom.xml
@@ -407,7 +407,7 @@
                                     <id>start-jetty</id>
                                     <phase>pre-integration-test</phase>
                                     <goals>
-                                        <!-- <goal>start</goal> -->
+                                        <goal>start</goal>
                                     </goals>
                                 </execution>
                                 <execution>

--- a/uitest/src/test/java/com/vaadin/tests/performance/MemoryIT.java
+++ b/uitest/src/test/java/com/vaadin/tests/performance/MemoryIT.java
@@ -44,11 +44,6 @@ public class MemoryIT extends SingleBrowserTest {
     protected void closeApplication() {
     }
 
-    @Override
-    protected String getScreenshotDirectory() {
-        return ".";
-    }
-
     private long getGridSize(String path, int itemsCount) {
         // Repeat until we get consecutive results within 0.1% of each other
         double lastResult = 0;


### PR DESCRIPTION
This patch is about making profiles for managing parts of the releasing process. Splitting out non-deployed unnecessary modules from the staging build we can make a more reliable configuration for the nexus staging plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8484)
<!-- Reviewable:end -->
