### PR TITLE
Fix NullPointerException sorting columns with null values

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -892,7 +892,14 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
         }
 
         private static boolean hasCommonComparableBaseType(Object a, Object b) {
-            if (a instanceof Comparable<?> && b instanceof Comparable<?>) {
+            if (a instanceof Comparable<?> || b instanceof Comparable<?>) {
+                if (a == null || b == null) {
+                    // "a" or "b" is null, so the other is a Comparable instance
+                    // and in compareComparables(Object, Object) we manage null values
+                    return true;
+                }
+                    
+                // "a" and "b" are Comparables
                 Class<?> aClass = a.getClass();
                 Class<?> bClass = b.getClass();
 

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -899,18 +899,20 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
                     return true;
                 }
                     
-                // "a" and "b" are Comparables
-                Class<?> aClass = a.getClass();
-                Class<?> bClass = b.getClass();
+                if (a instanceof Comparable<?> && b instanceof Comparable<?>) {
 
-                if (aClass == bClass) {
-                    return true;
-                }
+                        Class<?> aClass = a.getClass();
+                        Class<?> bClass = b.getClass();
 
-                Class<?> baseType = ReflectTools.findCommonBaseType(aClass,
+                        if (aClass == bClass) {
+                        return true;
+                        }
+
+                        Class<?> baseType = ReflectTools.findCommonBaseType(aClass,
                         bClass);
-                if (!baseType.isAssignableFrom(Comparable.class)) {
-                    return false;
+                        if (!baseType.isAssignableFrom(Comparable.class)) {
+                                return false;
+                        }
                 }
             }
 

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -887,7 +887,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
             if (hasCommonComparableBaseType(a, b)) {
                 return compareComparables(a, b);
             } else {
-                return compareComparables(a.toString(), b.toString());
+                return compareComparables(Objects.toString(a, null), Objects.toString(b, null));
             }
         }
 


### PR DESCRIPTION
Sorting a column in Grid with renderer having Object as presentationType throws a NullPointerException if there are null values.
In the method "compareMaybeComparables" use "Objects.toString" to avoid NullPointerException.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8605)
<!-- Reviewable:end -->
