### PR TITLE
Change dependency from TestBench meta package to TestBench core

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -96,7 +96,7 @@
                 <version>${project.version}</version>
             </dependency>
 
-            <!-- AddOn Dependencies -->
+            <!-- Add-on Dependencies -->
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-spring-boot-starter</artifactId>
@@ -114,7 +114,7 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-testbench</artifactId>
+                <artifactId>vaadin-testbench-core</artifactId>
                 <version>${vaadin.testbench.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
The TestBench meta package depends on vaadin-testbench-api but
possibly a different version than what is defined in the bom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8603)
<!-- Reviewable:end -->
