### PR TITLE
Simplify setting of TestBench version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,9 @@
         <sonar.analysis.mode>preview</sonar.analysis.mode>
         <sonar.issuesReport.console.enable>true</sonar.issuesReport.console.enable>
         <sonar.issuesReport.html.enable>true</sonar.issuesReport.html.enable>
+
         <vaadin.icons.version>3.0.0</vaadin.icons.version>
+        <vaadin.testbench.version>5.0.0.beta5</vaadin.testbench.version>
     </properties>
 
     <!-- TODO: remove this after maven plugin has been released -->
@@ -235,7 +237,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-testbench</artifactId>
-                <version>5.0.0.beta5</version>
+                <version>${vaadin.testbench.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>

--- a/testbench-api/pom.xml
+++ b/testbench-api/pom.xml
@@ -15,7 +15,7 @@
     <description>Vaadin Framework Element API for TestBench</description>
 
     <properties>
-        <testbench.core.version>5.0.0.beta5</testbench.core.version>
+        <testbench.core.version>${vaadin.testbench.version}</testbench.core.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Now, only vaadin.testbench.version needs to be set for root and BOM
modules, and other modules do not need changes to upgrade TestBench.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8566)
<!-- Reviewable:end -->
