### PR TITLE
Update getting-started-idea.asciidoc

### DIFF
--- a/documentation/getting-started/getting-started-idea.asciidoc
+++ b/documentation/getting-started/getting-started-idea.asciidoc
@@ -84,7 +84,7 @@ launch a Vaadin Maven application on the light-weight Jetty web server.
 
 . Select "Run > Edit Configurations".
 
-. Click [guibutton]#+# and select menu:Maven[] to create a new Maven run/debug configuration.
+. Click [guibutton]#+# and select [guilabel]#Maven# to create a new Maven run/debug configuration.
 
 . Enter a [guilabel]#Name# for the run configuration.
 For the [guilabel]#Command line#, enter "`package jetty:run`# to first compile and package the project, and then launch Jetty to run it.


### PR DESCRIPTION
At https://vaadin.com/docs/-/part/framework/getting-started/getting-started-idea.html the word "maven" looks broken because it gets a .menu classname which has position:absolute. I changed it to guilabel, just like most similar text around it is using.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8756)
<!-- Reviewable:end -->
