### PR TITLE
Fix partial state change handling of JavaScript components

### DIFF
--- a/client/src/main/java/com/vaadin/client/JavaScriptConnectorHelper.java
+++ b/client/src/main/java/com/vaadin/client/JavaScriptConnectorHelper.java
@@ -396,12 +396,6 @@ public class JavaScriptConnectorHelper {
             JavaScriptObject input)
     /*-{
         // Copy all fields to existing state object
-        for(var key in state) {
-            if (state.hasOwnProperty(key)) {
-                delete state[key];
-            }
-        }
-    
         for(var key in input) {
             if (input.hasOwnProperty(key)) {
                 state[key] = input[key];


### PR DESCRIPTION
In ace0e324b69753431dcde9949eaa9b0e3e648db9 (Use diffstate for JS connectors) 
partial state change handling for JavaScript components was introduced, but the
setNativeState method in JavaScriptConnectorHelper was not adjusted.
By removing the cleanup code from the updateNativeState method it can 
be ensured that the non-changed properties are still present on the state object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8691)
<!-- Reviewable:end -->
