### PR TITLE
Exclude Firefox for CBG/RBG focus/blur tests

### DIFF
--- a/uitest/src/test/java/com/vaadin/tests/components/checkboxgroup/CheckBoxGroupFocusBlurTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/checkboxgroup/CheckBoxGroupFocusBlurTest.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.vaadin.testbench.elements.CheckBoxGroupElement;
 import com.vaadin.testbench.elements.LabelElement;
@@ -84,5 +85,11 @@ public class CheckBoxGroupFocusBlurTest extends MultiBrowserTest {
         checkBoxes.get(4).sendKeys(Keys.SPACE);
         // no new events
         Assert.assertFalse(logContainsText("4."));
+    }
+
+    @Override
+    public List<DesiredCapabilities> getBrowsersToTest() {
+        // Focus does not move when expected with Selenium/TB and Firefox 45
+        return getBrowsersExcludingFirefox();
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupFocusBlurTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupFocusBlurTest.java
@@ -23,9 +23,10 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
-import com.vaadin.testbench.elements.RadioButtonGroupElement;
 import com.vaadin.testbench.elements.LabelElement;
+import com.vaadin.testbench.elements.RadioButtonGroupElement;
 import com.vaadin.tests.tb3.MultiBrowserTest;
 
 /**
@@ -84,5 +85,11 @@ public class RadioButtonGroupFocusBlurTest extends MultiBrowserTest {
         radioButtons.get(4).sendKeys(Keys.TAB);
         // focus has gone away
         waitUntil(driver -> logContainsText("4. Blur Event"), 5);
+    }
+
+    @Override
+    public List<DesiredCapabilities> getBrowsersToTest() {
+        // Focus does not move when expected with Selenium/TB and Firefox 45
+        return getBrowsersExcludingFirefox();
     }
 }


### PR DESCRIPTION
TestBench commands do not result in same focus behavior as in other
browsers. Focus works in manual tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8560)
<!-- Reviewable:end -->
