### PR TITLE
Fix warning: '_' should not be used as an identifier

### DIFF
--- a/uitest/src/test/java/com/vaadin/v7/tests/components/grid/basicfeatures/server/GridSortingTest.java
+++ b/uitest/src/test/java/com/vaadin/v7/tests/components/grid/basicfeatures/server/GridSortingTest.java
@@ -58,11 +58,11 @@ public class GridSortingTest extends GridBasicFeaturesTest {
         }
     }
 
-    private static SortInfo _(int sortOrder, SortDirection sortDirection) {
+    private static SortInfo getSortInfo(int sortOrder, SortDirection sortDirection) {
         return new SortInfo(sortOrder, sortDirection);
     }
 
-    private static SortInfoWithColumn _(int columnIndex, int sortOrder,
+    private static SortInfoWithColumn getSortInfo(int columnIndex, int sortOrder,
             SortDirection sortDirection) {
         return new SortInfoWithColumn(columnIndex, sortOrder, sortDirection);
     }
@@ -79,7 +79,7 @@ public class GridSortingTest extends GridBasicFeaturesTest {
 
         // Verify that programmatic sorting calls are identified as originating
         // from API
-        assertColumnsAreSortedAs(_(9, 1, SortDirection.DESCENDING));
+        assertColumnsAreSortedAs(getSortInfo(9, 1, SortDirection.DESCENDING));
 
         String row = "";
         for (int i = 0; i < 3; ++i) {
@@ -99,7 +99,7 @@ public class GridSortingTest extends GridBasicFeaturesTest {
                 getGridElement().getHeaderCell(0, 9).getAttribute("class")
                         .contains("sort-desc"));
 
-        assertColumnsAreSortedAs(_(10, 1, SortDirection.ASCENDING));
+        assertColumnsAreSortedAs(getSortInfo(10, 1, SortDirection.ASCENDING));
 
         for (int i = 0; i < 5; ++i) {
             Integer firstRow = Integer
@@ -126,7 +126,7 @@ public class GridSortingTest extends GridBasicFeaturesTest {
                 getGridElement().getHeaderCell(0, 10).getAttribute("class")
                         .contains("sort-asc"));
 
-        assertColumnsAreSortedAs(_(7, 1, SortDirection.DESCENDING));
+        assertColumnsAreSortedAs(getSortInfo(7, 1, SortDirection.DESCENDING));
     }
 
     @Test
@@ -147,9 +147,9 @@ public class GridSortingTest extends GridBasicFeaturesTest {
 
         assertLastSortIsUserOriginated(true);
 
-        assertColumnsAreSortedAs(_(9, 1, SortDirection.ASCENDING));
+        assertColumnsAreSortedAs(getSortInfo(9, 1, SortDirection.ASCENDING));
         clickHeader(grid.getHeaderCell(0, 9));
-        assertColumnsAreSortedAs(_(9, 1, SortDirection.DESCENDING));
+        assertColumnsAreSortedAs(getSortInfo(9, 1, SortDirection.DESCENDING));
 
         // First cells for first 3 rows are (9, 0), (99, 0) and (999, 0)
         String row = "";
@@ -166,7 +166,7 @@ public class GridSortingTest extends GridBasicFeaturesTest {
         // Column 10 is random numbers from Random with seed 13334
         // Click header to sort ascending
         clickHeader(grid.getHeaderCell(0, 10));
-        assertColumnsAreSortedAs(_(10, 1, SortDirection.ASCENDING));
+        assertColumnsAreSortedAs(getSortInfo(10, 1, SortDirection.ASCENDING));
 
         for (int i = 0; i < 5; ++i) {
             Integer firstRow = Integer
@@ -184,9 +184,9 @@ public class GridSortingTest extends GridBasicFeaturesTest {
         // 2, 1 and 0.
         // Click header twice to sort descending
         clickHeader(grid.getHeaderCell(0, 7));
-        assertColumnsAreSortedAs(_(7, 1, SortDirection.ASCENDING));
+        assertColumnsAreSortedAs(getSortInfo(7, 1, SortDirection.ASCENDING));
         clickHeader(grid.getHeaderCell(0, 7));
-        assertColumnsAreSortedAs(_(7, 1, SortDirection.DESCENDING));
+        assertColumnsAreSortedAs(getSortInfo(7, 1, SortDirection.DESCENDING));
 
         for (int i = 0; i < 3; ++i) {
             assertEquals(
@@ -257,7 +257,7 @@ public class GridSortingTest extends GridBasicFeaturesTest {
         // Sort ASCENDING on first column
         sendKey(Keys.ENTER);
         assertLastSortIsUserOriginated(true);
-        assertColumnsAreSortedAs(_(1, SortDirection.ASCENDING));
+        assertColumnsAreSortedAs(getSortInfo(1, SortDirection.ASCENDING));
 
         // Move to next column
         sendKey(Keys.RIGHT);
@@ -266,8 +266,8 @@ public class GridSortingTest extends GridBasicFeaturesTest {
         holdKey(Keys.SHIFT);
         sendKey(Keys.ENTER);
         releaseKey(Keys.SHIFT);
-        assertColumnsAreSortedAs(_(1, SortDirection.ASCENDING),
-                _(2, SortDirection.ASCENDING));
+        assertColumnsAreSortedAs(getSortInfo(1, SortDirection.ASCENDING),
+        		getSortInfo(2, SortDirection.ASCENDING));
 
         // Move to next column
         sendKey(Keys.RIGHT);
@@ -276,8 +276,8 @@ public class GridSortingTest extends GridBasicFeaturesTest {
         holdKey(Keys.SHIFT);
         sendKey(Keys.ENTER);
         releaseKey(Keys.SHIFT);
-        assertColumnsAreSortedAs(_(1, SortDirection.ASCENDING),
-                _(2, SortDirection.ASCENDING), _(3, SortDirection.ASCENDING));
+        assertColumnsAreSortedAs(getSortInfo(1, SortDirection.ASCENDING),
+        		getSortInfo(2, SortDirection.ASCENDING), getSortInfo(3, SortDirection.ASCENDING));
 
         // Move back to the second column
         sendKey(Keys.LEFT);
@@ -286,22 +286,22 @@ public class GridSortingTest extends GridBasicFeaturesTest {
         holdKey(Keys.SHIFT);
         sendKey(Keys.ENTER);
         releaseKey(Keys.SHIFT);
-        assertColumnsAreSortedAs(_(1, SortDirection.ASCENDING),
-                _(2, SortDirection.DESCENDING), _(3, SortDirection.ASCENDING));
+        assertColumnsAreSortedAs(getSortInfo(1, SortDirection.ASCENDING),
+        		getSortInfo(2, SortDirection.DESCENDING), getSortInfo(3, SortDirection.ASCENDING));
 
         // Move back to the third column
         sendKey(Keys.RIGHT);
 
         // Set sorting to third column, ASCENDING
         sendKey(Keys.ENTER);
-        assertColumnsAreSortedAs(_(2, 1, SortDirection.ASCENDING));
+        assertColumnsAreSortedAs(getSortInfo(2, 1, SortDirection.ASCENDING));
 
         // Move to the fourth column
         sendKey(Keys.RIGHT);
 
         // Make sure that single-column sorting also works as expected
         sendKey(Keys.ENTER);
-        assertColumnsAreSortedAs(_(3, 1, SortDirection.ASCENDING));
+        assertColumnsAreSortedAs(getSortInfo(3, 1, SortDirection.ASCENDING));
 
     }
 


### PR DESCRIPTION
Changing test method name to be not underscore '_', since it is reserved keyword for lambda expressions in Java 8.

Please note in Java 9, underscore is disallowed at all, https://bugs.openjdk.java.net/browse/JDK-8061549

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8755)
<!-- Reviewable:end -->
