### PR TITLE
Allow powerful Navigator subclassing

### DIFF
--- a/server/src/main/java/com/vaadin/navigator/Navigator.java
+++ b/server/src/main/java/com/vaadin/navigator/Navigator.java
@@ -364,14 +364,14 @@ public class Navigator implements Serializable {
         }
     }
 
-    private UI ui;
-    private NavigationStateManager stateManager;
-    private ViewDisplay display;
-    private View currentView = null;
-    private List<ViewChangeListener> listeners = new LinkedList<>();
-    private List<ViewProvider> providers = new LinkedList<>();
-    private String currentNavigationState = null;
-    private ViewProvider errorProvider;
+    protected UI ui;
+    protected NavigationStateManager stateManager;
+    protected ViewDisplay display;
+    protected View currentView = null;
+    protected List<ViewChangeListener> listeners = new LinkedList<>();
+    protected List<ViewProvider> providers = new LinkedList<>();
+    protected String currentNavigationState = null;
+    protected ViewProvider errorProvider;
 
     /**
      * Creates a navigator that is tracking the active view using URI fragments
@@ -997,7 +997,7 @@ public class Navigator implements Serializable {
      *            state string
      * @return suitable provider
      */
-    private ViewProvider getViewProvider(String state) {
+    protected ViewProvider getViewProvider(String state) {
         String longestViewName = null;
         ViewProvider longestViewNameProvider = null;
         for (ViewProvider provider : providers) {

--- a/server/src/main/java/com/vaadin/navigator/Navigator.java
+++ b/server/src/main/java/com/vaadin/navigator/Navigator.java
@@ -364,14 +364,27 @@ public class Navigator implements Serializable {
         }
     }
 
+    /**
+     * The {@link UI} bound with the Navigator.
+     */
     protected UI ui;
+    
+    /**
+     * The {@link NavigationStateManager} that is used to get, listen to
+     * and manipulate the navigation state used by the Navigator.
+     */
     protected NavigationStateManager stateManager;
+    
+    /**
+     *  The {@link ViewDisplay} used by the Navigator.
+     */
     protected ViewDisplay display;
-    protected View currentView = null;
-    protected List<ViewChangeListener> listeners = new LinkedList<>();
-    protected List<ViewProvider> providers = new LinkedList<>();
-    protected String currentNavigationState = null;
-    protected ViewProvider errorProvider;
+    
+    private View currentView = null;
+    private List<ViewChangeListener> listeners = new LinkedList<>();
+    private List<ViewProvider> providers = new LinkedList<>();
+    private String currentNavigationState = null;
+    private ViewProvider errorProvider;
 
     /**
      * Creates a navigator that is tracking the active view using URI fragments


### PR DESCRIPTION
`protected` methods in `Navigator` permit to create new `Navigator`s to add new capabilities to Vaadin, but `Navigator` fields are still `private` and this limit, for example, the overriding of `Navigator.init`. This PR makes `protected` the `Navigator` fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8663)
<!-- Reviewable:end -->
