### PR TITLE
Always load the deferred connector bundle

### DIFF
--- a/client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -48,8 +48,6 @@ import com.vaadin.client.debug.internal.TestBenchSection;
 import com.vaadin.client.debug.internal.VDebugWindow;
 import com.vaadin.client.debug.internal.theme.DebugWindowStyles;
 import com.vaadin.client.event.PointerEventSupport;
-import com.vaadin.client.metadata.BundleLoadCallback;
-import com.vaadin.client.metadata.ConnectorBundleLoader;
 import com.vaadin.client.metadata.NoDataException;
 import com.vaadin.client.metadata.TypeData;
 import com.vaadin.client.ui.UnknownComponentConnector;
@@ -662,22 +660,6 @@ public class ApplicationConfiguration implements EntryPoint {
                 cmd.execute();
             }
             callbacks.clear();
-        } else if (dependenciesLoading == 0 && !ConnectorBundleLoader.get()
-                .isBundleLoaded(ConnectorBundleLoader.DEFERRED_BUNDLE_NAME)) {
-            ConnectorBundleLoader.get().loadBundle(
-                    ConnectorBundleLoader.DEFERRED_BUNDLE_NAME,
-                    new BundleLoadCallback() {
-                        @Override
-                        public void loaded() {
-                            // Nothing to do
-                        }
-
-                        @Override
-                        public void failed(Throwable reason) {
-                            getLogger().log(Level.SEVERE,
-                                    "Error loading deferred bundle", reason);
-                        }
-                    });
         }
     }
 

--- a/client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -58,6 +58,7 @@ import com.vaadin.client.VConsole;
 import com.vaadin.client.ValueMap;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.extensions.AbstractExtensionConnector;
+import com.vaadin.client.metadata.ConnectorBundleLoader;
 import com.vaadin.client.metadata.NoDataException;
 import com.vaadin.client.metadata.Property;
 import com.vaadin.client.metadata.Type;
@@ -564,6 +565,8 @@ public class MessageHandler {
 
                 endRequestIfResponse(json);
                 resumeResponseHandling(lock);
+
+                ConnectorBundleLoader.get().ensureDeferredBundleLoaded();
 
                 if (Profiler.isEnabled()) {
                     Scheduler.get().scheduleDeferred(new ScheduledCommand() {

--- a/client/src/main/java/com/vaadin/client/metadata/ConnectorBundleLoader.java
+++ b/client/src/main/java/com/vaadin/client/metadata/ConnectorBundleLoader.java
@@ -17,7 +17,10 @@ package com.vaadin.client.metadata;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.shared.GWT;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Display;
@@ -207,5 +210,50 @@ public abstract class ConnectorBundleLoader {
         s.setWhiteSpace(WhiteSpace.NORMAL);
         s.setVisibility(Visibility.VISIBLE);
         s.setMargin(0, Unit.PX);
+    }
+
+    /**
+     * Starts loading the deferred bundle if it hasn't already been started.
+     */
+    public void ensureDeferredBundleLoaded() {
+        if (!isBundleLoaded(DEFERRED_BUNDLE_NAME)) {
+            loadBundle(DEFERRED_BUNDLE_NAME, new BundleLoadCallback() {
+                @Override
+                public void loaded() {
+                    // Nothing to do
+                }
+
+                @Override
+                public void failed(Throwable reason) {
+                    getLogger().log(Level.SEVERE,
+                            "Error loading deferred bundle", reason);
+                }
+            });
+        }
+    }
+
+    private static Logger getLogger() {
+        return Logger.getLogger(ConnectorBundleLoader.class.getName());
+    }
+
+    /**
+     * Gets a list of all currently loaded bundle names.
+     * <p>
+     * This method is intended for testing the loading mechanism.
+     *
+     * @return a list of bundles, not <code>null</code>
+     */
+    public List<String> getLoadedBundles() {
+        ArrayList<String> bundles = new ArrayList<>();
+
+        JsArrayString keys = asyncBlockLoaders.getKeys();
+        for (int i = 0; i < keys.length(); i++) {
+            String bundleName = keys.get(i);
+            if (isBundleLoaded(bundleName)) {
+                bundles.add(bundleName);
+            }
+        }
+
+        return bundles;
     }
 }

--- a/uitest/src/main/java/com/vaadin/tests/application/ConnectorBundleStatus.java
+++ b/uitest/src/main/java/com/vaadin/tests/application/ConnectorBundleStatus.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.application;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.tests.widgetset.TestingWidgetSet;
+import com.vaadin.tests.widgetset.server.ConnectorBundleStatusDisplay;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.RichTextArea;
+
+@Widgetset(TestingWidgetSet.NAME)
+public class ConnectorBundleStatus extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        ConnectorBundleStatusDisplay statusDisplay = new ConnectorBundleStatusDisplay();
+        statusDisplay.setId("bundleStatus");
+
+        Button refreshButton = new Button("Refresh status",
+                e -> statusDisplay.updateStatus());
+        refreshButton.setId("refresh");
+
+        Button rtaButton = new Button("Add RichTextArea (in the lazy bundle)",
+                e -> addComponent(new RichTextArea()));
+        rtaButton.setId("rta");
+
+        addComponents(statusDisplay, refreshButton, rtaButton);
+    }
+
+}

--- a/uitest/src/main/java/com/vaadin/tests/application/InitiallyDeferredLoading.java
+++ b/uitest/src/main/java/com/vaadin/tests/application/InitiallyDeferredLoading.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.application;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.tests.widgetset.TestingWidgetSet;
+import com.vaadin.tests.widgetset.server.DeferredComponent;
+
+@Widgetset(TestingWidgetSet.NAME)
+public class InitiallyDeferredLoading extends AbstractTestUI {
+    @Override
+    protected void setup(VaadinRequest request) {
+        DeferredComponent deferredComponent = new DeferredComponent();
+        deferredComponent.setId("deferred");
+
+        addComponent(deferredComponent);
+    }
+
+    @Override
+    public String getTestDescription() {
+        return "This UI contains a component from the deferred bundle. "
+                + "It should still be visible as soon as the UI is loaded.";
+    }
+
+}

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/ConnectorBundleStatusDisplayConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/ConnectorBundleStatusDisplayConnector.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.widgetset.client;
+
+import java.util.List;
+
+import com.google.gwt.user.client.ui.Label;
+import com.vaadin.client.metadata.ConnectorBundleLoader;
+import com.vaadin.client.ui.AbstractComponentConnector;
+import com.vaadin.shared.ui.Connect;
+import com.vaadin.tests.widgetset.server.ConnectorBundleStatusDisplay;
+
+@Connect(ConnectorBundleStatusDisplay.class)
+public class ConnectorBundleStatusDisplayConnector extends AbstractComponentConnector {
+    @Override
+    public Label getWidget() {
+        return (Label) super.getWidget();
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        registerRpc(ConnectorBundleStatusRpc.class,
+                new ConnectorBundleStatusRpc() {
+                    @Override
+                    public void updateStatus() {
+                        ConnectorBundleStatusDisplayConnector.this.updateStatus();
+                    }
+                });
+
+        updateStatus();
+    }
+
+    private void updateStatus() {
+        List<String> bundles = ConnectorBundleLoader.get().getLoadedBundles();
+        getWidget().setText(bundles.toString());
+    }
+}

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/ConnectorBundleStatusRpc.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/ConnectorBundleStatusRpc.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.widgetset.client;
+
+import com.vaadin.shared.communication.ClientRpc;
+
+public interface ConnectorBundleStatusRpc extends ClientRpc {
+    public void updateStatus();
+}

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/DeferredConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/DeferredConnector.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.widgetset.client;
+
+import com.google.gwt.user.client.ui.Label;
+import com.vaadin.client.ui.AbstractComponentConnector;
+import com.vaadin.shared.ui.Connect;
+import com.vaadin.shared.ui.Connect.LoadStyle;
+import com.vaadin.tests.widgetset.server.DeferredComponent;
+
+@Connect(value = DeferredComponent.class, loadStyle = LoadStyle.DEFERRED)
+public class DeferredConnector extends AbstractComponentConnector {
+    @Override
+    protected void init() {
+        super.init();
+
+        getWidget().setText("DeferredConnector");
+    }
+
+    @Override
+    public Label getWidget() {
+        return (Label) super.getWidget();
+    }
+}

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/server/ConnectorBundleStatusDisplay.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/server/ConnectorBundleStatusDisplay.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.widgetset.server;
+
+import com.vaadin.tests.widgetset.client.ConnectorBundleStatusRpc;
+import com.vaadin.ui.AbstractComponent;
+
+public class ConnectorBundleStatusDisplay extends AbstractComponent {
+
+    public ConnectorBundleStatusDisplay() {
+        setCaption("Loaded bundles");
+    }
+
+    public void updateStatus() {
+        getRpcProxy(ConnectorBundleStatusRpc.class).updateStatus();
+    }
+}

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/server/DeferredComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/server/DeferredComponent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.widgetset.server;
+
+import com.vaadin.ui.AbstractComponent;
+
+public class DeferredComponent extends AbstractComponent {
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/application/ConnectorBundleStatusTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/application/ConnectorBundleStatusTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.application;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.testbench.By;
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class ConnectorBundleStatusTest extends SingleBrowserTest {
+
+    @Test
+    public void testConnectorBundleLoading() {
+        openTestURL();
+
+        assertLoaded("__eager");
+
+        $(ButtonElement.class).id("refresh").click();
+
+        assertLoaded("__eager", "__deferred");
+
+        $(ButtonElement.class).id("rta").click();
+        $(ButtonElement.class).id("refresh").click();
+
+        assertLoaded("__eager", "__deferred",
+                "com.vaadin.client.ui.richtextarea.RichTextAreaConnector");
+    }
+
+    private void assertLoaded(String... expectedNames) {
+        String bundleStatus = findElement(By.id("bundleStatus")).getText();
+        Assert.assertEquals(Arrays.asList(expectedNames).toString(),
+                bundleStatus);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/application/InitiallyDeferredLoadingTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/application/InitiallyDeferredLoadingTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.application;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class InitiallyDeferredLoadingTest extends SingleBrowserTest {
+    @Test
+    public void testInitiallyDeferredComponent() {
+        openTestURL();
+
+        WebElement deferredComponent = findElement(By.id("deferred"));
+
+        Assert.assertEquals("DeferredConnector", deferredComponent.getText());
+    }
+}


### PR DESCRIPTION
endDependencyLoading that was used for starting to load the deferred
connector bundle is only called during regular application init if the
theme wasn't yet loaded when the initial UIDL request finished.

With this patch, the bundle is instead set to be loaded after the
initial UIDL message has been completely processed.

Fixes #4763

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8713)
<!-- Reviewable:end -->
