### PR TITLE
Fix NPE sorting columns with null values

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -887,7 +887,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
             if (hasCommonComparableBaseType(a, b)) {
                 return compareComparables(a, b);
             } else {
-                return compareComparables(a.toString(), b.toString());
+                return compareComparables(Objects.toString(a, null), Objects.toString(b, null));
             }
         }
 
@@ -905,6 +905,10 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
                 if (!baseType.isAssignableFrom(Comparable.class)) {
                     return false;
                 }
+            }
+            if ((a == null && b instanceof Comparable<?>)
+                || (b == null && a instanceof Comparable<?>)) {
+                return true;
             }
 
             return false;

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -887,7 +887,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
             if (hasCommonComparableBaseType(a, b)) {
                 return compareComparables(a, b);
             } else {
-                return compareComparables(Objects.toString(a, null), Objects.toString(b, null));
+                return compareComparables(Objects.toString(a, ""), Objects.toString(b, ""));
             }
         }
 

--- a/server/src/test/java/com/vaadin/tests/components/grid/GridNullValueSortTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/grid/GridNullValueSortTest.java
@@ -3,6 +3,7 @@ package com.vaadin.tests.components.grid;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vaadin.server.VaadinSession;
 import com.vaadin.tests.util.MockUI;
 import com.vaadin.ui.Grid;
 import com.vaadin.ui.Grid.Column;

--- a/server/src/test/java/com/vaadin/tests/components/grid/GridNullValueSortTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/grid/GridNullValueSortTest.java
@@ -1,0 +1,43 @@
+package com.vaadin.tests.components.grid;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.tests.util.MockUI;
+import com.vaadin.ui.Grid.Column;
+
+public class GridNullValueSortTest {
+
+    private Grid<TestClass> grid;
+    private Column<TestClass, String> stringColumn;
+    private Column<TestClass, Object> nonComparableColumn;
+
+    @Test
+    public void sortWithNullValues() {
+        this.grid.sort(this.stringColumn);
+        this.grid.sort(this.nonComparableColumn);
+        this.grid.getDataCommunicator().beforeClientResponse(true);
+    }
+
+    @Before
+    public void setup() {
+        VaadinSession.setCurrent(null);
+        this.grid = new Grid<TestClass>();
+        this.stringColumn = this.grid.addColumn(bean -> bean.stringField);
+        this.nonComparableColumn = this.grid.addColumn(bean -> bean.nonComparableField);
+
+        this.grid.setItems(new TestClass(null, new Object()), new TestClass("something", null));
+        new MockUI().setContent(grid);
+    }
+
+    private static class TestClass {
+
+        private final String stringField;
+        private final Object nonComparableField;
+
+        TestClass(final String stringField, final Object nonComparableField) {
+            this.stringField = stringField;
+            this.nonComparableField = nonComparableField;
+        }
+    }
+}

--- a/server/src/test/java/com/vaadin/tests/components/grid/GridNullValueSortTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/grid/GridNullValueSortTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.tests.util.MockUI;
+import com.vaadin.ui.Grid;
 import com.vaadin.ui.Grid.Column;
 
 public class GridNullValueSortTest {


### PR DESCRIPTION
Sorting a column in Grid throws a NullPointerException if there are null values and we are using the default TextRenderer.

Modify the method "hasCommonComparableBaseType(Object,Object)" to return true when one Object parameter is null and the other is a Comparable instance.

Modify the method "compareMaybeComparables" to avoid NullPointerException when we need to compare a null with a non-Comparable instance by using its toString representation.

Example code:

```
public class MyBean {
		
	private String fieldWithoutNulls;
	private String fieldWithNulls;
		
	public MyBean(String fieldWithoutNulls, String fieldWithNulls) {
		this.fieldWithoutNulls = fieldWithoutNulls;
		this.fieldWithNulls = fieldWithNulls;
	}
		
	public String getFieldWithoutNulls() {
		return fieldWithoutNulls;
	}
		
	public void setFieldWithoutNulls(String fieldWithoutNulls) {
		this.fieldWithoutNulls = fieldWithoutNulls;
	}
		
	public String getFieldWithNulls() {
		return fieldWithNulls;
	}
		
	public void setFieldWithNulls(String fieldWithNulls) {
		this.fieldWithNulls = fieldWithNulls;
	}
}
```
```
Grid<MyBean> grid = new Grid<>();
Column<MyBean, String> c1 = grid.addColumn(MyBean::getFieldWithoutNulls);
Column<MyBean, String> c2 = grid.addColumn(MyBean::getFieldWithNulls);
layout.addComponent(grid);
grid.setItems(new MyBean("blabla",null),new MyBean("hello","goodbye"));
grid.sort(c1); // ok
grid.sort(c2); // NPE (also if users clicks the column header)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8610)
<!-- Reviewable:end -->
