### PR TITLE
Fix js state partial updates

### DIFF
--- a/client/src/main/java/com/vaadin/client/JavaScriptConnectorHelper.java
+++ b/client/src/main/java/com/vaadin/client/JavaScriptConnectorHelper.java
@@ -396,12 +396,6 @@ public class JavaScriptConnectorHelper {
             JavaScriptObject input)
     /*-{
         // Copy all fields to existing state object
-        for(var key in state) {
-            if (state.hasOwnProperty(key)) {
-                delete state[key];
-            }
-        }
-    
         for(var key in input) {
             if (input.hasOwnProperty(key)) {
                 state[key] = input[key];

--- a/uitest/src/main/java/com/vaadin/tests/components/javascriptcomponent/JavaScriptStateTracking.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/javascriptcomponent/JavaScriptStateTracking.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.javascriptcomponent;
+
+import com.vaadin.annotations.JavaScript;
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.Constants;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.shared.ui.JavaScriptComponentState;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.AbstractJavaScriptComponent;
+import com.vaadin.ui.Button;
+
+@JavaScript("JavaScriptStateTracking.js")
+@Widgetset(Constants.DEFAULT_WIDGETSET)
+public class JavaScriptStateTracking extends AbstractTestUI {
+
+    public static class StateTrackingComponentState
+            extends JavaScriptComponentState {
+        public int counter = 0;
+        public String field1 = "initial value";
+        public String field2;
+    }
+
+    public static class StateTrackingComponent
+            extends AbstractJavaScriptComponent {
+        @Override
+        protected StateTrackingComponentState getState() {
+            return (StateTrackingComponentState) super.getState();
+        }
+    }
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        StateTrackingComponent stateTrackingComponent = new StateTrackingComponent();
+
+        Button setField2 = new Button("Set field2", e -> {
+            stateTrackingComponent.getState().counter++;
+            stateTrackingComponent.getState().field2 = "updated value "
+                    + stateTrackingComponent.getState().counter;
+        });
+        setField2.setId("setField2");
+
+        Button clearField1 = new Button("Clear field1", e -> {
+            stateTrackingComponent.getState().counter++;
+            stateTrackingComponent.getState().field1 = null;
+        });
+        clearField1.setId("clearField1");
+
+        addComponents(stateTrackingComponent, setField2, clearField1);
+    }
+
+}

--- a/uitest/src/main/resources/com/vaadin/tests/components/javascriptcomponent/JavaScriptStateTracking.js
+++ b/uitest/src/main/resources/com/vaadin/tests/components/javascriptcomponent/JavaScriptStateTracking.js
@@ -1,0 +1,13 @@
+window.com_vaadin_tests_components_javascriptcomponent_JavaScriptStateTracking_StateTrackingComponent = function() {
+	var self = this;
+
+	this.showState = function(state) {
+		this.getElement().innerHTML = 'counter: <span id="counter">' + state.counter + '</span><br>'
+				+ 'field1: <span id="field1">' + state.field1 + '</span><br>'
+				+ 'field2: <span id="field2">' + state.field2 + '</span>';
+	}
+
+	this.onStateChange = function() {
+		this.showState(this.getState());
+	}
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/javascriptcomponent/JavaScriptStateTrackingTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/javascriptcomponent/JavaScriptStateTrackingTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.javascriptcomponent;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.testbench.By;
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class JavaScriptStateTrackingTest extends SingleBrowserTest {
+    @Test
+    public void testStateTracking() {
+        openTestURL();
+
+        // field2 should really be null instead of undefined, but that's a
+        // separate issue
+        assertValues(0, "initial value", "undefined");
+
+        $(ButtonElement.class).id("setField2").click();
+
+        assertValues(1, "initial value", "updated value 1");
+
+        $(ButtonElement.class).id("clearField1").click();
+
+        assertValues(2, "null", "updated value 1");
+
+        $(ButtonElement.class).id("setField2").click();
+
+        assertValues(3, "null", "updated value 3");
+    }
+
+    private void assertValues(int expectedCounter, String expectedField1,
+            String expectedField2) {
+        Assert.assertEquals(String.valueOf(expectedCounter),
+                findElement(By.id("counter")).getText());
+        Assert.assertEquals(String.valueOf(expectedField1),
+                findElement(By.id("field1")).getText());
+        Assert.assertEquals(String.valueOf(expectedField2),
+                findElement(By.id("field2")).getText());
+    }
+}


### PR DESCRIPTION
#7853 updated JavaScript connectors to only send shared state changes instead of sending the full state for every change. That patch failed to remove some client-side logic that assumed that each state change always contains all properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8695)
<!-- Reviewable:end -->
