### PR TITLE
Fix absoluteLayoutResizeComponents test for IE8

### DIFF
--- a/uitest/src/test/java/com/vaadin/tests/components/absolutelayout/AbsoluteLayoutResizeComponentsIE8Test.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/absolutelayout/AbsoluteLayoutResizeComponentsIE8Test.java
@@ -17,7 +17,6 @@ import com.vaadin.tests.tb3.MultiBrowserTest;
  */
 public class AbsoluteLayoutResizeComponentsIE8Test extends MultiBrowserTest {
 
-    // Don't test IE8 with this test as it uses auto sizing.
     @Override
     public List<DesiredCapabilities> getBrowsersToTest() {
         return getBrowserCapabilities(Browser.IE8);

--- a/uitest/src/test/java/com/vaadin/tests/components/absolutelayout/AbsoluteLayoutResizeComponentsIE8Test.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/absolutelayout/AbsoluteLayoutResizeComponentsIE8Test.java
@@ -15,13 +15,17 @@ import com.vaadin.tests.tb3.MultiBrowserTest;
 /**
  * Tests for component positioning after width changes from defined to relative and relative to defined
  */
-public class AbsoluteLayoutResizeComponentsTest extends MultiBrowserTest {
+public class AbsoluteLayoutResizeComponentsIE8Test extends MultiBrowserTest {
 
     // Don't test IE8 with this test as it uses auto sizing.
     @Override
     public List<DesiredCapabilities> getBrowsersToTest() {
-        return getBrowserCapabilities(Browser.IE9, Browser.IE10, Browser.IE11,
-                Browser.FIREFOX, Browser.CHROME, Browser.PHANTOMJS);
+        return getBrowserCapabilities(Browser.IE8);
+    }
+
+    @Override
+    protected Class<?> getUIClass() {
+        return AbsoluteLayoutResizeComponents.class;
     }
 
     @Test
@@ -35,26 +39,17 @@ public class AbsoluteLayoutResizeComponentsTest extends MultiBrowserTest {
         Assert.assertNotNull("No wrapper element found for expanding panel [ID: " + componentId + "]", panelWrapper);
 
         String left = panelWrapper.getCssValue("left");
-        Assert.assertEquals(
-                "Component wrapper was missing left:0; from its css positioning",
-                "0px", left);
+        Assert.assertEquals("Component wrapper was missing left:0; from its css positioning", "0px", left);
 
         WebElement panelComponent = findElement(By.id(componentId));
-        Assert.assertEquals("Panel is not on the left side of the screen", 0,
-                panelComponent.getLocation().getX());
+        Assert.assertEquals("Panel is not on the left side of the screen", 0, panelComponent.getLocation().getX());
 
         // Click button to change component size
         $(ButtonElement.class).id(componentId + "-button").click();
 
-        // Not testing "left" here as testing for AUTO doesn't work in chrome
-        // version 40 which calculates the actual left value, testing width
-        // instead of the wrapper instead
-        String width = panelWrapper.getCssValue("width");
-        Assert.assertEquals("Width was more that it should have been.", "250px",
-                width);
-
-        Assert.assertNotEquals("Panel is still on the left side of the screen",
-                0, panelComponent.getLocation().getX());
+        left = panelWrapper.getCssValue("left");
+        Assert.assertEquals("Component wrapper did not have its left positioning reset to auto", "auto", left);
+        Assert.assertNotEquals("Panel is still on the left side of the screen", 0, panelComponent.getLocation().getX());
     }
 
     @Test
@@ -67,29 +62,20 @@ public class AbsoluteLayoutResizeComponentsTest extends MultiBrowserTest {
 
         Assert.assertNotNull("No wrapper element found for panel [ID: " + componentId + "]", panelWrapper);
 
-        String width = panelWrapper.getCssValue("width");
-        Assert.assertEquals("Width was more that it should have been.", "250px",
-                width);
+        String left = panelWrapper.getCssValue("left");
+        Assert.assertEquals("Component wrapper has a set Left marker", "auto", left);
 
         WebElement panelComponent = findElement(By.id(componentId));
-        Assert.assertNotEquals(
-                "Panel is positioned to the left side of the screen", 0,
-                panelComponent.getLocation().getX());
+        Assert.assertNotEquals("Panel is positioned to the left side of the screen", 0, panelComponent.getLocation().getX());
 
         // Click button to change component size
         $(ButtonElement.class).id(componentId + "-button").click();
 
-        String left = panelWrapper.getCssValue("left");
-        Assert.assertEquals(
-                "Component wrapper was missing left:0; from its css positioning",
-                "0px", left);
 
-        width = panelWrapper.getCssValue("width");
-        Assert.assertNotEquals("Width hasn't changed from the initial value.",
-                "250px", width);
+        left = panelWrapper.getCssValue("left");
+        Assert.assertEquals("Component wrapper was missing left:0; from its css positioning", "0px", left);
 
-        Assert.assertEquals("Panel is not on the left side of the screen", 0,
-                panelComponent.getLocation().getX());
+        Assert.assertEquals("Panel is not on the left side of the screen", 0, panelComponent.getLocation().getX());
     }
 
     @Test
@@ -102,29 +88,19 @@ public class AbsoluteLayoutResizeComponentsTest extends MultiBrowserTest {
 
         Assert.assertNotNull("No wrapper element found for AbsoluteLayout [ID: " + componentId + "].", panelWrapper);
 
-        String width = panelWrapper.getCssValue("width");
-        Assert.assertEquals("Width was more that it should have been.", "250px",
-                width);
+        String left = panelWrapper.getCssValue("left");
+        Assert.assertEquals("Component wrapper did not have its left positioning reset to auto", "auto", left);
 
         WebElement panelComponent = findElement(By.id(componentId));
-        Assert.assertNotEquals(
-                "Panel is positioned to the left side of the screen", 0,
-                panelComponent.getLocation().getX());
+        Assert.assertNotEquals("Panel is positioned to the left side of the screen", 0, panelComponent.getLocation().getX());
 
         // Click button to change component size
         $(ButtonElement.class).id(componentId + "-button").click();
 
-        String left = panelWrapper.getCssValue("left");
-        Assert.assertEquals(
-                "Component wrapper was missing left:0; from its css positioning",
-                "0px", left);
+        left = panelWrapper.getCssValue("left");
+        Assert.assertEquals("Component wrapper was missing left:0; from its css positioning", "0px", left);
 
-        width = panelWrapper.getCssValue("width");
-        Assert.assertNotEquals("Width hasn't changed from the initial value.",
-                "250px", width);
-
-        Assert.assertEquals("Panel is not on the left side of the screen", 0,
-                panelComponent.getLocation().getX());
+        Assert.assertEquals("Panel is not on the left side of the screen", 0, panelComponent.getLocation().getX());
     }
 
     /**

--- a/uitest/src/test/java/com/vaadin/tests/components/absolutelayout/AbsoluteLayoutResizeComponentsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/absolutelayout/AbsoluteLayoutResizeComponentsTest.java
@@ -20,8 +20,7 @@ public class AbsoluteLayoutResizeComponentsTest extends MultiBrowserTest {
     // Don't test IE8 with this test as it uses auto sizing.
     @Override
     public List<DesiredCapabilities> getBrowsersToTest() {
-        return getBrowserCapabilities(Browser.IE9, Browser.IE10, Browser.IE11,
-                Browser.FIREFOX, Browser.CHROME, Browser.PHANTOMJS);
+        return getBrowsersExcludingIE8();
     }
 
     @Test


### PR DESCRIPTION
IE8 handles the sizings differently from other tested browsers so it
needs to be tested on 'left: auto' and not wrapper div width.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8497)
<!-- Reviewable:end -->
