### PR TITLE
Avoid double unregister of columns on the client side

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
@@ -148,7 +148,7 @@ public class GridConnector extends AbstractListingConnector
     /**
      * Method called for a row details refresh. Runs all callbacks if any
      * details were shown and clears the callbacks.
-     * 
+     *
      * @param detailsShown
      *            True if any details were set visible
      */
@@ -177,7 +177,7 @@ public class GridConnector extends AbstractListingConnector
     /**
      * Add a single use details runnable callback for when we get a call to
      * {@link #detailsRefreshed(boolean)}.
-     * 
+     *
      * @param refreshCallback
      *            Details refreshed callback
      */
@@ -187,7 +187,7 @@ public class GridConnector extends AbstractListingConnector
 
     /**
      * Check if we have details for given row.
-     * 
+     *
      * @param rowIndex
      * @return
      */
@@ -211,8 +211,9 @@ public class GridConnector extends AbstractListingConnector
                 // Add details refresh listener and handle possible detail for
                 // scrolled row.
                 addDetailsRefreshCallback(() -> {
-                    if (rowHasDetails(row))
+                    if (rowHasDetails(row)) {
                         getWidget().scrollToRow(row, destination);
+                    }
                 });
             }
 
@@ -227,8 +228,9 @@ public class GridConnector extends AbstractListingConnector
                 Scheduler.get()
                         .scheduleFinally(() -> getWidget().scrollToEnd());
                 addDetailsRefreshCallback(() -> {
-                    if (rowHasDetails(getWidget().getDataSource().size() - 1))
+                    if (rowHasDetails(getWidget().getDataSource().size() - 1)) {
                         getWidget().scrollToEnd();
+                    }
                 });
             }
         });
@@ -429,8 +431,6 @@ public class GridConnector extends AbstractListingConnector
     @Override
     public void onUnregister() {
         super.onUnregister();
-
-        columnToIdMap.clear();
     }
 
     @Override

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridDetach.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridDetach.java
@@ -1,0 +1,32 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.tests.data.bean.Person;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Grid;
+
+/**
+ * This UI is the application entry point. A UI may either represent a browser
+ * window (or tab) or some part of a html page where a Vaadin application is
+ * embedded.
+ * <p>
+ * The UI is initialized using {@link #init(VaadinRequest)}. This method is
+ * intended to be overridden to add component to the user interface and
+ * initialize non-component functionality.
+ */
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class GridDetach extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest vaadinRequest) {
+        Grid<Person> grid = new Grid<>();
+        grid.addColumn(Person::getFirstName).setCaption("asd");
+        grid.addColumn(Person::getAge).setCaption("foobar");
+
+        addComponent(grid);
+        addComponent(new Button("Detach grid", e -> removeComponent(grid)));
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridDetachTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridDetachTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.grid;
+
+import org.junit.Test;
+
+import com.vaadin.testbench.By;
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class GridDetachTest extends SingleBrowserTest {
+
+    @Test
+    public void gridDetachesWithoutErrors() {
+        openTestURL("debug");
+        $(ButtonElement.class).first().click();
+
+        assertElementNotPresent(By.className("v-grid"));
+        assertNoErrorNotifications();
+    }
+}


### PR DESCRIPTION
Columns unregister themselves from the grid through removeColumn, also
when the whole grid is removed.

Fixes #8748

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8749)
<!-- Reviewable:end -->
