### PR TITLE
Make all selected rows draggable

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridDragSourceExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridDragSourceExtensionConnector.java
@@ -15,19 +15,28 @@
  */
 package com.vaadin.client.connectors.grid;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.TableRowElement;
 import com.vaadin.client.ServerConnector;
 import com.vaadin.client.extensions.DragSourceExtensionConnector;
 import com.vaadin.client.widget.escalator.RowContainer;
+import com.vaadin.client.widget.grid.selection.SelectionModel;
 import com.vaadin.client.widgets.Escalator;
+import com.vaadin.client.widgets.Grid;
 import com.vaadin.shared.Range;
 import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.ui.grid.GridDragSourceExtensionState;
 import com.vaadin.ui.GridDragSourceExtension;
 
 import elemental.events.Event;
+import elemental.json.Json;
+import elemental.json.JsonArray;
 import elemental.json.JsonObject;
+import elemental.json.JsonValue;
 
 /**
  * Adds HTML5 drag and drop functionality to a {@link com.vaadin.client.widgets.Grid
@@ -66,11 +75,71 @@ public class GridDragSourceExtensionConnector extends
 
             JsonObject rowData = gridConnector.getDataSource().getRow(rowIndex);
 
+            // Generate drag data. Dragged row or all the selected rows
+            JsonValue dragData = dragMultipleRows(rowData) ? toJsonArray(
+                    getSelectedRows().stream().map(this::getDragData)
+                            .collect(Collectors.toList()))
+                    : getDragData(rowData);
+
             // Set drag data in DataTransfer object
             ((NativeEvent) event).getDataTransfer()
                     .setData(GridDragSourceExtensionState.DATA_TYPE_DRAG_DATA,
-                            getDragData(rowData).toJson());
+                            dragData.toJson());
         }
+    }
+
+    /**
+     * Tells if multiple rows are dragged. Returns true if multiple selection is
+     * allowed and a selected row is dragged.
+     *
+     * @param draggedRow
+     *         Data of dragged row.
+     * @return {@code true} if multiple rows are dragged, {@code false}
+     * otherwise.
+     */
+    private boolean dragMultipleRows(JsonObject draggedRow) {
+        SelectionModel<JsonObject> selectionModel = getGrid()
+                .getSelectionModel();
+        return selectionModel.isSelectionAllowed()
+                && selectionModel instanceof MultiSelectionModelConnector.MultiSelectionModel
+                && selectionModel.isSelected(draggedRow);
+    }
+
+    /**
+     * Collects the data of all selected rows.
+     *
+     * @return List of data of all selected rows.
+     */
+    private List<JsonObject> getSelectedRows() {
+        List<JsonObject> rows = new ArrayList<>();
+
+        SelectionModel<JsonObject> selectionModel = getGrid()
+                .getSelectionModel();
+
+        int size = gridConnector.getDataSource().size();
+        for (int i = 0; i < size; i++) {
+            JsonObject row = gridConnector.getDataSource().getRow(i);
+            if (selectionModel.isSelected(row)) {
+                rows.add(row);
+            }
+        }
+
+        return rows;
+    }
+
+    /**
+     * Converts a list of {@link JsonObject}s to a {@link JsonArray}.
+     *
+     * @param objects
+     *         List of json objects.
+     * @return Json array containing all json objects.
+     */
+    private JsonArray toJsonArray(List<JsonObject> objects) {
+        JsonArray array = Json.createArray();
+        for (int i = 0; i < objects.size(); i++) {
+            array.set(i, objects.get(i));
+        }
+        return array;
     }
 
     /**
@@ -104,8 +173,12 @@ public class GridDragSourceExtensionConnector extends
         getGridBody().setNewEscalatorRowCallback(null);
     }
 
+    private Grid<JsonObject> getGrid() {
+        return gridConnector.getWidget();
+    }
+
     private Escalator getEscalator() {
-        return gridConnector.getWidget().getEscalator();
+        return getGrid().getEscalator();
     }
 
     private RowContainer.BodyRowContainer getGridBody() {

--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridDragSourceExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridDragSourceExtensionConnector.java
@@ -77,7 +77,7 @@ public class GridDragSourceExtensionConnector extends
 
             // Generate drag data. Dragged row or all the selected rows
             JsonValue dragData = dragMultipleRows(rowData) ? toJsonArray(
-                    getSelectedRows().stream().map(this::getDragData)
+                    getSelectedVisibleRows().stream().map(this::getDragData)
                             .collect(Collectors.toList()))
                     : getDragData(rowData);
 
@@ -106,25 +106,32 @@ public class GridDragSourceExtensionConnector extends
     }
 
     /**
-     * Collects the data of all selected rows.
+     * Collects the data of all selected visible rows.
      *
-     * @return List of data of all selected rows.
+     * @return List of data of all selected visible rows.
      */
-    private List<JsonObject> getSelectedRows() {
-        List<JsonObject> rows = new ArrayList<>();
+    private List<JsonObject> getSelectedVisibleRows() {
+        return getSelectedRowsInRange(getEscalator().getVisibleRowRange());
+    }
 
-        SelectionModel<JsonObject> selectionModel = getGrid()
-                .getSelectionModel();
+    /**
+     * Get all selected rows from a subset of rows defined by {@code range}.
+     *
+     * @param range
+     *         Range of indexes.
+     * @return List of data of all selected rows in the given range.
+     */
+    private List<JsonObject> getSelectedRowsInRange(Range range) {
+        List<JsonObject> selectedRows = new ArrayList<>();
 
-        int size = gridConnector.getDataSource().size();
-        for (int i = 0; i < size; i++) {
+        for (int i = range.getStart(); i < range.getEnd(); i++) {
             JsonObject row = gridConnector.getDataSource().getRow(i);
-            if (selectionModel.isSelected(row)) {
-                rows.add(row);
+            if (SelectionModel.isItemSelected(row)) {
+                selectedRows.add(row);
             }
         }
 
-        return rows;
+        return selectedRows;
     }
 
     /**

--- a/server/src/main/java/com/vaadin/ui/GridDragSourceExtension.java
+++ b/server/src/main/java/com/vaadin/ui/GridDragSourceExtension.java
@@ -26,6 +26,9 @@ import elemental.json.JsonObject;
 
 /**
  * Makes a Grid's rows draggable for HTML5 drag and drop functionality.
+ * <p>
+ * When selection mode is {@link com.vaadin.ui.Grid.SelectionMode#MULTI}, the
+ * currently visible rows are dragged.
  *
  * @param <T>
  *         The Grid bean type.

--- a/server/src/main/java/com/vaadin/ui/GridDragSourceExtension.java
+++ b/server/src/main/java/com/vaadin/ui/GridDragSourceExtension.java
@@ -27,8 +27,8 @@ import elemental.json.JsonObject;
 /**
  * Makes a Grid's rows draggable for HTML5 drag and drop functionality.
  * <p>
- * When selection mode is {@link com.vaadin.ui.Grid.SelectionMode#MULTI}, the
- * currently visible rows are dragged.
+ * When dragging a selected row, all the visible selected rows are dragged. Note
+ * that ONLY visible rows are taken into account.
  *
  * @param <T>
  *         The Grid bean type.

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridDragAndDrop.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridDragAndDrop.java
@@ -42,6 +42,8 @@ public class GridDragAndDrop extends AbstractTestUIWithLog {
         dragSourceComponent.addColumn(Bean::getId).setCaption("ID");
         dragSourceComponent.addColumn(Bean::getValue).setCaption("Value");
 
+        dragSourceComponent.setSelectionMode(Grid.SelectionMode.MULTI);
+
         GridDragSourceExtension<Bean> dragSource = new GridDragSourceExtension<>(
                 dragSourceComponent);
         dragSource.setDragDataGenerator(bean -> {

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridDragAndDrop.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridDragAndDrop.java
@@ -16,13 +16,16 @@
 package com.vaadin.tests.components.grid;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import com.vaadin.annotations.Widgetset;
 import com.vaadin.event.dnd.DropTargetExtension;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.shared.ui.grid.GridDragSourceExtensionState;
 import com.vaadin.tests.components.AbstractTestUIWithLog;
+import com.vaadin.ui.ComboBox;
 import com.vaadin.ui.Grid;
 import com.vaadin.ui.GridDragSourceExtension;
 import com.vaadin.ui.HorizontalLayout;
@@ -32,6 +35,7 @@ import com.vaadin.ui.Layout;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 
+@Widgetset("com.vaadin.DefaultWidgetSet")
 public class GridDragAndDrop extends AbstractTestUIWithLog {
     @Override
     protected void setup(VaadinRequest request) {
@@ -41,8 +45,6 @@ public class GridDragAndDrop extends AbstractTestUIWithLog {
         dragSourceComponent.setItems(createItems(50));
         dragSourceComponent.addColumn(Bean::getId).setCaption("ID");
         dragSourceComponent.addColumn(Bean::getValue).setCaption("Value");
-
-        dragSourceComponent.setSelectionMode(Grid.SelectionMode.MULTI);
 
         GridDragSourceExtension<Bean> dragSource = new GridDragSourceExtension<>(
                 dragSourceComponent);
@@ -64,7 +66,17 @@ public class GridDragAndDrop extends AbstractTestUIWithLog {
         Layout layout = new HorizontalLayout();
         layout.addComponents(dragSourceComponent, dropTargetComponent);
 
-        addComponent(layout);
+        // Selection mode combo box
+        ComboBox<Grid.SelectionMode> selectionModeSwitch = new ComboBox<>(
+                "Change selection mode");
+        selectionModeSwitch.setItems(Arrays.asList(Grid.SelectionMode.SINGLE,
+                Grid.SelectionMode.MULTI));
+        selectionModeSwitch.setEmptySelectionAllowed(false);
+        selectionModeSwitch.addValueChangeListener(event -> dragSourceComponent
+                .setSelectionMode(event.getValue()));
+        selectionModeSwitch.setSelectedItem(Grid.SelectionMode.SINGLE);
+
+        addComponents(selectionModeSwitch, layout);
     }
 
     private List<Bean> createItems(int num) {


### PR DESCRIPTION
Resolves  #8397

If selection mode is `MULTI` and dragged row is selected, collect all other selected rows and create a json array of their drag data.

Is it a good idea to iterate through all the rows to look for selected ones? On the client side there doesn't seem to be a method that returns them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8746)
<!-- Reviewable:end -->
