### PR TITLE
Remove extra line before package declaration

### DIFF
--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/ArraySerializer.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/ArraySerializer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.widgetsetutils.metadata;
 
 import com.google.gwt.core.ext.TreeLogger;

--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/ClientRpcVisitor.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/ClientRpcVisitor.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.widgetsetutils.metadata;
 
 import java.util.Set;

--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/CustomSerializer.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/CustomSerializer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.widgetsetutils.metadata;
 
 import com.google.gwt.core.client.GWT;

--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/EnumSerializer.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/EnumSerializer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.widgetsetutils.metadata;
 
 import com.google.gwt.core.ext.TreeLogger;

--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/FieldProperty.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/FieldProperty.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.widgetsetutils.metadata;
 
 import java.lang.annotation.Annotation;

--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/GeneratedSerializer.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/GeneratedSerializer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.widgetsetutils.metadata;
 
 import com.google.gwt.core.ext.TreeLogger;

--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/JsonSerializer.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/JsonSerializer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.widgetsetutils.metadata;
 
 import com.google.gwt.core.ext.TreeLogger;

--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/MethodProperty.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/MethodProperty.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.widgetsetutils.metadata;
 
 import java.lang.annotation.Annotation;

--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/Property.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/Property.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.widgetsetutils.metadata;
 
 import java.lang.annotation.Annotation;

--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/ServerRpcVisitor.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/metadata/ServerRpcVisitor.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.widgetsetutils.metadata;
 
 import java.util.Set;

--- a/client-compiler/src/main/java/com/vaadin/tools/CvalAddonsChecker.java
+++ b/client-compiler/src/main/java/com/vaadin/tools/CvalAddonsChecker.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tools;
 
 import static com.vaadin.tools.CvalChecker.LINE;

--- a/client-compiler/src/main/java/com/vaadin/tools/CvalChecker.java
+++ b/client-compiler/src/main/java/com/vaadin/tools/CvalChecker.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tools;
 
 import static java.lang.Integer.parseInt;

--- a/client-compiler/src/test/java/com/vaadin/tools/CvalAddonsCheckerTest.java
+++ b/client-compiler/src/test/java/com/vaadin/tools/CvalAddonsCheckerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tools;
 
 import static com.vaadin.tools.CvalAddonsChecker.VAADIN_AGPL;

--- a/client-compiler/src/test/java/com/vaadin/tools/CvalAddonstCheckerUseCasesTest.java
+++ b/client-compiler/src/test/java/com/vaadin/tools/CvalAddonstCheckerUseCasesTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tools;
 
 import static com.vaadin.tools.CvalAddonsChecker.VAADIN_AGPL;

--- a/client-compiler/src/test/java/com/vaadin/tools/CvalCheckerTest.java
+++ b/client-compiler/src/test/java/com/vaadin/tools/CvalCheckerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tools;
 
 import static com.vaadin.tools.CvalAddonsChecker.VAADIN_ADDON_LICENSE;

--- a/client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.util.HashMap;

--- a/client/src/main/java/com/vaadin/client/BrowserInfo.java
+++ b/client/src/main/java/com/vaadin/client/BrowserInfo.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import com.google.gwt.user.client.ui.RootPanel;

--- a/client/src/main/java/com/vaadin/client/ComponentConnector.java
+++ b/client/src/main/java/com/vaadin/client/ComponentConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/ContainerResizedListener.java
+++ b/client/src/main/java/com/vaadin/client/ContainerResizedListener.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 /**

--- a/client/src/main/java/com/vaadin/client/DateTimeService.java
+++ b/client/src/main/java/com/vaadin/client/DateTimeService.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.util.Date;

--- a/client/src/main/java/com/vaadin/client/FastStringMap.java
+++ b/client/src/main/java/com/vaadin/client/FastStringMap.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import com.google.gwt.core.client.JavaScriptObject;

--- a/client/src/main/java/com/vaadin/client/HasComponentsConnector.java
+++ b/client/src/main/java/com/vaadin/client/HasComponentsConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.util.List;

--- a/client/src/main/java/com/vaadin/client/JavaScriptConnectorHelper.java
+++ b/client/src/main/java/com/vaadin/client/JavaScriptConnectorHelper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/JavaScriptExtension.java
+++ b/client/src/main/java/com/vaadin/client/JavaScriptExtension.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import com.vaadin.client.communication.HasJavaScriptConnectorHelper;

--- a/client/src/main/java/com/vaadin/client/JsArrayObject.java
+++ b/client/src/main/java/com/vaadin/client/JsArrayObject.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import com.google.gwt.core.client.JavaScriptObject;

--- a/client/src/main/java/com/vaadin/client/LocaleNotLoadedException.java
+++ b/client/src/main/java/com/vaadin/client/LocaleNotLoadedException.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 @SuppressWarnings("serial")

--- a/client/src/main/java/com/vaadin/client/LocaleService.java
+++ b/client/src/main/java/com/vaadin/client/LocaleService.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.util.HashMap;

--- a/client/src/main/java/com/vaadin/client/Paintable.java
+++ b/client/src/main/java/com/vaadin/client/Paintable.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 /**

--- a/client/src/main/java/com/vaadin/client/Profiler.java
+++ b/client/src/main/java/com/vaadin/client/Profiler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ResourceLoader.java
+++ b/client/src/main/java/com/vaadin/client/ResourceLoader.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.util.Collection;

--- a/client/src/main/java/com/vaadin/client/SimpleTree.java
+++ b/client/src/main/java/com/vaadin/client/SimpleTree.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import com.google.gwt.dom.client.Document;

--- a/client/src/main/java/com/vaadin/client/StyleConstants.java
+++ b/client/src/main/java/com/vaadin/client/StyleConstants.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 public class StyleConstants {

--- a/client/src/main/java/com/vaadin/client/UIDL.java
+++ b/client/src/main/java/com/vaadin/client/UIDL.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.util.HashSet;

--- a/client/src/main/java/com/vaadin/client/Util.java
+++ b/client/src/main/java/com/vaadin/client/Util.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/VCaption.java
+++ b/client/src/main/java/com/vaadin/client/VCaption.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.util.logging.Logger;

--- a/client/src/main/java/com/vaadin/client/VCaptionWrapper.java
+++ b/client/src/main/java/com/vaadin/client/VCaptionWrapper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import com.google.gwt.user.client.ui.FlowPanel;

--- a/client/src/main/java/com/vaadin/client/VErrorMessage.java
+++ b/client/src/main/java/com/vaadin/client/VErrorMessage.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/VLoadingIndicator.java
+++ b/client/src/main/java/com/vaadin/client/VLoadingIndicator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/WidgetSet.java
+++ b/client/src/main/java/com/vaadin/client/WidgetSet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.util.logging.Level;

--- a/client/src/main/java/com/vaadin/client/WidgetUtil.java
+++ b/client/src/main/java/com/vaadin/client/WidgetUtil.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client;
 
 import java.io.Serializable;

--- a/client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
+++ b/client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.communication;
 
 import java.util.logging.Logger;

--- a/client/src/main/java/com/vaadin/client/communication/HasJavaScriptConnectorHelper.java
+++ b/client/src/main/java/com/vaadin/client/communication/HasJavaScriptConnectorHelper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.communication;
 
 import com.vaadin.client.JavaScriptConnectorHelper;

--- a/client/src/main/java/com/vaadin/client/communication/JSONSerializer.java
+++ b/client/src/main/java/com/vaadin/client/communication/JSONSerializer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.communication;
 
 import com.vaadin.client.ApplicationConnection;

--- a/client/src/main/java/com/vaadin/client/communication/JavaScriptMethodInvocation.java
+++ b/client/src/main/java/com/vaadin/client/communication/JavaScriptMethodInvocation.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.communication;
 
 import com.vaadin.shared.communication.MethodInvocation;

--- a/client/src/main/java/com/vaadin/client/communication/JsonDecoder.java
+++ b/client/src/main/java/com/vaadin/client/communication/JsonDecoder.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.communication;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/communication/JsonEncoder.java
+++ b/client/src/main/java/com/vaadin/client/communication/JsonEncoder.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.communication;
 
 import java.util.Collection;

--- a/client/src/main/java/com/vaadin/client/communication/PushConnection.java
+++ b/client/src/main/java/com/vaadin/client/communication/PushConnection.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.communication;
 
 import com.google.gwt.user.client.Command;

--- a/client/src/main/java/com/vaadin/client/communication/RpcManager.java
+++ b/client/src/main/java/com/vaadin/client/communication/RpcManager.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.communication;
 
 import java.util.Collection;

--- a/client/src/main/java/com/vaadin/client/connectors/grid/AbstractGridRendererConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/AbstractGridRendererConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.connectors.grid;
 
 import com.vaadin.client.ServerConnector;

--- a/client/src/main/java/com/vaadin/client/data/AbstractRemoteDataSource.java
+++ b/client/src/main/java/com/vaadin/client/data/AbstractRemoteDataSource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.data;
 
 import java.util.HashMap;

--- a/client/src/main/java/com/vaadin/client/data/CacheStrategy.java
+++ b/client/src/main/java/com/vaadin/client/data/CacheStrategy.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.data;
 
 import com.vaadin.shared.Range;

--- a/client/src/main/java/com/vaadin/client/data/DataChangeHandler.java
+++ b/client/src/main/java/com/vaadin/client/data/DataChangeHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.data;
 
 /**

--- a/client/src/main/java/com/vaadin/client/data/DataSource.java
+++ b/client/src/main/java/com/vaadin/client/data/DataSource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.data;
 
 import java.util.function.Consumer;

--- a/client/src/main/java/com/vaadin/client/debug/internal/ErrorNotificationHandler.java
+++ b/client/src/main/java/com/vaadin/client/debug/internal/ErrorNotificationHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.debug.internal;
 
 import java.util.logging.Handler;

--- a/client/src/main/java/com/vaadin/client/debug/internal/Icon.java
+++ b/client/src/main/java/com/vaadin/client/debug/internal/Icon.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.debug.internal;
 
 public enum Icon {

--- a/client/src/main/java/com/vaadin/client/debug/internal/InfoSection.java
+++ b/client/src/main/java/com/vaadin/client/debug/internal/InfoSection.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.debug.internal;
 
 import java.util.List;

--- a/client/src/main/java/com/vaadin/client/debug/internal/SelectorPath.java
+++ b/client/src/main/java/com/vaadin/client/debug/internal/SelectorPath.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.debug.internal;
 
 import java.util.HashMap;

--- a/client/src/main/java/com/vaadin/client/extensions/AbstractExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/AbstractExtensionConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.extensions;
 
 import com.vaadin.client.ServerConnector;

--- a/client/src/main/java/com/vaadin/client/extensions/BrowserWindowOpenerConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/BrowserWindowOpenerConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.extensions;
 
 import java.util.Map.Entry;

--- a/client/src/main/java/com/vaadin/client/extensions/FileDownloaderConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/FileDownloaderConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.extensions;
 
 import com.google.gwt.dom.client.Document;

--- a/client/src/main/java/com/vaadin/client/extensions/ResponsiveConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/ResponsiveConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.extensions;
 
 import java.util.logging.Level;

--- a/client/src/main/java/com/vaadin/client/extensions/javascriptmanager/JavaScriptManagerConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/javascriptmanager/JavaScriptManagerConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.extensions.javascriptmanager;
 
 import java.util.HashSet;

--- a/client/src/main/java/com/vaadin/client/metadata/InvokationHandler.java
+++ b/client/src/main/java/com/vaadin/client/metadata/InvokationHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.metadata;
 
 public interface InvokationHandler {

--- a/client/src/main/java/com/vaadin/client/metadata/NoDataException.java
+++ b/client/src/main/java/com/vaadin/client/metadata/NoDataException.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.metadata;
 
 public class NoDataException extends Exception {

--- a/client/src/main/java/com/vaadin/client/metadata/ProxyHandler.java
+++ b/client/src/main/java/com/vaadin/client/metadata/ProxyHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.metadata;
 
 public interface ProxyHandler {

--- a/client/src/main/java/com/vaadin/client/ui/Action.java
+++ b/client/src/main/java/com/vaadin/client/ui/Action.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.user.client.Command;

--- a/client/src/main/java/com/vaadin/client/ui/CalendarEntry.java
+++ b/client/src/main/java/com/vaadin/client/ui/CalendarEntry.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.Date;

--- a/client/src/main/java/com/vaadin/client/ui/ImageIcon.java
+++ b/client/src/main/java/com/vaadin/client/ui/ImageIcon.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.core.client.Scheduler;

--- a/client/src/main/java/com/vaadin/client/ui/ShortcutActionHandler.java
+++ b/client/src/main/java/com/vaadin/client/ui/ShortcutActionHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ui/TreeAction.java
+++ b/client/src/main/java/com/vaadin/client/ui/TreeAction.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 /**

--- a/client/src/main/java/com/vaadin/client/ui/UnknownComponentConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/UnknownComponentConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.core.client.GWT;

--- a/client/src/main/java/com/vaadin/client/ui/VAbstractCalendarPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractCalendarPanel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.Date;

--- a/client/src/main/java/com/vaadin/client/ui/VAbstractDateFieldCalendar.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractDateFieldCalendar.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.event.dom.client.DomEvent;

--- a/client/src/main/java/com/vaadin/client/ui/VAbstractPopupCalendar.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractPopupCalendar.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.Date;

--- a/client/src/main/java/com/vaadin/client/ui/VAbstractSplitPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractSplitPanel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.Collections;

--- a/client/src/main/java/com/vaadin/client/ui/VAbstractTextualDate.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractTextualDate.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.Date;

--- a/client/src/main/java/com/vaadin/client/ui/VAudio.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAudio.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.AudioElement;

--- a/client/src/main/java/com/vaadin/client/ui/VButton.java
+++ b/client/src/main/java/com/vaadin/client/ui/VButton.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.aria.client.Roles;

--- a/client/src/main/java/com/vaadin/client/ui/VCheckBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCheckBox.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/ui/VCheckBoxGroup.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCheckBoxGroup.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ui/VComboBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VComboBox.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ui/VContextMenu.java
+++ b/client/src/main/java/com/vaadin/client/ui/VContextMenu.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.core.client.Scheduler;

--- a/client/src/main/java/com/vaadin/client/ui/VCssLayout.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCssLayout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.user.client.ui.FlowPanel;

--- a/client/src/main/java/com/vaadin/client/ui/VCustomComponent.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCustomComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.user.client.ui.SimplePanel;

--- a/client/src/main/java/com/vaadin/client/ui/VCustomLayout.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCustomLayout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.HashMap;

--- a/client/src/main/java/com/vaadin/client/ui/VDateField.java
+++ b/client/src/main/java/com/vaadin/client/ui/VDateField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.Date;

--- a/client/src/main/java/com/vaadin/client/ui/VDragAndDropWrapperIE.java
+++ b/client/src/main/java/com/vaadin/client/ui/VDragAndDropWrapperIE.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.AnchorElement;

--- a/client/src/main/java/com/vaadin/client/ui/VEmbedded.java
+++ b/client/src/main/java/com/vaadin/client/ui/VEmbedded.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.HashMap;

--- a/client/src/main/java/com/vaadin/client/ui/VFormLayout.java
+++ b/client/src/main/java/com/vaadin/client/ui/VFormLayout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ui/VGridLayout.java
+++ b/client/src/main/java/com/vaadin/client/ui/VGridLayout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.HashMap;

--- a/client/src/main/java/com/vaadin/client/ui/VLabel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VLabel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.user.client.Event;

--- a/client/src/main/java/com/vaadin/client/ui/VLink.java
+++ b/client/src/main/java/com/vaadin/client/ui/VLink.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/ui/VMediaBase.java
+++ b/client/src/main/java/com/vaadin/client/ui/VMediaBase.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.Document;

--- a/client/src/main/java/com/vaadin/client/ui/VNativeButton.java
+++ b/client/src/main/java/com/vaadin/client/ui/VNativeButton.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/ui/VNotification.java
+++ b/client/src/main/java/com/vaadin/client/ui/VNotification.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ui/VOverlay.java
+++ b/client/src/main/java/com/vaadin/client/ui/VOverlay.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.logging.Logger;

--- a/client/src/main/java/com/vaadin/client/ui/VPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VPanel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.DivElement;

--- a/client/src/main/java/com/vaadin/client/ui/VPasswordField.java
+++ b/client/src/main/java/com/vaadin/client/ui/VPasswordField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.user.client.DOM;

--- a/client/src/main/java/com/vaadin/client/ui/VProgressBar.java
+++ b/client/src/main/java/com/vaadin/client/ui/VProgressBar.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/ui/VRadioButtonGroup.java
+++ b/client/src/main/java/com/vaadin/client/ui/VRadioButtonGroup.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ui/VRichTextArea.java
+++ b/client/src/main/java/com/vaadin/client/ui/VRichTextArea.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ui/VSplitPanelHorizontal.java
+++ b/client/src/main/java/com/vaadin/client/ui/VSplitPanelHorizontal.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.Style.Overflow;

--- a/client/src/main/java/com/vaadin/client/ui/VSplitPanelVertical.java
+++ b/client/src/main/java/com/vaadin/client/ui/VSplitPanelVertical.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.Style.Overflow;

--- a/client/src/main/java/com/vaadin/client/ui/VTabsheet.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTabsheet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.Iterator;

--- a/client/src/main/java/com/vaadin/client/ui/VTabsheetPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTabsheetPanel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/ui/VTextArea.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTextArea.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/ui/VTextField.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTextField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ui/VUI.java
+++ b/client/src/main/java/com/vaadin/client/ui/VUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ui/VUnknownComponent.java
+++ b/client/src/main/java/com/vaadin/client/ui/VUnknownComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.user.client.ui.Composite;

--- a/client/src/main/java/com/vaadin/client/ui/VUpload.java
+++ b/client/src/main/java/com/vaadin/client/ui/VUpload.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.core.client.GWT;

--- a/client/src/main/java/com/vaadin/client/ui/VVideo.java
+++ b/client/src/main/java/com/vaadin/client/ui/VVideo.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import com.google.gwt.dom.client.Document;

--- a/client/src/main/java/com/vaadin/client/ui/VWindow.java
+++ b/client/src/main/java/com/vaadin/client/ui/VWindow.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui;
 
 import static com.vaadin.client.WidgetUtil.isFocusedElementEditable;

--- a/client/src/main/java/com/vaadin/client/ui/aria/AriaHelper.java
+++ b/client/src/main/java/com/vaadin/client/ui/aria/AriaHelper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.aria;
 
 import com.google.gwt.aria.client.Id;

--- a/client/src/main/java/com/vaadin/client/ui/aria/HandlesAriaCaption.java
+++ b/client/src/main/java/com/vaadin/client/ui/aria/HandlesAriaCaption.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.aria;
 
 /**

--- a/client/src/main/java/com/vaadin/client/ui/aria/HandlesAriaInvalid.java
+++ b/client/src/main/java/com/vaadin/client/ui/aria/HandlesAriaInvalid.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.aria;
 
 /**

--- a/client/src/main/java/com/vaadin/client/ui/aria/HandlesAriaRequired.java
+++ b/client/src/main/java/com/vaadin/client/ui/aria/HandlesAriaRequired.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.aria;
 
 /**

--- a/client/src/main/java/com/vaadin/client/ui/button/ButtonConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/button/ButtonConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.button;
 
 import com.google.gwt.event.dom.client.ClickEvent;

--- a/client/src/main/java/com/vaadin/client/ui/datefield/AbstractTextualDateConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/datefield/AbstractTextualDateConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.datefield;
 
 import com.vaadin.client.ApplicationConnection;

--- a/client/src/main/java/com/vaadin/client/ui/datefield/PopupDateFieldConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/datefield/PopupDateFieldConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.datefield;
 
 import com.vaadin.shared.ui.Connect;

--- a/client/src/main/java/com/vaadin/client/ui/datefield/PopupDateTimeFieldConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/datefield/PopupDateTimeFieldConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.datefield;
 
 import com.vaadin.shared.ui.Connect;

--- a/client/src/main/java/com/vaadin/client/ui/datefield/TextualDateConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/datefield/TextualDateConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.datefield;
 
 import java.util.Date;

--- a/client/src/main/java/com/vaadin/client/ui/embedded/EmbeddedConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/embedded/EmbeddedConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.embedded;
 
 import java.util.Map;

--- a/client/src/main/java/com/vaadin/client/ui/layout/ElementResizeListener.java
+++ b/client/src/main/java/com/vaadin/client/ui/layout/ElementResizeListener.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.layout;
 
 public interface ElementResizeListener {

--- a/client/src/main/java/com/vaadin/client/ui/link/LinkConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/link/LinkConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.link;
 
 import com.google.gwt.dom.client.Style.Display;

--- a/client/src/main/java/com/vaadin/client/ui/loginform/LoginFormConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/loginform/LoginFormConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.loginform;
 
 import com.google.gwt.core.client.Scheduler;

--- a/client/src/main/java/com/vaadin/client/ui/loginform/VLoginForm.java
+++ b/client/src/main/java/com/vaadin/client/ui/loginform/VLoginForm.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.loginform;
 
 import com.google.gwt.user.client.ui.FormPanel;

--- a/client/src/main/java/com/vaadin/client/ui/menubar/MenuBar.java
+++ b/client/src/main/java/com/vaadin/client/ui/menubar/MenuBar.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.menubar;
 
 /*

--- a/client/src/main/java/com/vaadin/client/ui/menubar/MenuItem.java
+++ b/client/src/main/java/com/vaadin/client/ui/menubar/MenuItem.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.menubar;
 
 /*

--- a/client/src/main/java/com/vaadin/client/ui/nativeselect/NativeSelectConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/nativeselect/NativeSelectConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.nativeselect;
 
 import com.google.gwt.event.shared.HandlerRegistration;

--- a/client/src/main/java/com/vaadin/client/ui/optiongroup/CheckBoxGroupConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/optiongroup/CheckBoxGroupConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.optiongroup;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ui/optiongroup/RadioButtonGroupConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/optiongroup/RadioButtonGroupConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.optiongroup;
 
 import java.util.ArrayList;

--- a/client/src/main/java/com/vaadin/client/ui/orderedlayout/CaptionPosition.java
+++ b/client/src/main/java/com/vaadin/client/ui/orderedlayout/CaptionPosition.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.orderedlayout;
 
 /**

--- a/client/src/main/java/com/vaadin/client/ui/orderedlayout/Slot.java
+++ b/client/src/main/java/com/vaadin/client/ui/orderedlayout/Slot.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.orderedlayout;
 
 import java.util.List;

--- a/client/src/main/java/com/vaadin/client/ui/textarea/TextAreaConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/textarea/TextAreaConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.textarea;
 
 import com.google.gwt.dom.client.Style;

--- a/client/src/main/java/com/vaadin/client/ui/upload/UploadConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/upload/UploadConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.upload;
 
 import com.google.gwt.event.dom.client.ChangeEvent;

--- a/client/src/main/java/com/vaadin/client/widget/escalator/ColumnConfiguration.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/ColumnConfiguration.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.widget.escalator;
 
 import java.util.Map;

--- a/client/src/main/java/com/vaadin/client/widget/escalator/EscalatorUpdater.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/EscalatorUpdater.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.widget.escalator;
 
 import com.vaadin.client.widgets.Escalator;

--- a/client/src/main/java/com/vaadin/client/widget/escalator/PositionFunction.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/PositionFunction.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.widget.escalator;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/widget/escalator/Row.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/Row.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.widget.escalator;
 
 import com.google.gwt.dom.client.TableRowElement;

--- a/client/src/main/java/com/vaadin/client/widget/escalator/RowContainer.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/RowContainer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.widget.escalator;
 
 import com.google.gwt.dom.client.Element;

--- a/client/src/main/java/com/vaadin/client/widget/escalator/RowVisibilityChangeEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/RowVisibilityChangeEvent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.widget.escalator;
 
 import com.google.gwt.event.shared.GwtEvent;

--- a/client/src/main/java/com/vaadin/client/widget/escalator/RowVisibilityChangeHandler.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/RowVisibilityChangeHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.widget.escalator;
 
 import com.google.gwt.event.shared.EventHandler;

--- a/client/src/main/java/com/vaadin/client/widget/escalator/ScrollbarBundle.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/ScrollbarBundle.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.widget.escalator;
 
 import com.google.gwt.animation.client.AnimationScheduler;

--- a/client/src/main/java/com/vaadin/client/widgets/Overlay.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Overlay.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.widgets;
 
 import java.util.ArrayList;

--- a/client/src/test/java/com/vaadin/client/ui/grid/PartitioningTest.java
+++ b/client/src/test/java/com/vaadin/client/ui/grid/PartitioningTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.client.ui.grid;
 
 import static org.junit.Assert.assertEquals;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/GridConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/GridConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.connectors;
 
 import java.util.ArrayList;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/RpcDataSourceConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/RpcDataSourceConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.connectors;
 
 import java.util.ArrayList;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCalendarPanel.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCalendarPanel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.Date;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCheckBox.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCheckBox.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import com.google.gwt.dom.client.Element;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCustomComponent.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCustomComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import com.google.gwt.user.client.ui.SimplePanel;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VDateField.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VDateField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.Date;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VDateFieldCalendar.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VDateFieldCalendar.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.Date;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VFilterSelect.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VFilterSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.ArrayList;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VForm.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VForm.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import com.google.gwt.dom.client.Element;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VLabel.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VLabel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import com.google.gwt.user.client.Event;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VListSelect.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VListSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.ArrayList;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VNativeSelect.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VNativeSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.ArrayList;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VOptionGroup.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VOptionGroup.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.ArrayList;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VOptionGroupBase.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VOptionGroupBase.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.Set;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VPasswordField.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VPasswordField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import com.google.gwt.user.client.DOM;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VPopupCalendar.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VPopupCalendar.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.Date;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VProgressBar.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VProgressBar.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import com.google.gwt.dom.client.Element;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VProgressIndicator.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VProgressIndicator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import com.vaadin.v7.shared.ui.progressindicator.ProgressIndicatorState;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VRichTextArea.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VRichTextArea.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.HashMap;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.ArrayList;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTextField.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTextField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import com.google.gwt.core.client.Scheduler;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTextualDate.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTextualDate.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.Date;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTree.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTree.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.ArrayList;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTreeTable.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTreeTable.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.ArrayList;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTwinColSelect.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTwinColSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import java.util.ArrayList;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VUpload.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VUpload.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui;
 
 import com.google.gwt.core.client.GWT;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/datefield/DateFieldConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/datefield/DateFieldConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.datefield;
 
 import java.util.Date;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/datefield/PopupDateFieldConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/datefield/PopupDateFieldConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.datefield;
 
 import com.vaadin.shared.ui.Connect;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/datefield/TextualDateConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/datefield/TextualDateConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.datefield;
 
 import com.vaadin.client.ApplicationConnection;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/listselect/ListSelectConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/listselect/ListSelectConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.listselect;
 
 import com.vaadin.shared.ui.Connect;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/nativeselect/NativeSelectConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/nativeselect/NativeSelectConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.nativeselect;
 
 import com.vaadin.client.ui.ConnectorFocusAndBlurHandler;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/optiongroup/OptionGroupBaseConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/optiongroup/OptionGroupBaseConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.optiongroup;
 
 import com.vaadin.client.ApplicationConnection;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/optiongroup/OptionGroupConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/optiongroup/OptionGroupConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.optiongroup;
 
 import java.util.ArrayList;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/passwordfield/PasswordFieldConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/passwordfield/PasswordFieldConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.passwordfield;
 
 import com.vaadin.shared.ui.Connect;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/progressindicator/ProgressBarConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/progressindicator/ProgressBarConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.progressindicator;
 
 import com.vaadin.client.communication.StateChangeEvent;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/progressindicator/ProgressIndicatorConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/progressindicator/ProgressIndicatorConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.progressindicator;
 
 import com.google.gwt.user.client.Timer;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/textarea/TextAreaConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/textarea/TextAreaConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.textarea;
 
 import com.google.gwt.dom.client.Element;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/textfield/TextFieldConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/textfield/TextFieldConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.textfield;
 
 import com.google.gwt.core.client.Scheduler;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/twincolselect/TwinColSelectConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/twincolselect/TwinColSelectConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.twincolselect;
 
 import com.vaadin.client.ApplicationConnection;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/upload/UploadConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/upload/UploadConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.ui.upload;
 
 import com.google.gwt.event.dom.client.ChangeEvent;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/ColumnConfiguration.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/ColumnConfiguration.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.widget.escalator;
 
 import java.util.Map;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/EscalatorUpdater.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/EscalatorUpdater.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.widget.escalator;
 
 import com.vaadin.v7.client.widgets.Escalator;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/PositionFunction.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/PositionFunction.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.widget.escalator;
 
 import com.google.gwt.dom.client.Element;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/Row.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/Row.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.widget.escalator;
 
 import com.google.gwt.dom.client.TableRowElement;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/RowContainer.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/RowContainer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.widget.escalator;
 
 import com.google.gwt.dom.client.Element;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/RowVisibilityChangeEvent.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/RowVisibilityChangeEvent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.widget.escalator;
 
 import com.google.gwt.event.shared.GwtEvent;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/RowVisibilityChangeHandler.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/RowVisibilityChangeHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.widget.escalator;
 
 import com.google.gwt.event.shared.EventHandler;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/ScrollbarBundle.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widget/escalator/ScrollbarBundle.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.client.widget.escalator;
 
 import com.google.gwt.animation.client.AnimationScheduler;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/Buffered.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/Buffered.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/BufferedValidatable.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/BufferedValidatable.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/Container.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/Container.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/Item.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/Item.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/Property.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/Property.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/Validatable.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/Validatable.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/Validator.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/Validator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/BeanItem.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/BeanItem.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util;
 
 import java.beans.PropertyDescriptor;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/ContainerHierarchicalWrapper.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/ContainerHierarchicalWrapper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/ContainerOrderedWrapper.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/ContainerOrderedWrapper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util;
 
 import java.util.ArrayList;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/FilesystemContainer.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/FilesystemContainer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util;
 
 import java.io.File;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/HierarchicalContainer.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/HierarchicalContainer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util;
 
 import java.util.Collection;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/IndexedContainer.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/IndexedContainer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/MethodProperty.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/MethodProperty.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util;
 
 import static com.vaadin.util.ReflectTools.convertPrimitiveType;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/ObjectProperty.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/ObjectProperty.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util;
 
 import com.vaadin.v7.data.Property;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/PropertysetItem.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/PropertysetItem.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util;
 
 import java.util.Collection;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/TextFileProperty.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/TextFileProperty.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util;
 
 import java.io.BufferedReader;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/AbstractStringToNumberConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/AbstractStringToNumberConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.text.NumberFormat;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/Converter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/Converter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/ConverterFactory.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/ConverterFactory.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/DateToLongConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/DateToLongConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.util.Date;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/DateToSqlDateConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/DateToSqlDateConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/DefaultConverterFactory.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/DefaultConverterFactory.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.math.BigDecimal;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/ReverseConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/ReverseConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.util.Locale;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToBooleanConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToBooleanConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.util.Locale;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToByteConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToByteConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.text.NumberFormat;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToDateConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToDateConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.text.DateFormat;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToDoubleConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToDoubleConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.text.NumberFormat;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToFloatConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToFloatConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.text.NumberFormat;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToIntegerConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToIntegerConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.text.NumberFormat;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToLongConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToLongConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.text.NumberFormat;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToShortConverter.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/StringToShortConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.converter;
 
 import java.text.NumberFormat;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/validator/BeanValidator.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/validator/BeanValidator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.validator;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/validator/CompositeValidator.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/validator/CompositeValidator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.validator;
 
 import java.util.Collection;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/validator/NullValidator.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/validator/NullValidator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.validator;
 
 import com.vaadin.v7.data.Validator;

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/validator/StringLengthValidator.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/validator/StringLengthValidator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.validator;
 
 /**

--- a/compatibility-server/src/main/java/com/vaadin/v7/event/FieldEvents.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/event/FieldEvents.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.event;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/server/communication/data/RpcDataProviderExtension.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/server/communication/data/RpcDataProviderExtension.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.server.communication.data;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/AbstractField.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/AbstractField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/AbstractTextField.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/AbstractTextField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.util.Collection;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/CheckBox.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/CheckBox.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.util.Collection;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/ComboBox.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/ComboBox.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/CustomField.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/CustomField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/DateField.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/DateField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.text.SimpleDateFormat;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Field.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Field.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import com.vaadin.ui.Component;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Form.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Form.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Grid.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Grid.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/InlineDateField.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/InlineDateField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.util.Date;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Label.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Label.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.lang.reflect.Method;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/ListSelect.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/ListSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.util.Collection;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/NativeSelect.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/NativeSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.util.Collection;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/OptionGroup.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/OptionGroup.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.util.Collection;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/PopupDateField.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/PopupDateField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.util.Date;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/ProgressBar.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/ProgressBar.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import org.jsoup.nodes.Element;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/ProgressIndicator.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/ProgressIndicator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import com.vaadin.shared.communication.PushMode;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/RichTextArea.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/RichTextArea.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.util.Map;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Select.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Select.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.util.Collection;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Slider.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Slider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.util.Collection;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Table.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Table.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/TextArea.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/TextArea.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import org.jsoup.nodes.Element;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/TextField.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/TextField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import org.jsoup.nodes.Attributes;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Tree.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Tree.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/TreeTable.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/TreeTable.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.io.Serializable;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/TwinColSelect.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/TwinColSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui;
 
 import java.util.Collection;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/components/calendar/event/CalendarEditableEventProvider.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/components/calendar/event/CalendarEditableEventProvider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.ui.components.calendar.event;
 
 /**

--- a/compatibility-server/src/test/java/com/vaadin/v7/data/util/filter/LikeFilterTest.java
+++ b/compatibility-server/src/test/java/com/vaadin/v7/data/util/filter/LikeFilterTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.data.util.filter;
 
 import org.junit.Assert;

--- a/compatibility-server/src/test/java/com/vaadin/v7/tests/data/converter/AnyEnumToStringConverterTest.java
+++ b/compatibility-server/src/test/java/com/vaadin/v7/tests/data/converter/AnyEnumToStringConverterTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.tests.data.converter;
 
 import java.util.Locale;

--- a/compatibility-server/src/test/java/com/vaadin/v7/tests/data/converter/SpecificEnumToStringConverterTest.java
+++ b/compatibility-server/src/test/java/com/vaadin/v7/tests/data/converter/SpecificEnumToStringConverterTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.tests.data.converter;
 
 import java.util.Locale;

--- a/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/datefield/DateFieldConverterTest.java
+++ b/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/datefield/DateFieldConverterTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.tests.server.component.datefield;
 
 import java.util.Date;

--- a/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/table/CacheUpdateExceptionCausesTest.java
+++ b/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/table/CacheUpdateExceptionCausesTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.tests.server.component.table;
 
 import org.junit.Assert;

--- a/compatibility-shared/src/main/java/com/vaadin/v7/shared/ui/grid/ColumnGroupState.java
+++ b/compatibility-shared/src/main/java/com/vaadin/v7/shared/ui/grid/ColumnGroupState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.shared.ui.grid;
 
 import java.io.Serializable;

--- a/compatibility-shared/src/main/java/com/vaadin/v7/shared/ui/grid/GridState.java
+++ b/compatibility-shared/src/main/java/com/vaadin/v7/shared/ui/grid/GridState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.shared.ui.grid;
 
 import java.util.ArrayList;

--- a/compatibility-shared/src/main/java/com/vaadin/v7/shared/ui/progressindicator/ProgressBarState.java
+++ b/compatibility-shared/src/main/java/com/vaadin/v7/shared/ui/progressindicator/ProgressBarState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.shared.ui.progressindicator;
 
 import com.vaadin.shared.annotations.NoLayout;

--- a/compatibility-shared/src/main/java/com/vaadin/v7/shared/ui/table/CollapseMenuContent.java
+++ b/compatibility-shared/src/main/java/com/vaadin/v7/shared/ui/table/CollapseMenuContent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.shared.ui.table;
 
 /**

--- a/server/src/main/java/com/vaadin/annotations/JavaScript.java
+++ b/server/src/main/java/com/vaadin/annotations/JavaScript.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.annotations;
 
 import java.lang.annotation.Documented;

--- a/server/src/main/java/com/vaadin/annotations/PreserveOnRefresh.java
+++ b/server/src/main/java/com/vaadin/annotations/PreserveOnRefresh.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.annotations;
 
 import java.lang.annotation.ElementType;

--- a/server/src/main/java/com/vaadin/annotations/Push.java
+++ b/server/src/main/java/com/vaadin/annotations/Push.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.annotations;
 
 import java.lang.annotation.ElementType;

--- a/server/src/main/java/com/vaadin/annotations/StyleSheet.java
+++ b/server/src/main/java/com/vaadin/annotations/StyleSheet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.annotations;
 
 import java.lang.annotation.Documented;

--- a/server/src/main/java/com/vaadin/annotations/Theme.java
+++ b/server/src/main/java/com/vaadin/annotations/Theme.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.annotations;
 
 import java.lang.annotation.ElementType;

--- a/server/src/main/java/com/vaadin/annotations/Title.java
+++ b/server/src/main/java/com/vaadin/annotations/Title.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.annotations;
 
 import java.lang.annotation.ElementType;

--- a/server/src/main/java/com/vaadin/annotations/VaadinServletConfiguration.java
+++ b/server/src/main/java/com/vaadin/annotations/VaadinServletConfiguration.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.annotations;
 
 import java.lang.annotation.Documented;

--- a/server/src/main/java/com/vaadin/annotations/Widgetset.java
+++ b/server/src/main/java/com/vaadin/annotations/Widgetset.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.annotations;
 
 import java.lang.annotation.ElementType;

--- a/server/src/main/java/com/vaadin/data/Converter.java
+++ b/server/src/main/java/com/vaadin/data/Converter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/data/Result.java
+++ b/server/src/main/java/com/vaadin/data/Result.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/data/Validator.java
+++ b/server/src/main/java/com/vaadin/data/Validator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/data/converter/AbstractStringToNumberConverter.java
+++ b/server/src/main/java/com/vaadin/data/converter/AbstractStringToNumberConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data.converter;
 
 import java.text.NumberFormat;

--- a/server/src/main/java/com/vaadin/data/converter/DateToLongConverter.java
+++ b/server/src/main/java/com/vaadin/data/converter/DateToLongConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data.converter;
 
 import java.util.Date;

--- a/server/src/main/java/com/vaadin/data/converter/DateToSqlDateConverter.java
+++ b/server/src/main/java/com/vaadin/data/converter/DateToSqlDateConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/server/src/main/java/com/vaadin/data/converter/StringToBooleanConverter.java
+++ b/server/src/main/java/com/vaadin/data/converter/StringToBooleanConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data.converter;
 
 import java.util.Locale;

--- a/server/src/main/java/com/vaadin/data/converter/StringToDateConverter.java
+++ b/server/src/main/java/com/vaadin/data/converter/StringToDateConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data.converter;
 
 import java.text.DateFormat;

--- a/server/src/main/java/com/vaadin/data/converter/StringToDoubleConverter.java
+++ b/server/src/main/java/com/vaadin/data/converter/StringToDoubleConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data.converter;
 
 import java.text.NumberFormat;

--- a/server/src/main/java/com/vaadin/data/converter/StringToFloatConverter.java
+++ b/server/src/main/java/com/vaadin/data/converter/StringToFloatConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data.converter;
 
 import java.text.NumberFormat;

--- a/server/src/main/java/com/vaadin/data/converter/StringToIntegerConverter.java
+++ b/server/src/main/java/com/vaadin/data/converter/StringToIntegerConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data.converter;
 
 import java.text.NumberFormat;

--- a/server/src/main/java/com/vaadin/data/converter/StringToLongConverter.java
+++ b/server/src/main/java/com/vaadin/data/converter/StringToLongConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data.converter;
 
 import java.text.NumberFormat;

--- a/server/src/main/java/com/vaadin/data/validator/BeanValidator.java
+++ b/server/src/main/java/com/vaadin/data/validator/BeanValidator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data.validator;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/data/validator/StringLengthValidator.java
+++ b/server/src/main/java/com/vaadin/data/validator/StringLengthValidator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data.validator;
 
 import com.vaadin.data.ValidationResult;

--- a/server/src/main/java/com/vaadin/event/Action.java
+++ b/server/src/main/java/com/vaadin/event/Action.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.event;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/event/ConnectorEvent.java
+++ b/server/src/main/java/com/vaadin/event/ConnectorEvent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.event;
 
 import java.util.EventObject;

--- a/server/src/main/java/com/vaadin/event/EventRouter.java
+++ b/server/src/main/java/com/vaadin/event/EventRouter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.event;
 
 import java.lang.reflect.Method;

--- a/server/src/main/java/com/vaadin/event/FieldEvents.java
+++ b/server/src/main/java/com/vaadin/event/FieldEvents.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.event;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/event/ListenerMethod.java
+++ b/server/src/main/java/com/vaadin/event/ListenerMethod.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.event;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/event/MethodEventSource.java
+++ b/server/src/main/java/com/vaadin/event/MethodEventSource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.event;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/event/MouseEvents.java
+++ b/server/src/main/java/com/vaadin/event/MouseEvents.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.event;
 
 import java.lang.reflect.Method;

--- a/server/src/main/java/com/vaadin/event/ShortcutAction.java
+++ b/server/src/main/java/com/vaadin/event/ShortcutAction.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.event;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/navigator/NavigationStateManager.java
+++ b/server/src/main/java/com/vaadin/navigator/NavigationStateManager.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.navigator;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/navigator/View.java
+++ b/server/src/main/java/com/vaadin/navigator/View.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.navigator;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/navigator/ViewChangeListener.java
+++ b/server/src/main/java/com/vaadin/navigator/ViewChangeListener.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.navigator;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/navigator/ViewDisplay.java
+++ b/server/src/main/java/com/vaadin/navigator/ViewDisplay.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.navigator;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/navigator/ViewProvider.java
+++ b/server/src/main/java/com/vaadin/navigator/ViewProvider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.navigator;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/AbstractErrorMessage.java
+++ b/server/src/main/java/com/vaadin/server/AbstractErrorMessage.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.PrintWriter;

--- a/server/src/main/java/com/vaadin/server/AbstractExtension.java
+++ b/server/src/main/java/com/vaadin/server/AbstractExtension.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 /**

--- a/server/src/main/java/com/vaadin/server/AbstractJavaScriptExtension.java
+++ b/server/src/main/java/com/vaadin/server/AbstractJavaScriptExtension.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import com.vaadin.shared.JavaScriptExtensionState;

--- a/server/src/main/java/com/vaadin/server/BootstrapFragmentResponse.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapFragmentResponse.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.util.List;

--- a/server/src/main/java/com/vaadin/server/BootstrapHandler.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.BufferedWriter;

--- a/server/src/main/java/com/vaadin/server/BootstrapListener.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapListener.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/BootstrapPageResponse.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapPageResponse.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.util.Map;

--- a/server/src/main/java/com/vaadin/server/BootstrapResponse.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapResponse.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.util.EventObject;

--- a/server/src/main/java/com/vaadin/server/BrowserWindowOpener.java
+++ b/server/src/main/java/com/vaadin/server/BrowserWindowOpener.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.util.Collections;

--- a/server/src/main/java/com/vaadin/server/ClassResource.java
+++ b/server/src/main/java/com/vaadin/server/ClassResource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/ClientMethodInvocation.java
+++ b/server/src/main/java/com/vaadin/server/ClientMethodInvocation.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/CompositeErrorMessage.java
+++ b/server/src/main/java/com/vaadin/server/CompositeErrorMessage.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/server/ConnectorResource.java
+++ b/server/src/main/java/com/vaadin/server/ConnectorResource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 /**

--- a/server/src/main/java/com/vaadin/server/CustomizedSystemMessages.java
+++ b/server/src/main/java/com/vaadin/server/CustomizedSystemMessages.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/DefaultDeploymentConfiguration.java
+++ b/server/src/main/java/com/vaadin/server/DefaultDeploymentConfiguration.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.util.Properties;

--- a/server/src/main/java/com/vaadin/server/DefaultErrorHandler.java
+++ b/server/src/main/java/com/vaadin/server/DefaultErrorHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.lang.reflect.InvocationTargetException;

--- a/server/src/main/java/com/vaadin/server/DefaultSystemMessagesProvider.java
+++ b/server/src/main/java/com/vaadin/server/DefaultSystemMessagesProvider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 /**

--- a/server/src/main/java/com/vaadin/server/DefaultUIProvider.java
+++ b/server/src/main/java/com/vaadin/server/DefaultUIProvider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import com.vaadin.ui.UI;

--- a/server/src/main/java/com/vaadin/server/DeploymentConfiguration.java
+++ b/server/src/main/java/com/vaadin/server/DeploymentConfiguration.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/DownloadStream.java
+++ b/server/src/main/java/com/vaadin/server/DownloadStream.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/EncodeResult.java
+++ b/server/src/main/java/com/vaadin/server/EncodeResult.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/ErrorMessage.java
+++ b/server/src/main/java/com/vaadin/server/ErrorMessage.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/Extension.java
+++ b/server/src/main/java/com/vaadin/server/Extension.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 /**

--- a/server/src/main/java/com/vaadin/server/ExternalResource.java
+++ b/server/src/main/java/com/vaadin/server/ExternalResource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/FileDownloader.java
+++ b/server/src/main/java/com/vaadin/server/FileDownloader.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/FileResource.java
+++ b/server/src/main/java/com/vaadin/server/FileResource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.File;

--- a/server/src/main/java/com/vaadin/server/FontAwesome.java
+++ b/server/src/main/java/com/vaadin/server/FontAwesome.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 /**

--- a/server/src/main/java/com/vaadin/server/FontIcon.java
+++ b/server/src/main/java/com/vaadin/server/FontIcon.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import com.vaadin.shared.ui.ContentMode;

--- a/server/src/main/java/com/vaadin/server/GlobalResourceHandler.java
+++ b/server/src/main/java/com/vaadin/server/GlobalResourceHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/JavaScriptCallbackHelper.java
+++ b/server/src/main/java/com/vaadin/server/JavaScriptCallbackHelper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/JsonCodec.java
+++ b/server/src/main/java/com/vaadin/server/JsonCodec.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.beans.IntrospectionException;

--- a/server/src/main/java/com/vaadin/server/JsonPaintTarget.java
+++ b/server/src/main/java/com/vaadin/server/JsonPaintTarget.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.PrintWriter;

--- a/server/src/main/java/com/vaadin/server/KeyMapper.java
+++ b/server/src/main/java/com/vaadin/server/KeyMapper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/LegacyApplication.java
+++ b/server/src/main/java/com/vaadin/server/LegacyApplication.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.net.URL;

--- a/server/src/main/java/com/vaadin/server/LegacyApplicationUIProvider.java
+++ b/server/src/main/java/com/vaadin/server/LegacyApplicationUIProvider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.net.MalformedURLException;

--- a/server/src/main/java/com/vaadin/server/LegacyCommunicationManager.java
+++ b/server/src/main/java/com/vaadin/server/LegacyCommunicationManager.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/LegacyVaadinPortlet.java
+++ b/server/src/main/java/com/vaadin/server/LegacyVaadinPortlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import javax.portlet.PortletConfig;

--- a/server/src/main/java/com/vaadin/server/LegacyVaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/LegacyVaadinServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import javax.servlet.ServletConfig;

--- a/server/src/main/java/com/vaadin/server/LocaleService.java
+++ b/server/src/main/java/com/vaadin/server/LocaleService.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/server/src/main/java/com/vaadin/server/Page.java
+++ b/server/src/main/java/com/vaadin/server/Page.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/PaintException.java
+++ b/server/src/main/java/com/vaadin/server/PaintException.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/PaintTarget.java
+++ b/server/src/main/java/com/vaadin/server/PaintTarget.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/RequestHandler.java
+++ b/server/src/main/java/com/vaadin/server/RequestHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/Resource.java
+++ b/server/src/main/java/com/vaadin/server/Resource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/Responsive.java
+++ b/server/src/main/java/com/vaadin/server/Responsive.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import com.vaadin.shared.extension.responsive.ResponsiveState;

--- a/server/src/main/java/com/vaadin/server/Scrollable.java
+++ b/server/src/main/java/com/vaadin/server/Scrollable.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/ServerRpcManager.java
+++ b/server/src/main/java/com/vaadin/server/ServerRpcManager.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/ServiceDestroyEvent.java
+++ b/server/src/main/java/com/vaadin/server/ServiceDestroyEvent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.util.EventObject;

--- a/server/src/main/java/com/vaadin/server/ServiceDestroyListener.java
+++ b/server/src/main/java/com/vaadin/server/ServiceDestroyListener.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/ServiceException.java
+++ b/server/src/main/java/com/vaadin/server/ServiceException.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 public class ServiceException extends Exception {

--- a/server/src/main/java/com/vaadin/server/SessionDestroyEvent.java
+++ b/server/src/main/java/com/vaadin/server/SessionDestroyEvent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.util.EventObject;

--- a/server/src/main/java/com/vaadin/server/SessionDestroyListener.java
+++ b/server/src/main/java/com/vaadin/server/SessionDestroyListener.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/SessionInitEvent.java
+++ b/server/src/main/java/com/vaadin/server/SessionInitEvent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.util.EventObject;

--- a/server/src/main/java/com/vaadin/server/SessionInitListener.java
+++ b/server/src/main/java/com/vaadin/server/SessionInitListener.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/Sizeable.java
+++ b/server/src/main/java/com/vaadin/server/Sizeable.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/StreamResource.java
+++ b/server/src/main/java/com/vaadin/server/StreamResource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.InputStream;

--- a/server/src/main/java/com/vaadin/server/SystemError.java
+++ b/server/src/main/java/com/vaadin/server/SystemError.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 /**

--- a/server/src/main/java/com/vaadin/server/SystemMessages.java
+++ b/server/src/main/java/com/vaadin/server/SystemMessages.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/SystemMessagesProvider.java
+++ b/server/src/main/java/com/vaadin/server/SystemMessagesProvider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/ThemeResource.java
+++ b/server/src/main/java/com/vaadin/server/ThemeResource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import com.vaadin.util.FileTypeResolver;

--- a/server/src/main/java/com/vaadin/server/UIClassSelectionEvent.java
+++ b/server/src/main/java/com/vaadin/server/UIClassSelectionEvent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 /**

--- a/server/src/main/java/com/vaadin/server/UICreateEvent.java
+++ b/server/src/main/java/com/vaadin/server/UICreateEvent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import com.vaadin.ui.UI;

--- a/server/src/main/java/com/vaadin/server/UIProvider.java
+++ b/server/src/main/java/com/vaadin/server/UIProvider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.InputStream;

--- a/server/src/main/java/com/vaadin/server/UIProviderEvent.java
+++ b/server/src/main/java/com/vaadin/server/UIProviderEvent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/UserError.java
+++ b/server/src/main/java/com/vaadin/server/UserError.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 /**

--- a/server/src/main/java/com/vaadin/server/VaadinPortletRequest.java
+++ b/server/src/main/java/com/vaadin/server/VaadinPortletRequest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.BufferedReader;

--- a/server/src/main/java/com/vaadin/server/VaadinPortletResponse.java
+++ b/server/src/main/java/com/vaadin/server/VaadinPortletResponse.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/VaadinPortletService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinPortletService.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import static com.vaadin.shared.util.SharedUtil.trimTrailingSlashes;

--- a/server/src/main/java/com/vaadin/server/VaadinRequest.java
+++ b/server/src/main/java/com/vaadin/server/VaadinRequest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.BufferedReader;

--- a/server/src/main/java/com/vaadin/server/VaadinResponse.java
+++ b/server/src/main/java/com/vaadin/server/VaadinResponse.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinService.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.BufferedWriter;

--- a/server/src/main/java/com/vaadin/server/VaadinServletRequest.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServletRequest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import javax.servlet.http.HttpServletRequest;

--- a/server/src/main/java/com/vaadin/server/VaadinServletResponse.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServletResponse.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import javax.servlet.http.HttpServletResponse;

--- a/server/src/main/java/com/vaadin/server/VaadinServletService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServletService.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.File;

--- a/server/src/main/java/com/vaadin/server/VaadinSession.java
+++ b/server/src/main/java/com/vaadin/server/VaadinSession.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/VariableOwner.java
+++ b/server/src/main/java/com/vaadin/server/VariableOwner.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/WebBrowser.java
+++ b/server/src/main/java/com/vaadin/server/WebBrowser.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/WidgetsetInfo.java
+++ b/server/src/main/java/com/vaadin/server/WidgetsetInfo.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/WidgetsetInfoImpl.java
+++ b/server/src/main/java/com/vaadin/server/WidgetsetInfoImpl.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 /**

--- a/server/src/main/java/com/vaadin/server/WrappedHttpSession.java
+++ b/server/src/main/java/com/vaadin/server/WrappedHttpSession.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.util.Collections;

--- a/server/src/main/java/com/vaadin/server/WrappedPortletSession.java
+++ b/server/src/main/java/com/vaadin/server/WrappedPortletSession.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.util.Set;

--- a/server/src/main/java/com/vaadin/server/WrappedSession.java
+++ b/server/src/main/java/com/vaadin/server/WrappedSession.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/communication/AtmospherePushConnection.java
+++ b/server/src/main/java/com/vaadin/server/communication/AtmospherePushConnection.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/ClientRpcWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/ClientRpcWriter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/ConnectorHierarchyWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/ConnectorHierarchyWriter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/ConnectorTypeWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/ConnectorTypeWriter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/FileUploadHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/FileUploadHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.BufferedWriter;

--- a/server/src/main/java/com/vaadin/server/communication/HeartbeatHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/HeartbeatHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/LegacyUidlWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/LegacyUidlWriter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/MetadataWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/MetadataWriter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/PortletBootstrapHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PortletBootstrapHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/PortletListenerNotifier.java
+++ b/server/src/main/java/com/vaadin/server/communication/PortletListenerNotifier.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/PublishedFileHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PublishedFileHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/PushConnection.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushConnection.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/server/communication/PushHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/PushRequestHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushRequestHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/ResourceWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/ResourceWriter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/ServerRpcHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/ServerRpcHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/ServletBootstrapHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/ServletBootstrapHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import com.vaadin.server.BootstrapHandler;

--- a/server/src/main/java/com/vaadin/server/communication/SharedStateWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/SharedStateWriter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/UidlRequestHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/UidlRequestHandler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/server/communication/UidlWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/UidlWriter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server.communication;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/ui/AbstractComponent.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.lang.reflect.Method;

--- a/server/src/main/java/com/vaadin/ui/AbstractComponentContainer.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractComponentContainer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/AbstractField.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/AbstractLayout.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractLayout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import org.jsoup.nodes.Element;

--- a/server/src/main/java/com/vaadin/ui/AbstractMedia.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractMedia.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.IOException;

--- a/server/src/main/java/com/vaadin/ui/AbstractOrderedLayout.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractOrderedLayout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/AbstractSplitPanel.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractSplitPanel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/AbstractTextField.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractTextField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/Audio.java
+++ b/server/src/main/java/com/vaadin/ui/Audio.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import com.vaadin.server.Resource;

--- a/server/src/main/java/com/vaadin/ui/Button.java
+++ b/server/src/main/java/com/vaadin/ui/Button.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/CheckBox.java
+++ b/server/src/main/java/com/vaadin/ui/CheckBox.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/CheckBoxGroup.java
+++ b/server/src/main/java/com/vaadin/ui/CheckBoxGroup.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/Component.java
+++ b/server/src/main/java/com/vaadin/ui/Component.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/ComponentContainer.java
+++ b/server/src/main/java/com/vaadin/ui/ComponentContainer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Iterator;

--- a/server/src/main/java/com/vaadin/ui/CustomComponent.java
+++ b/server/src/main/java/com/vaadin/ui/CustomComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collections;

--- a/server/src/main/java/com/vaadin/ui/CustomField.java
+++ b/server/src/main/java/com/vaadin/ui/CustomField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/CustomLayout.java
+++ b/server/src/main/java/com/vaadin/ui/CustomLayout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.BufferedReader;

--- a/server/src/main/java/com/vaadin/ui/Embedded.java
+++ b/server/src/main/java/com/vaadin/ui/Embedded.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.HashMap;

--- a/server/src/main/java/com/vaadin/ui/FormLayout.java
+++ b/server/src/main/java/com/vaadin/ui/FormLayout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import com.vaadin.shared.ui.MarginInfo;

--- a/server/src/main/java/com/vaadin/ui/GridLayout.java
+++ b/server/src/main/java/com/vaadin/ui/GridLayout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/JavaScript.java
+++ b/server/src/main/java/com/vaadin/ui/JavaScript.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.HashMap;

--- a/server/src/main/java/com/vaadin/ui/JavaScriptFunction.java
+++ b/server/src/main/java/com/vaadin/ui/JavaScriptFunction.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/Label.java
+++ b/server/src/main/java/com/vaadin/ui/Label.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/Layout.java
+++ b/server/src/main/java/com/vaadin/ui/Layout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/Link.java
+++ b/server/src/main/java/com/vaadin/ui/Link.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/LoginForm.java
+++ b/server/src/main/java/com/vaadin/ui/LoginForm.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.ByteArrayInputStream;

--- a/server/src/main/java/com/vaadin/ui/NativeSelect.java
+++ b/server/src/main/java/com/vaadin/ui/NativeSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/Notification.java
+++ b/server/src/main/java/com/vaadin/ui/Notification.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/NotificationConfiguration.java
+++ b/server/src/main/java/com/vaadin/ui/NotificationConfiguration.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/server/src/main/java/com/vaadin/ui/Panel.java
+++ b/server/src/main/java/com/vaadin/ui/Panel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/PasswordField.java
+++ b/server/src/main/java/com/vaadin/ui/PasswordField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import org.jsoup.nodes.Attributes;

--- a/server/src/main/java/com/vaadin/ui/PushConfiguration.java
+++ b/server/src/main/java/com/vaadin/ui/PushConfiguration.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/RadioButtonGroup.java
+++ b/server/src/main/java/com/vaadin/ui/RadioButtonGroup.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/ReconnectDialogConfiguration.java
+++ b/server/src/main/java/com/vaadin/ui/ReconnectDialogConfiguration.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/RichTextArea.java
+++ b/server/src/main/java/com/vaadin/ui/RichTextArea.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Objects;

--- a/server/src/main/java/com/vaadin/ui/SingleComponentContainer.java
+++ b/server/src/main/java/com/vaadin/ui/SingleComponentContainer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import com.vaadin.ui.HasComponents.ComponentAttachDetachNotifier;

--- a/server/src/main/java/com/vaadin/ui/Slider.java
+++ b/server/src/main/java/com/vaadin/ui/Slider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/TabSheet.java
+++ b/server/src/main/java/com/vaadin/ui/TabSheet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/ui/TextField.java
+++ b/server/src/main/java/com/vaadin/ui/TextField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import org.jsoup.nodes.Attributes;

--- a/server/src/main/java/com/vaadin/ui/TwinColSelect.java
+++ b/server/src/main/java/com/vaadin/ui/TwinColSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/UI.java
+++ b/server/src/main/java/com/vaadin/ui/UI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.ByteArrayOutputStream;

--- a/server/src/main/java/com/vaadin/ui/Video.java
+++ b/server/src/main/java/com/vaadin/ui/Video.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.util.Collection;

--- a/server/src/main/java/com/vaadin/ui/Window.java
+++ b/server/src/main/java/com/vaadin/ui/Window.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.ui;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/util/ConnectorHelper.java
+++ b/server/src/main/java/com/vaadin/util/ConnectorHelper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.util;
 
 import java.util.LinkedList;

--- a/server/src/main/java/com/vaadin/util/CurrentInstance.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstance.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.util;
 
 import java.io.Serializable;

--- a/server/src/main/java/com/vaadin/util/FileTypeResolver.java
+++ b/server/src/main/java/com/vaadin/util/FileTypeResolver.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.util;
 
 import java.io.File;

--- a/server/src/test/java/com/vaadin/server/MockServletConfig.java
+++ b/server/src/test/java/com/vaadin/server/MockServletConfig.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/server/src/test/java/com/vaadin/server/MockServletContext.java
+++ b/server/src/test/java/com/vaadin/server/MockServletContext.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/server/src/test/java/com/vaadin/server/VaadinServletConfigurationTest.java
+++ b/server/src/test/java/com/vaadin/server/VaadinServletConfigurationTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/server/src/test/java/com/vaadin/tests/server/AssertionsEnabledTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/AssertionsEnabledTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.server;
 
 import static org.junit.Assert.assertTrue;

--- a/server/src/test/java/com/vaadin/tests/server/component/ComponentSizeParseTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/ComponentSizeParseTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.server.component;
 
 import org.junit.Assert;

--- a/server/src/test/java/com/vaadin/tests/server/navigator/ClassBasedViewProviderTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/navigator/ClassBasedViewProviderTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.server.navigator;
 
 import static org.junit.Assert.assertEquals;

--- a/server/src/test/java/com/vaadin/tests/server/navigator/NavigatorTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/navigator/NavigatorTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.server.navigator;
 
 import static org.junit.Assert.assertEquals;

--- a/server/src/test/java/com/vaadin/tests/server/navigator/UriFragmentManagerTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/navigator/UriFragmentManagerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.server.navigator;
 
 import org.easymock.EasyMock;

--- a/shared/src/main/java/com/vaadin/shared/AbstractComponentState.java
+++ b/shared/src/main/java/com/vaadin/shared/AbstractComponentState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared;
 
 import java.util.List;

--- a/shared/src/main/java/com/vaadin/shared/ComponentConstants.java
+++ b/shared/src/main/java/com/vaadin/shared/ComponentConstants.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared;
 
 import java.io.Serializable;

--- a/shared/src/main/java/com/vaadin/shared/JavaScriptConnectorState.java
+++ b/shared/src/main/java/com/vaadin/shared/JavaScriptConnectorState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared;
 
 import java.io.Serializable;

--- a/shared/src/main/java/com/vaadin/shared/JavaScriptExtensionState.java
+++ b/shared/src/main/java/com/vaadin/shared/JavaScriptExtensionState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared;
 
 import java.util.HashMap;

--- a/shared/src/main/java/com/vaadin/shared/Range.java
+++ b/shared/src/main/java/com/vaadin/shared/Range.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared;
 
 import java.io.Serializable;

--- a/shared/src/main/java/com/vaadin/shared/annotations/Delayed.java
+++ b/shared/src/main/java/com/vaadin/shared/annotations/Delayed.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.annotations;
 
 import java.lang.annotation.Documented;

--- a/shared/src/main/java/com/vaadin/shared/communication/ClientRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/communication/ClientRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.communication;
 
 import java.io.Serializable;

--- a/shared/src/main/java/com/vaadin/shared/communication/MethodInvocation.java
+++ b/shared/src/main/java/com/vaadin/shared/communication/MethodInvocation.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.communication;
 
 import java.io.Serializable;

--- a/shared/src/main/java/com/vaadin/shared/communication/PushMode.java
+++ b/shared/src/main/java/com/vaadin/shared/communication/PushMode.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.communication;
 
 /**

--- a/shared/src/main/java/com/vaadin/shared/communication/ServerRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/communication/ServerRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.communication;
 
 import java.io.Serializable;

--- a/shared/src/main/java/com/vaadin/shared/communication/SharedState.java
+++ b/shared/src/main/java/com/vaadin/shared/communication/SharedState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.communication;
 
 import java.io.Serializable;

--- a/shared/src/main/java/com/vaadin/shared/communication/UidlValue.java
+++ b/shared/src/main/java/com/vaadin/shared/communication/UidlValue.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.communication;
 
 import java.io.Serializable;

--- a/shared/src/main/java/com/vaadin/shared/data/DataProviderRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/data/DataProviderRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.data;
 
 import com.vaadin.shared.annotations.NoLayout;

--- a/shared/src/main/java/com/vaadin/shared/data/DataRequestRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/data/DataRequestRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.data;
 
 import com.vaadin.shared.annotations.Delayed;

--- a/shared/src/main/java/com/vaadin/shared/extension/javascriptmanager/ExecuteJavaScriptRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/extension/javascriptmanager/ExecuteJavaScriptRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.extension.javascriptmanager;
 
 import com.vaadin.shared.communication.ClientRpc;

--- a/shared/src/main/java/com/vaadin/shared/extension/javascriptmanager/JavaScriptManagerState.java
+++ b/shared/src/main/java/com/vaadin/shared/extension/javascriptmanager/JavaScriptManagerState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.extension.javascriptmanager;
 
 import java.util.HashSet;

--- a/shared/src/main/java/com/vaadin/shared/ui/AbstractComponentContainerState.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/AbstractComponentContainerState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui;
 
 import com.vaadin.shared.AbstractComponentState;

--- a/shared/src/main/java/com/vaadin/shared/ui/AbstractSingleComponentContainerState.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/AbstractSingleComponentContainerState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui;
 
 import com.vaadin.shared.AbstractComponentState;

--- a/shared/src/main/java/com/vaadin/shared/ui/AlignmentInfo.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/AlignmentInfo.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui;
 
 import java.io.Serializable;

--- a/shared/src/main/java/com/vaadin/shared/ui/BrowserWindowOpenerState.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/BrowserWindowOpenerState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui;
 
 import java.util.HashMap;

--- a/shared/src/main/java/com/vaadin/shared/ui/JavaScriptComponentState.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/JavaScriptComponentState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui;
 
 import java.util.HashMap;

--- a/shared/src/main/java/com/vaadin/shared/ui/MarginInfo.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/MarginInfo.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui;
 
 import java.io.Serializable;

--- a/shared/src/main/java/com/vaadin/shared/ui/MediaControl.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/MediaControl.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui;
 
 import com.vaadin.shared.annotations.NoLayout;

--- a/shared/src/main/java/com/vaadin/shared/ui/ValueChangeMode.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/ValueChangeMode.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui;
 
 /**

--- a/shared/src/main/java/com/vaadin/shared/ui/button/ButtonState.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/button/ButtonState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.button;
 
 import com.vaadin.shared.AbstractComponentState;

--- a/shared/src/main/java/com/vaadin/shared/ui/dd/AcceptCriterion.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/dd/AcceptCriterion.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.dd;
 
 import java.lang.annotation.ElementType;

--- a/shared/src/main/java/com/vaadin/shared/ui/dd/DragEventType.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/dd/DragEventType.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.dd;
 
 public enum DragEventType {

--- a/shared/src/main/java/com/vaadin/shared/ui/grid/GridState.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/grid/GridState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.grid;
 
 import java.util.ArrayList;

--- a/shared/src/main/java/com/vaadin/shared/ui/link/LinkConstants.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/link/LinkConstants.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.link;
 
 import java.io.Serializable;

--- a/shared/src/main/java/com/vaadin/shared/ui/loginform/LoginFormRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/loginform/LoginFormRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.loginform;
 
 import com.vaadin.shared.communication.ServerRpc;

--- a/shared/src/main/java/com/vaadin/shared/ui/loginform/LoginFormState.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/loginform/LoginFormState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.loginform;
 
 import com.vaadin.shared.Connector;

--- a/shared/src/main/java/com/vaadin/shared/ui/progressindicator/ProgressBarState.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/progressindicator/ProgressBarState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.progressindicator;
 
 import com.vaadin.shared.AbstractFieldState;

--- a/shared/src/main/java/com/vaadin/shared/ui/ui/DebugWindowClientRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/ui/DebugWindowClientRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.ui;
 
 import com.vaadin.shared.communication.ClientRpc;

--- a/shared/src/main/java/com/vaadin/shared/ui/ui/DebugWindowServerRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/ui/DebugWindowServerRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.ui;
 
 import com.vaadin.shared.Connector;

--- a/shared/src/main/java/com/vaadin/shared/ui/ui/PageClientRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/ui/PageClientRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.ui;
 
 import com.vaadin.shared.communication.ClientRpc;

--- a/shared/src/main/java/com/vaadin/shared/ui/ui/ScrollClientRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/ui/ScrollClientRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.ui;
 
 import com.vaadin.shared.annotations.NoLayout;

--- a/shared/src/main/java/com/vaadin/shared/ui/ui/Transport.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/ui/Transport.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.ui;
 
 /**

--- a/shared/src/main/java/com/vaadin/shared/ui/video/VideoConstants.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/video/VideoConstants.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.shared.ui.video;
 
 import java.io.Serializable;

--- a/uitest/src/main/java/com/vaadin/launcher/DevelopmentServerLauncher.java
+++ b/uitest/src/main/java/com/vaadin/launcher/DevelopmentServerLauncher.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.launcher;
 
 import java.io.File;

--- a/uitest/src/main/java/com/vaadin/launcher/util/BrowserLauncher.java
+++ b/uitest/src/main/java/com/vaadin/launcher/util/BrowserLauncher.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.launcher.util;
 
 import java.io.BufferedInputStream;

--- a/uitest/src/main/java/com/vaadin/tests/CustomLayoutDemo.java
+++ b/uitest/src/main/java/com/vaadin/tests/CustomLayoutDemo.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.shared.ui.ContentMode;

--- a/uitest/src/main/java/com/vaadin/tests/LayoutDemo.java
+++ b/uitest/src/main/java/com/vaadin/tests/LayoutDemo.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.server.ClassResource;

--- a/uitest/src/main/java/com/vaadin/tests/ModalWindow.java
+++ b/uitest/src/main/java/com/vaadin/tests/ModalWindow.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.ui.Button;

--- a/uitest/src/main/java/com/vaadin/tests/NativeWindowing.java
+++ b/uitest/src/main/java/com/vaadin/tests/NativeWindowing.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.net.MalformedURLException;

--- a/uitest/src/main/java/com/vaadin/tests/OrderedLayoutSwapComponents.java
+++ b/uitest/src/main/java/com/vaadin/tests/OrderedLayoutSwapComponents.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.ArrayList;

--- a/uitest/src/main/java/com/vaadin/tests/Parameters.java
+++ b/uitest/src/main/java/com/vaadin/tests/Parameters.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.io.IOException;

--- a/uitest/src/main/java/com/vaadin/tests/PerformanceTestBasicComponentRendering.java
+++ b/uitest/src/main/java/com/vaadin/tests/PerformanceTestBasicComponentRendering.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.Date;

--- a/uitest/src/main/java/com/vaadin/tests/PerformanceTestLabelsAndOrderedLayouts.java
+++ b/uitest/src/main/java/com/vaadin/tests/PerformanceTestLabelsAndOrderedLayouts.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.Date;

--- a/uitest/src/main/java/com/vaadin/tests/PerformanceTestSubTreeCaching.java
+++ b/uitest/src/main/java/com/vaadin/tests/PerformanceTestSubTreeCaching.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.Date;

--- a/uitest/src/main/java/com/vaadin/tests/RandomLayoutStress.java
+++ b/uitest/src/main/java/com/vaadin/tests/RandomLayoutStress.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.time.LocalDate;

--- a/uitest/src/main/java/com/vaadin/tests/StressComponentsInTable.java
+++ b/uitest/src/main/java/com/vaadin/tests/StressComponentsInTable.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.Date;

--- a/uitest/src/main/java/com/vaadin/tests/TableChangingDatasource.java
+++ b/uitest/src/main/java/com/vaadin/tests/TableChangingDatasource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.ui.Button;

--- a/uitest/src/main/java/com/vaadin/tests/TableSelectTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/TableSelectTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.ui.CustomComponent;

--- a/uitest/src/main/java/com/vaadin/tests/TestBench.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestBench.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.io.File;

--- a/uitest/src/main/java/com/vaadin/tests/TestCaptionWrapper.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestCaptionWrapper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.server.ClassResource;

--- a/uitest/src/main/java/com/vaadin/tests/TestDateField.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestDateField.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.Locale;

--- a/uitest/src/main/java/com/vaadin/tests/TestForAlignments.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForAlignments.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.tests.components.TestDateField;

--- a/uitest/src/main/java/com/vaadin/tests/TestForApplicationLayoutThatUsesWholeBrosersSpace.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForApplicationLayoutThatUsesWholeBrosersSpace.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.server.LegacyApplication;

--- a/uitest/src/main/java/com/vaadin/tests/TestForBasicApplicationLayout.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForBasicApplicationLayout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.Locale;

--- a/uitest/src/main/java/com/vaadin/tests/TestForChildComponentRendering.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForChildComponentRendering.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.ArrayList;

--- a/uitest/src/main/java/com/vaadin/tests/TestForContainerFilterable.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForContainerFilterable.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.ui.Button;

--- a/uitest/src/main/java/com/vaadin/tests/TestForGridLayoutChildComponentRendering.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForGridLayoutChildComponentRendering.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.ArrayList;

--- a/uitest/src/main/java/com/vaadin/tests/TestForMultipleStyleNames.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForMultipleStyleNames.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.ArrayList;

--- a/uitest/src/main/java/com/vaadin/tests/TestForNativeWindowing.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForNativeWindowing.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.net.MalformedURLException;

--- a/uitest/src/main/java/com/vaadin/tests/TestForPreconfiguredComponents.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForPreconfiguredComponents.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.ui.Button;

--- a/uitest/src/main/java/com/vaadin/tests/TestForStyledUpload.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForStyledUpload.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.io.File;

--- a/uitest/src/main/java/com/vaadin/tests/TestForTablesInitialColumnWidthLogicRendering.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForTablesInitialColumnWidthLogicRendering.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.Iterator;

--- a/uitest/src/main/java/com/vaadin/tests/TestForTrees.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForTrees.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.event.Action;

--- a/uitest/src/main/java/com/vaadin/tests/TestForUpload.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForUpload.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.io.ByteArrayInputStream;

--- a/uitest/src/main/java/com/vaadin/tests/TestForWindowOpen.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForWindowOpen.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.ui.Button;

--- a/uitest/src/main/java/com/vaadin/tests/TestForWindowing.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForWindowing.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.ui.Button;

--- a/uitest/src/main/java/com/vaadin/tests/TestIFrames.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestIFrames.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.shared.ui.ContentMode;

--- a/uitest/src/main/java/com/vaadin/tests/TestSelectAndDatefieldInDeepLayouts.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestSelectAndDatefieldInDeepLayouts.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.Collection;

--- a/uitest/src/main/java/com/vaadin/tests/TestSetVisibleAndCaching.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestSetVisibleAndCaching.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.ui.Button;

--- a/uitest/src/main/java/com/vaadin/tests/TestSizeableIncomponents.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestSizeableIncomponents.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.io.File;

--- a/uitest/src/main/java/com/vaadin/tests/TestSplitPanel.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestSplitPanel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.ui.Label;

--- a/uitest/src/main/java/com/vaadin/tests/TreeFilesystem.java
+++ b/uitest/src/main/java/com/vaadin/tests/TreeFilesystem.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.io.File;

--- a/uitest/src/main/java/com/vaadin/tests/TreeFilesystemContainer.java
+++ b/uitest/src/main/java/com/vaadin/tests/TreeFilesystemContainer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.io.File;

--- a/uitest/src/main/java/com/vaadin/tests/UsingCustomNewItemHandlerInSelect.java
+++ b/uitest/src/main/java/com/vaadin/tests/UsingCustomNewItemHandlerInSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.Random;

--- a/uitest/src/main/java/com/vaadin/tests/UsingObjectsInSelect.java
+++ b/uitest/src/main/java/com/vaadin/tests/UsingObjectsInSelect.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import java.util.LinkedList;

--- a/uitest/src/main/java/com/vaadin/tests/VerifyAssertionsEnabled.java
+++ b/uitest/src/main/java/com/vaadin/tests/VerifyAssertionsEnabled.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/VerifyJreVersion.java
+++ b/uitest/src/main/java/com/vaadin/tests/VerifyJreVersion.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/application/DetachOldUIOnReload.java
+++ b/uitest/src/main/java/com/vaadin/tests/application/DetachOldUIOnReload.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.application;
 
 import java.util.ArrayList;

--- a/uitest/src/main/java/com/vaadin/tests/application/NavigateWithOngoingXHR.java
+++ b/uitest/src/main/java/com/vaadin/tests/application/NavigateWithOngoingXHR.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.application;
 
 import java.io.IOException;

--- a/uitest/src/main/java/com/vaadin/tests/application/VaadinSessionAttribute.java
+++ b/uitest/src/main/java/com/vaadin/tests/application/VaadinSessionAttribute.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.application;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/application/calculator/Calc.java
+++ b/uitest/src/main/java/com/vaadin/tests/application/calculator/Calc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.application.calculator;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/applicationcontext/CloseSession.java
+++ b/uitest/src/main/java/com/vaadin/tests/applicationcontext/CloseSession.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.applicationcontext;
 
 import javax.servlet.http.HttpSession;

--- a/uitest/src/main/java/com/vaadin/tests/applicationcontext/CloseUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/applicationcontext/CloseUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.applicationcontext;
 
 import com.vaadin.server.Page;

--- a/uitest/src/main/java/com/vaadin/tests/applicationservlet/InitParamUIProvider.java
+++ b/uitest/src/main/java/com/vaadin/tests/applicationservlet/InitParamUIProvider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.applicationservlet;
 
 import com.vaadin.server.UIClassSelectionEvent;

--- a/uitest/src/main/java/com/vaadin/tests/browserfeatures/WebkitScrollbarTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/browserfeatures/WebkitScrollbarTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.browserfeatures;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/components/FileDownloaderUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/FileDownloaderUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components;
 
 import java.awt.image.BufferedImage;

--- a/uitest/src/main/java/com/vaadin/tests/components/abstractcomponent/RemSizeUnitTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/abstractcomponent/RemSizeUnitTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.abstractcomponent;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/components/abstractcomponent/UseStateFromHierachy.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/abstractcomponent/UseStateFromHierachy.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.abstractcomponent;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/components/button/ButtonIOSDragTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/button/ButtonIOSDragTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.button;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/components/button/ButtonUpdateAltText.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/button/ButtonUpdateAltText.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/components/customcomponent/CustomComponentHideContent.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/customcomponent/CustomComponentHideContent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.customcomponent;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/components/draganddropwrapper/DragAndDropBatchUpload.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/draganddropwrapper/DragAndDropBatchUpload.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.draganddropwrapper;
 
 import java.io.OutputStream;

--- a/uitest/src/main/java/com/vaadin/tests/components/draganddropwrapper/DragAndDropWrapperInPanel.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/draganddropwrapper/DragAndDropWrapperInPanel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.draganddropwrapper;
 
 import com.vaadin.tests.components.TestBase;

--- a/uitest/src/main/java/com/vaadin/tests/components/gridlayout/InsertRowInMiddle.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/gridlayout/InsertRowInMiddle.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.gridlayout;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/components/gridlayout/LayoutAfterHidingError.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/gridlayout/LayoutAfterHidingError.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.gridlayout;
 
 import com.vaadin.server.UserError;

--- a/uitest/src/main/java/com/vaadin/tests/components/javascriptcomponent/JavaScriptResizeListener.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/javascriptcomponent/JavaScriptResizeListener.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.javascriptcomponent;
 
 import com.vaadin.annotations.JavaScript;

--- a/uitest/src/main/java/com/vaadin/tests/components/layout/EmptySpaceOnPageAfterExpandedComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/layout/EmptySpaceOnPageAfterExpandedComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.layout;
 
 import com.vaadin.server.Page;

--- a/uitest/src/main/java/com/vaadin/tests/components/media/AudioTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/media/AudioTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.media;
 
 import com.vaadin.server.ClassResource;

--- a/uitest/src/main/java/com/vaadin/tests/components/media/Media.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/media/Media.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.media;
 
 import com.vaadin.server.ExternalResource;

--- a/uitest/src/main/java/com/vaadin/tests/components/orderedlayout/ErrorIndicator.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/orderedlayout/ErrorIndicator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/components/orderedlayout/ExpandChangeReattach.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/orderedlayout/ExpandChangeReattach.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.orderedlayout;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/components/orderedlayout/TooltipOnRequiredIndicator.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/orderedlayout/TooltipOnRequiredIndicator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/components/panel/WebkitScrollbarTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/panel/WebkitScrollbarTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.panel;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/components/progressindicator/ProgressBarTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/progressindicator/ProgressBarTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.progressindicator;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/components/slider/SliderUpdateFromValueChange.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/slider/SliderUpdateFromValueChange.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/components/splitpanel/RetainSplitterPositionWhenOutOfBounds.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/splitpanel/RetainSplitterPositionWhenOutOfBounds.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.splitpanel;
 
 import com.vaadin.server.Sizeable;

--- a/uitest/src/main/java/com/vaadin/tests/components/table/ColumnReorderingWithManyColumns.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/ColumnReorderingWithManyColumns.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.table;
 
 import com.vaadin.tests.components.TestBase;

--- a/uitest/src/main/java/com/vaadin/tests/components/table/ContainerSizeChangeDuringTablePaint.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/ContainerSizeChangeDuringTablePaint.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.table;
 
 import java.util.Iterator;

--- a/uitest/src/main/java/com/vaadin/tests/components/table/HiddenComponentCells.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/HiddenComponentCells.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/components/table/RefreshRenderedCellsOnlyIfAttached.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/RefreshRenderedCellsOnlyIfAttached.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.table;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/components/table/SetCurrentPageFirstItemIndex.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/SetCurrentPageFirstItemIndex.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/components/table/TableRemovedQuicklySendsInvalidRpcCalls.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/TableRemovedQuicklySendsInvalidRpcCalls.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.table;
 
 import java.util.ArrayList;

--- a/uitest/src/main/java/com/vaadin/tests/components/tabsheet/TabSheetHotKeysWithModifiers.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/tabsheet/TabSheetHotKeysWithModifiers.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/components/tabsheet/TabSheetWithTabIds.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/tabsheet/TabSheetWithTabIds.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/components/textfield/TextFieldEmptyingPrompt.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/textfield/TextFieldEmptyingPrompt.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.textfield;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/components/textfield/TextFieldTruncatesUnderscoresInModalDialogs.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/textfield/TextFieldTruncatesUnderscoresInModalDialogs.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.textfield;
 
 import com.vaadin.annotations.Theme;

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/CustomUITest.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/CustomUITest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.ui;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/PollListening.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/PollListening.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.ui;
 
 import com.vaadin.event.UIEvents.PollEvent;

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/UIAccess.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/UIAccess.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.ui;
 
 import java.util.concurrent.CountDownLatch;

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/UIAccessExceptionHandling.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/UIAccessExceptionHandling.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.ui;
 
 import java.util.Map;

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/UIInitTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/UIInitTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.ui;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/UIRefresh.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/UIRefresh.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.ui;
 
 import com.vaadin.annotations.PreserveOnRefresh;

--- a/uitest/src/main/java/com/vaadin/tests/components/window/WindowThemes.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/window/WindowThemes.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/debug/HierarchyAfterAnalyzeLayouts.java
+++ b/uitest/src/main/java/com/vaadin/tests/debug/HierarchyAfterAnalyzeLayouts.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.debug;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/extensions/BasicExtension.java
+++ b/uitest/src/main/java/com/vaadin/tests/extensions/BasicExtension.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.extensions;
 
 import com.vaadin.server.AbstractClientConnector;

--- a/uitest/src/main/java/com/vaadin/tests/extensions/BasicExtensionTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/extensions/BasicExtensionTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.extensions;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/extensions/BrowserPopupExtensionTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/extensions/BrowserPopupExtensionTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.extensions;
 
 import java.util.ArrayList;

--- a/uitest/src/main/java/com/vaadin/tests/extensions/JavascriptManagerTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/extensions/JavascriptManagerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.extensions;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/extensions/ResponsiveLayoutUpdate.java
+++ b/uitest/src/main/java/com/vaadin/tests/extensions/ResponsiveLayoutUpdate.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.extensions;
 
 import com.vaadin.annotations.Theme;

--- a/uitest/src/main/java/com/vaadin/tests/extensions/ResponsiveUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/extensions/ResponsiveUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.extensions;
 
 import com.vaadin.annotations.Theme;

--- a/uitest/src/main/java/com/vaadin/tests/extensions/ResponsiveWidthAndHeight.java
+++ b/uitest/src/main/java/com/vaadin/tests/extensions/ResponsiveWidthAndHeight.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.extensions;
 
 import com.vaadin.annotations.Theme;

--- a/uitest/src/main/java/com/vaadin/tests/extensions/SimpleJavaScriptExtensionTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/extensions/SimpleJavaScriptExtensionTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.extensions;
 
 import com.vaadin.annotations.JavaScript;

--- a/uitest/src/main/java/com/vaadin/tests/integration/ProxyTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/integration/ProxyTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.integration;
 
 import javax.servlet.http.HttpServletRequest;

--- a/uitest/src/main/java/com/vaadin/tests/layouts/MarginWithExpandRatio.java
+++ b/uitest/src/main/java/com/vaadin/tests/layouts/MarginWithExpandRatio.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.layouts;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/broadcastingmessages/Broadcaster.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/broadcastingmessages/Broadcaster.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.broadcastingmessages;
 
 import java.util.List;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/AutoGeneratingForm.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/AutoGeneratingForm.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a1;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/BasicApplication.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/BasicApplication.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a1;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/CreatingPreserveState.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/CreatingPreserveState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a1;
 
 import com.vaadin.annotations.PreserveOnRefresh;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/DefineUITheme.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/DefineUITheme.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a1;
 
 import com.vaadin.annotations.Theme;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/DifferentFeaturesForDifferentClients.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/DifferentFeaturesForDifferentClients.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a1;
 
 import com.vaadin.server.UIClassSelectionEvent;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/FindCurrentUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/FindCurrentUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a1;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/MultiTabApplication.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/MultiTabApplication.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a1;
 
 import com.vaadin.server.ExternalResource;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/UsingBeanValidation.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/UsingBeanValidation.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a1;
 
 import javax.validation.constraints.Max;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/UsingUriFragments.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/UsingUriFragments.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a1;
 
 import com.vaadin.server.Page.UriFragmentChangedEvent;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/UsingXyzWhenInitializing.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a1/UsingXyzWhenInitializing.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a1;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/ComponentInStateComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/ComponentInStateComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a2;
 
 import com.vaadin.tests.widgetset.client.minitutorials.v7a2.ComponentInStateState;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/MyComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/MyComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a2;
 
 import com.vaadin.shared.MouseEventDetails;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/MyComponentUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/MyComponentUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a2;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/MyPickerConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/MyPickerConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a2;
 
 import com.google.gwt.dom.client.Element;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/ResourceInStateComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/ResourceInStateComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a2;
 
 import com.vaadin.server.Resource;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/ResourceInStateUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a2/ResourceInStateUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a2;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/Analytics.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/Analytics.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import com.vaadin.annotations.JavaScript;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/AnalyticsUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/AnalyticsUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/CapsLockWarning.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/CapsLockWarning.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import com.vaadin.server.AbstractExtension;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/CapsLockWarningUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/CapsLockWarningUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/ComplexTypesBean.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/ComplexTypesBean.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 public class ComplexTypesBean {

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/ComplexTypesComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/ComplexTypesComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import java.util.ArrayList;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/ComplexTypesRpc.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/ComplexTypesRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import java.util.List;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/ComplexTypesUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/ComplexTypesUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/Flot.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/Flot.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import java.util.ArrayList;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/FlotHighlightRpc.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/FlotHighlightRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import com.vaadin.shared.communication.ClientRpc;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/FlotJavaScriptUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/FlotJavaScriptUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/RedButton.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/RedButton.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import com.vaadin.annotations.StyleSheet;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/RedButtonUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/RedButtonUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/RefresherTestUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7a3/RefresherTestUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7a3;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b1/Addition.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b1/Addition.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7b1;
 
 import com.vaadin.shared.AbstractComponentState;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b1/AxessingWebPageAndBrowserInfoUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b1/AxessingWebPageAndBrowserInfoUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7b1;
 
 import com.vaadin.server.Page;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b1/BootstrapListenerCode.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b1/BootstrapListenerCode.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7b1;
 
 import java.util.List;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b1/CapsLockWarningWithRpc.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b1/CapsLockWarningWithRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7b1;
 
 import com.vaadin.server.AbstractExtension;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b1/ReducingRoundTrips.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b1/ReducingRoundTrips.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7b1;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b2/CleanupUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b2/CleanupUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7b2;
 
 import com.vaadin.server.ClientConnector.DetachListener;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b5/HandlingLogout.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b5/HandlingLogout.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7b5;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b5/SettingReadingSessionAttributesUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b5/SettingReadingSessionAttributesUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7b5;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b6/LettingUserDownloadFile.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b6/LettingUserDownloadFile.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7b6;
 
 import java.awt.image.BufferedImage;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b6/MyPopupUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b6/MyPopupUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7b6;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b6/OpeningUIInPopup.java
+++ b/uitest/src/main/java/com/vaadin/tests/minitutorials/v7b6/OpeningUIInPopup.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.minitutorials.v7b6;
 
 import com.vaadin.server.BrowserWindowOpener;

--- a/uitest/src/main/java/com/vaadin/tests/push/BarInUIDL.java
+++ b/uitest/src/main/java/com/vaadin/tests/push/BarInUIDL.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.push;
 
 import com.vaadin.annotations.Push;

--- a/uitest/src/main/java/com/vaadin/tests/push/PushConfigurator.java
+++ b/uitest/src/main/java/com/vaadin/tests/push/PushConfigurator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/push/PushLargeData.java
+++ b/uitest/src/main/java/com/vaadin/tests/push/PushLargeData.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/push/PushLargeDataWebsocket.java
+++ b/uitest/src/main/java/com/vaadin/tests/push/PushLargeDataWebsocket.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.push;
 
 import com.vaadin.annotations.Push;

--- a/uitest/src/main/java/com/vaadin/tests/push/TablePushStreaming.java
+++ b/uitest/src/main/java/com/vaadin/tests/push/TablePushStreaming.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */

--- a/uitest/src/main/java/com/vaadin/tests/push/TrackMessageSizeUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/push/TrackMessageSizeUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.push;
 
 import java.io.IOException;

--- a/uitest/src/main/java/com/vaadin/tests/serialization/ChangeStateWhenReattaching.java
+++ b/uitest/src/main/java/com/vaadin/tests/serialization/ChangeStateWhenReattaching.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.serialization;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/serialization/DelegateToWidgetTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/serialization/DelegateToWidgetTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.serialization;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/serialization/DelegateWithoutStateClassTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/serialization/DelegateWithoutStateClassTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.serialization;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/serialization/LegacySerializerUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/serialization/LegacySerializerUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.serialization;
 
 import java.util.Map;

--- a/uitest/src/main/java/com/vaadin/tests/serialization/SerializerNamespaceTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/serialization/SerializerNamespaceTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.serialization;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/serialization/SerializerTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/serialization/SerializerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.serialization;
 
 import java.text.DateFormat;

--- a/uitest/src/main/java/com/vaadin/tests/tooltip/TooltipInWindow.java
+++ b/uitest/src/main/java/com/vaadin/tests/tooltip/TooltipInWindow.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.tooltip;
 
 import com.vaadin.server.VaadinRequest;

--- a/uitest/src/main/java/com/vaadin/tests/util/SampleDirectory.java
+++ b/uitest/src/main/java/com/vaadin/tests/util/SampleDirectory.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.util;
 
 import java.io.File;

--- a/uitest/src/main/java/com/vaadin/tests/vaadincontext/BootstrapModifyUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/vaadincontext/BootstrapModifyUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.vaadincontext;
 
 import org.jsoup.nodes.Element;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/TestingWidgetSet.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/TestingWidgetSet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset;
 
 public class TestingWidgetSet {

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/BasicExtensionTestConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/BasicExtensionTestConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.google.gwt.dom.client.DivElement;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/ComplexTestBean.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/ComplexTestBean.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import java.util.List;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/CustomUIConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/CustomUIConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.google.gwt.dom.client.Document;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/CustomUIConnectorRpc.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/CustomUIConnectorRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.vaadin.shared.communication.ClientRpc;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/DelegateConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/DelegateConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.vaadin.client.ui.AbstractComponentConnector;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/DelegateState.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/DelegateState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.vaadin.shared.AbstractComponentState;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/DelegateWidget.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/DelegateWidget.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.google.gwt.user.client.ui.HTML;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/DelegateWithoutStateClassConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/DelegateWithoutStateClassConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.google.gwt.core.shared.GWT;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/DummyLabelConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/DummyLabelConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.vaadin.client.communication.StateChangeEvent;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/IntermediateReplaceConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/IntermediateReplaceConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.vaadin.shared.ui.Connect;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/LabelState.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/LabelState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.vaadin.shared.AbstractComponentState;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/ReplacedConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/ReplacedConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.google.gwt.user.client.ui.HTML;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/ReplacingConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/ReplacingConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.vaadin.shared.ui.Connect;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/SerializerTestConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/SerializerTestConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import java.util.ArrayList;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/SerializerTestRpc.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/SerializerTestRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import java.util.Date;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/SimpleTestBean.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/SimpleTestBean.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import java.io.Serializable;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/UseStateFromHierachyChangeConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/UseStateFromHierachyChangeConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.google.gwt.user.client.ui.SimplePanel;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/UseStateFromHierachyChangeConnectorState.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/UseStateFromHierachyChangeConnectorState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.vaadin.shared.Connector;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/VExtendedTextArea.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/VExtendedTextArea.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client;
 
 import com.vaadin.v7.client.ui.VTextArea;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7a2/ComponentInStateState.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7a2/ComponentInStateState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client.minitutorials.v7a2;
 
 import com.vaadin.shared.AbstractComponentState;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7a2/ComponentInStateStateConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7a2/ComponentInStateStateConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client.minitutorials.v7a2;
 
 import com.google.gwt.user.client.ui.Label;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7a2/MyComponentWidget.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7a2/MyComponentWidget.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client.minitutorials.v7a2;
 
 import com.google.gwt.user.client.ui.Label;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7a2/ResourceInStateConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7a2/ResourceInStateConnector.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client.minitutorials.v7a2;
 
 import com.google.gwt.user.client.ui.Image;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7a3/ClientSideModule.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7a3/ClientSideModule.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client.minitutorials.v7a3;
 
 import com.google.gwt.core.client.EntryPoint;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7b1/CapsLockWarningRpc.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/minitutorials/v7b1/CapsLockWarningRpc.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.client.minitutorials.v7b1;
 
 import com.vaadin.shared.annotations.Delayed;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/server/DelegateToWidgetComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/server/DelegateToWidgetComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.server;
 
 import com.vaadin.tests.widgetset.client.DelegateState;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/server/DelegateWithoutStateClassComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/server/DelegateWithoutStateClassComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.server;
 
 import com.vaadin.v7.ui.TextArea;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/server/DummyLabel.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/server/DummyLabel.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.server;
 
 import com.vaadin.tests.widgetset.client.LabelState;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/server/ReplaceComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/server/ReplaceComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.server;
 
 import com.vaadin.ui.AbstractComponent;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/server/ReplaceComponentUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/server/ReplaceComponentUI.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.server;
 
 import com.vaadin.annotations.Widgetset;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/server/SerializerTestExtension.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/server/SerializerTestExtension.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.server;
 
 import com.vaadin.server.AbstractExtension;

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/server/UseStateFromHierachyComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/server/UseStateFromHierachyComponent.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.widgetset.server;
 
 import com.vaadin.tests.widgetset.client.UseStateFromHierachyChangeConnectorState;

--- a/uitest/src/main/java/com/vaadin/v7/tests/components/grid/basicfeatures/EscalatorBasicClientFeatures.java
+++ b/uitest/src/main/java/com/vaadin/v7/tests/components/grid/basicfeatures/EscalatorBasicClientFeatures.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.tests.components.grid.basicfeatures;
 
 import com.vaadin.annotations.Title;

--- a/uitest/src/main/java/com/vaadin/v7/tests/components/textfield/TextChangeListenerLosesFocus.java
+++ b/uitest/src/main/java/com/vaadin/v7/tests/components/textfield/TextChangeListenerLosesFocus.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.v7.tests.components.textfield;
 
 import com.vaadin.tests.components.TestBase;

--- a/uitest/src/test/java/com/vaadin/tests/components/table/TableDropIndicatorValoTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/table/TableDropIndicatorValoTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.table;
 
 import java.util.List;

--- a/uitest/src/test/java/com/vaadin/tests/components/ui/UIRefreshTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ui/UIRefreshTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.components.ui;
 
 import org.junit.Assert;

--- a/uitest/src/test/java/com/vaadin/tests/extensions/ResponsiveLayoutUpdateTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/extensions/ResponsiveLayoutUpdateTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.extensions;
 
 import org.junit.Test;

--- a/uitest/src/test/java/com/vaadin/tests/extensions/ResponsiveUITest.java
+++ b/uitest/src/test/java/com/vaadin/tests/extensions/ResponsiveUITest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.extensions;
 
 import static org.junit.Assert.assertEquals;

--- a/uitest/src/test/java/com/vaadin/tests/extensions/ResponsiveWidthAndHeightTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/extensions/ResponsiveWidthAndHeightTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.extensions;
 
 import static org.junit.Assert.assertEquals;

--- a/uitest/src/test/java/com/vaadin/tests/tb3/AbstractTB3Test.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/AbstractTB3Test.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.tb3;
 
 import java.io.IOException;

--- a/uitest/src/test/java/com/vaadin/tests/tb3/AllTB3Tests.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/AllTB3Tests.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.tb3;
 
 import java.io.IOException;

--- a/uitest/src/test/java/com/vaadin/tests/tb3/MultiBrowserTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/MultiBrowserTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.tb3;
 
 import java.util.ArrayList;

--- a/uitest/src/test/java/com/vaadin/tests/tb3/ParallelScheduler.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/ParallelScheduler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.tb3;
 
 import java.util.ArrayList;

--- a/uitest/src/test/java/com/vaadin/tests/tb3/PrivateTB3Configuration.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/PrivateTB3Configuration.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.tb3;
 
 import java.io.File;

--- a/uitest/src/test/java/com/vaadin/tests/tb3/ScreenshotTB3Test.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/ScreenshotTB3Test.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.tb3;
 
 import java.io.File;

--- a/uitest/src/test/java/com/vaadin/tests/tb3/TB3Runner.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/TB3Runner.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.tb3;
 
 import java.lang.reflect.Field;

--- a/uitest/src/test/java/com/vaadin/tests/tb3/TB3TestSuite.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/TB3TestSuite.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.tb3;
 
 import java.io.IOException;

--- a/uitest/src/test/java/com/vaadin/tests/tb3/TooltipTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/TooltipTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.tests.tb3;
 
 import java.util.List;

--- a/uitest/src/test/java/com/vaadin/tests/tb3/WebsocketTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/WebsocketTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 /**
  *
  */


### PR DESCRIPTION
Remove extra line before package declaration.

Currently some Java files have no empty line between the license header and package declaration, and some files have.

This PR removes the empty line between the license header and the package declaration, to unify all the sources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8763)
<!-- Reviewable:end -->
