### PR TITLE
Replace usage of getParent() to prevent client side NPE during onUnregister

### DIFF
--- a/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import com.google.gwt.dom.client.DataTransfer;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.client.ComponentConnector;
 import com.vaadin.client.ServerConnector;
 import com.vaadin.event.dnd.DragSourceExtension;
@@ -45,8 +46,15 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
     private final EventListener dragStartListener = this::onDragStart;
     private final EventListener dragEndListener = this::onDragEnd;
 
+    /**
+     * Widget of the drag source component.
+     */
+    private Widget dragSourceWidget;
+
     @Override
     protected void extend(ServerConnector target) {
+        dragSourceWidget = ((ComponentConnector) target).getWidget();
+
         Element dragSourceElement = getDraggableElement();
 
         dragSourceElement.setDraggable(Element.DRAGGABLE_TRUE);
@@ -124,7 +132,7 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * @return the draggable element in the parent widget.
      */
     protected Element getDraggableElement() {
-        return ((ComponentConnector) getParent()).getWidget().getElement();
+        return dragSourceWidget.getElement();
     }
 
     private native void setEffectAllowed(DataTransfer dataTransfer,

--- a/client/src/main/java/com/vaadin/client/extensions/DropTargetExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/DropTargetExtensionConnector.java
@@ -25,6 +25,7 @@ import com.google.gwt.dom.client.BrowserEvents;
 import com.google.gwt.dom.client.DataTransfer;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.client.ComponentConnector;
 import com.vaadin.client.ServerConnector;
 import com.vaadin.event.dnd.DropTargetExtension;
@@ -51,8 +52,15 @@ public class DropTargetExtensionConnector extends AbstractExtensionConnector {
     private final EventListener dragLeaveListener = this::onDragLeave;
     private final EventListener dropListener = this::onDrop;
 
+    /**
+     * Widget of the drop target component.
+     */
+    private Widget dropTargetWidget;
+
     @Override
     protected void extend(ServerConnector target) {
+        dropTargetWidget = ((ComponentConnector) target).getWidget();
+
         EventTarget dropTarget = getDropTargetElement().cast();
 
         // dragenter event
@@ -91,7 +99,7 @@ public class DropTargetExtensionConnector extends AbstractExtensionConnector {
      * @return the drop target element in the parent widget.
      */
     protected Element getDropTargetElement() {
-        return ((ComponentConnector) getParent()).getWidget().getElement();
+        return dropTargetWidget.getElement();
     }
 
     /**


### PR DESCRIPTION
resolves #8646

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8648)
<!-- Reviewable:end -->
