### PR TITLE
Delegate Checkbox caption handling to parent

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/checkbox/CheckBoxConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/checkbox/CheckBoxConnector.java
@@ -48,7 +48,7 @@ public class CheckBoxConnector extends AbstractFieldConnector
 
     @Override
     public boolean delegateCaptionHandling() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
I don't know why it had been set to false... Is there any particular reason ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8523)
<!-- Reviewable:end -->
