### PR TITLE
Correctly detach components in merged cells

### DIFF
--- a/server/src/main/java/com/vaadin/ui/components/grid/StaticSection.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/StaticSection.java
@@ -388,6 +388,13 @@ public abstract class StaticSection<ROW extends StaticSection.StaticRow<?>>
             for (CELL cell : cells.values()) {
                 cell.detach();
             }
+            for (CellState cellState : rowState.cellGroups.keySet()) {
+                if (cellState.type == GridStaticCellType.WIDGET
+                        && cellState.connector != null) {
+                    ((Component) cellState.connector).setParent(null);
+                    cellState.connector = null;
+                }
+            }
         }
 
         void checkIfAlreadyMerged(String columnId) {

--- a/server/src/test/java/com/vaadin/tests/server/component/grid/GridChildrenTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/grid/GridChildrenTest.java
@@ -64,12 +64,33 @@ public class GridChildrenTest {
     }
 
     @Test
+    public void removeHeaderWithComponentInMergedHeaderCell() {
+        HeaderCell merged = grid.getDefaultHeaderRow().join("foo", "bar",
+                "baz");
+        Label label = new Label();
+        merged.setComponent(label);
+        Assert.assertEquals(grid, label.getParent());
+        grid.removeHeaderRow(0);
+        Assert.assertNull(label.getParent());
+    }
+
+    @Test
     public void removeComponentInMergedFooterCell() {
         FooterCell merged = grid.addFooterRowAt(0).join("foo", "bar", "baz");
         Label label = new Label();
         merged.setComponent(label);
         Assert.assertEquals(grid, label.getParent());
         merged.setText("foo");
+        Assert.assertNull(label.getParent());
+    }
+
+    @Test
+    public void removeFooterWithComponentInMergedFooterCell() {
+        FooterCell merged = grid.addFooterRowAt(0).join("foo", "bar", "baz");
+        Label label = new Label();
+        merged.setComponent(label);
+        Assert.assertEquals(grid, label.getParent());
+        grid.removeFooterRow(0);
         Assert.assertNull(label.getParent());
     }
 


### PR DESCRIPTION
This was already once fixed in 7.7 in #8142

Test depends on #8772

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8773)
<!-- Reviewable:end -->
