### PR TITLE
Fixes client-side error when Upload in TabSheet and Push (#8728)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VUpload.java
+++ b/client/src/main/java/com/vaadin/client/ui/VUpload.java
@@ -267,10 +267,12 @@ public class VUpload extends SimplePanel {
                             t.cancel();
                         }
                         VConsole.log("VUpload:Submit complete");
-                        ((UploadConnector) ConnectorMap.get(client)
-                                .getConnector(VUpload.this))
-                                        .getRpcProxy(UploadServerRpc.class)
-                                        .poll();
+                        if (isAttached()) {
+                            // no need to call poll() if component is already
+                            // detached #8728
+                            ((UploadConnector) ConnectorMap.get(client).getConnector(VUpload.this))
+                                .getRpcProxy(UploadServerRpc.class).poll();
+                        }
                     }
 
                     rebuildPanel();

--- a/uitest/src/main/java/com/vaadin/tests/components/upload/UploadInTabsheet.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/upload/UploadInTabsheet.java
@@ -1,0 +1,41 @@
+package com.vaadin.tests.components.upload;
+
+import java.io.ByteArrayOutputStream;
+
+import com.vaadin.annotations.Push;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractReindeerTestUI;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.TabSheet;
+import com.vaadin.ui.Upload;
+
+/**
+ * Test UI for case where Upload is in a TabSheet and Tab is changed directly
+ * after Upload Succeed
+ */
+@Push
+public class UploadInTabsheet extends AbstractReindeerTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        TabSheet t = new TabSheet();
+        Upload upload = new Upload("Upload", (filename, mimeType) -> new
+            ByteArrayOutputStream());
+        upload.setImmediateMode(false);
+        upload.addSucceededListener(event -> upload.getUI().access(()->{
+                t.setSelectedTab(1);
+            }));
+        upload.setWidthUndefined();
+
+        t.addComponent(upload);
+        t.addComponent(new Label("Second tab"));
+
+        addComponent(t);
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 8728;
+    }
+
+}

--- a/uitest/src/main/java/com/vaadin/tests/components/upload/UploadInTabsheet.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/upload/UploadInTabsheet.java
@@ -1,0 +1,40 @@
+package com.vaadin.tests.components.upload;
+
+import java.io.ByteArrayOutputStream;
+
+import com.vaadin.annotations.Push;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractReindeerTestUI;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.TabSheet;
+import com.vaadin.ui.Upload;
+
+/**
+ * Test UI for case where Upload is in a TabSheet and Tab is changed directly
+ * after Upload Succeed
+ */
+@Push
+public class UploadInTabsheet extends AbstractReindeerTestUI {
+
+    @Override protected void setup(VaadinRequest request) {
+        TabSheet t = new TabSheet();
+        Upload upload = new Upload("Upload", (filename, mimeType) -> new
+            ByteArrayOutputStream());
+        upload.setImmediateMode(false);
+        upload.addSucceededListener(event -> upload.getUI().access(()->{
+                t.setSelectedTab(1);
+            }));
+        upload.setWidthUndefined();
+
+        t.addComponent(upload);
+        t.addComponent(new Label("Second tab"));
+
+        addComponent(t);
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 8728;
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/upload/UploadInTabsheetTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/upload/UploadInTabsheetTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.upload;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.internal.WrapsElement;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebElement;
+
+import com.vaadin.testbench.elements.UploadElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+/**
+ * Verifies that there's no client side errors when changing a tab containing
+ * Upload right after uploading is succeeded (#8728)
+ */
+public class UploadInTabsheetTest extends MultiBrowserTest {
+
+    @Override
+    public List<DesiredCapabilities> getBrowsersToTest() {
+        // PhantomJS fails to upload files for unknown reasons
+        return getBrowsersExcludingPhantomJS();
+    }
+
+    @Test
+    public void testThatChangingTabAfterUploadDoesntCauseErrors()
+        throws Exception {
+        setDebug(true);
+        openTestURL();
+
+        File tempFile = createTempFile();
+        fillPathToUploadInput(tempFile.getPath());
+
+        getSubmitButton().click();
+
+        assertNoErrorNotifications();
+    }
+
+    /**
+     * @return The generated temp file handle
+     * @throws IOException
+     */
+    private File createTempFile() throws IOException {
+        File tempFile = File.createTempFile("TestFileUpload", ".txt");
+        BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
+        writer.write(getTempFileContents());
+        writer.close();
+        tempFile.deleteOnExit();
+        return tempFile;
+    }
+
+    private String getTempFileContents() {
+        return "This is a test file!\nRow 2\nRow3";
+    }
+
+    private void fillPathToUploadInput(String tempFileName) throws Exception {
+        // create a valid path in upload input element. Instead of selecting a
+        // file by some file browsing dialog, we use the local path directly.
+        WebElement input = getInput();
+        setLocalFileDetector(input);
+        input.sendKeys(tempFileName);
+    }
+
+    private WebElement getSubmitButton() {
+        UploadElement upload = $(UploadElement.class).first();
+        WebElement submitButton = upload.findElement(By.className("v-button"));
+        return submitButton;
+    }
+
+    private WebElement getInput() {
+        return getDriver().findElement(By.className("gwt-FileUpload"));
+    }
+
+    private void setLocalFileDetector(WebElement element) throws Exception {
+        if (getRunLocallyBrowser() != null) {
+            return;
+        }
+
+        if (element instanceof WrapsElement) {
+            element = ((WrapsElement) element).getWrappedElement();
+        }
+        if (element instanceof RemoteWebElement) {
+            ((RemoteWebElement) element)
+                    .setFileDetector(new LocalFileDetector());
+        } else {
+            throw new IllegalArgumentException(
+                    "Expected argument of type RemoteWebElement, received "
+                            + element.getClass().getName());
+        }
+    }
+}


### PR DESCRIPTION
A client side error happened when Tabsheet's tab containing a Upload is changed
 after upload succeeds and if Push is used. This happened since
 UploadSuccessEvent is emitted on the server-side right after the streaming is
 finished. After that client-side receives response and does deferred call to
 UploadServerRpc.poll(). When Push is used and component is detached after
 UploadSuccessEvent (e.g. by changing the tab) that deferred call happens too
 late causing NPE since UploadConnector is already null. It should be safe to
 just not call UploadServerRpc.poll() since the Upload component is already
 detached and that poll() call is anyway NOP on server-side. Thus, we decided
 add if (isAttached()) check to that part of code, another possibility would
 have been added a null check.

Change-Id: If4ec387a23443685879ceb6fee5b0b1ea0a98d31

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8735)
<!-- Reviewable:end -->
