### PR TITLE
Fix null caption for NativeSelect and ComboBox

### DIFF
--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -240,8 +240,11 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
         registerRpc(new FocusAndBlurServerRpcDecorator(this, this::fireEvent));
 
         addDataGenerator((T data, JsonObject jsonObject) -> {
-            jsonObject.put(DataCommunicatorConstants.NAME,
-                    getItemCaptionGenerator().apply(data));
+            String caption = getItemCaptionGenerator().apply(data);
+            if (caption == null) {
+                caption = "";
+            }
+            jsonObject.put(DataCommunicatorConstants.NAME, caption);
             String style = itemStyleGenerator.apply(data);
             if (style != null) {
                 jsonObject.put(ComboBoxConstants.STYLE, style);

--- a/server/src/main/java/com/vaadin/ui/ItemCaptionGenerator.java
+++ b/server/src/main/java/com/vaadin/ui/ItemCaptionGenerator.java
@@ -36,7 +36,8 @@ public interface ItemCaptionGenerator<T>
      *
      * @param item
      *            the item to get caption for
-     * @return the caption of the item; not {@code null}
+     * @return the caption of the item; {@code null} will be shown as an empty
+     *         string
      */
     @Override
     String apply(T item);

--- a/server/src/main/java/com/vaadin/ui/NativeSelect.java
+++ b/server/src/main/java/com/vaadin/ui/NativeSelect.java
@@ -52,9 +52,13 @@ public class NativeSelect<T> extends AbstractSingleSelect<T>
      */
     public NativeSelect() {
         registerRpc(new FocusAndBlurServerRpcDecorator(this, this::fireEvent));
-        addDataGenerator(
-                (item, json) -> json.put(DataCommunicatorConstants.DATA,
-                        getItemCaptionGenerator().apply(item)));
+        addDataGenerator((item, json) -> {
+            String caption = getItemCaptionGenerator().apply(item);
+            if (caption == null) {
+                caption = "";
+            }
+            json.put(DataCommunicatorConstants.DATA, caption);
+        });
 
         setItemCaptionGenerator(String::valueOf);
     }

--- a/server/src/test/java/com/vaadin/tests/server/component/ItemCaptionGeneratorTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/ItemCaptionGeneratorTest.java
@@ -1,0 +1,85 @@
+package com.vaadin.tests.server.component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.data.provider.DataGenerator;
+import com.vaadin.shared.data.DataCommunicatorConstants;
+import com.vaadin.shared.ui.ListingJsonConstants;
+import com.vaadin.ui.AbstractListing;
+import com.vaadin.ui.CheckBoxGroup;
+import com.vaadin.ui.ComboBox;
+import com.vaadin.ui.ListSelect;
+import com.vaadin.ui.NativeSelect;
+import com.vaadin.ui.RadioButtonGroup;
+import com.vaadin.ui.TwinColSelect;
+
+import elemental.json.JsonObject;
+
+public class ItemCaptionGeneratorTest {
+
+    private static class TestDataGenerator implements DataGenerator<Object> {
+        JsonObject generated = null;
+
+        @Override
+        public void generateData(Object item, JsonObject jsonObject) {
+            generated = jsonObject;
+        }
+
+    }
+
+    @Test
+    public void testItemCaptionGenerator_nullCaptionGiven_convertedToEmptyString() {
+        Collection<AbstractListing<Object>> listings = new ArrayList<>();
+
+        ComboBox<Object> comboBox = new ComboBox<>();
+        comboBox.setData(DataCommunicatorConstants.NAME);
+        comboBox.setItemCaptionGenerator(item -> null);
+        listings.add(comboBox);
+
+        CheckBoxGroup<Object> cbg = new CheckBoxGroup<>();
+        cbg.setData(ListingJsonConstants.JSONKEY_ITEM_VALUE);
+        cbg.setItemCaptionGenerator(item -> null);
+        listings.add(cbg);
+
+        ListSelect<Object> listSelect = new ListSelect<>();
+        listSelect.setData(ListingJsonConstants.JSONKEY_ITEM_VALUE);
+        listSelect.setItemCaptionGenerator(item -> null);
+        listings.add(listSelect);
+
+        NativeSelect<Object> nativeSelect = new NativeSelect<>();
+        nativeSelect.setData(DataCommunicatorConstants.DATA);
+        nativeSelect.setItemCaptionGenerator(item -> null);
+        listings.add(nativeSelect);
+
+        RadioButtonGroup<Object> rbg = new RadioButtonGroup<>();
+        rbg.setData(ListingJsonConstants.JSONKEY_ITEM_VALUE);
+        rbg.setItemCaptionGenerator(item -> null);
+        listings.add(rbg);
+
+        TwinColSelect<Object> tc = new TwinColSelect<>();
+        tc.setData(ListingJsonConstants.JSONKEY_ITEM_VALUE);
+        tc.setItemCaptionGenerator(item -> null);
+        listings.add(tc);
+
+        for (AbstractListing<Object> listing : listings) {
+            listing.setItems("Uno");
+            TestDataGenerator dataGenerator = new TestDataGenerator();
+            listing.getDataCommunicator().addDataGenerator(dataGenerator);
+            listing.getDataCommunicator().beforeClientResponse(true);
+
+            Assert.assertEquals(
+                    listing.getClass().getName()
+                            + " does not convert null caption from generator to empty string",
+                    "",
+                    dataGenerator.generated.hasKey((String) listing.getData())
+                            ? dataGenerator.generated.getString(
+                                    (String) listing.getData())
+                            : null);
+        }
+    }
+
+}


### PR DESCRIPTION
Unified the null caption converting to empty string,
as it was with other selects supporting item caption generator.

Fixes #8630

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8633)
<!-- Reviewable:end -->
