### PR TITLE
components-grid to use correct function setHidable

### DIFF
--- a/documentation/components/components-grid.asciidoc
+++ b/documentation/components/components-grid.asciidoc
@@ -310,8 +310,8 @@ the [methodname]#removeColumn()#, as described later.
 === Hiding and Removing Columns
 
 Columns can be hidden by calling [methodname]#setHidden()# in [classname]#Column#.
-Furthermore, you can set the columns user hideable using method
-[methodname]#setHideable()#.
+Furthermore, you can set the columns user hidable using method
+[methodname]#setHidable()#.
 
 Columns can be removed with [methodname]#removeColumn()# and
 [methodname]#removeAllColumns()#. To restore a previously removed column,


### PR DESCRIPTION
The correct function to use in Vaadin 8 (also before) is setHidable()
https://vaadin.com/api/8.0.0/com/vaadin/ui/Grid.Column.html#setHidable-boolean-
For 7.7.7:
https://vaadin.com/api/7.7.7/com/vaadin/ui/Grid.Column.html#setHidable-boolean-

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8843)
<!-- Reviewable:end -->
