### PR TITLE
Remove unnecessary width calculation on Grid initial render

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -5002,7 +5002,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             if (this.sortable != sortable) {
                 this.sortable = sortable;
                 if (grid != null) {
-                    grid.refreshHeader();
+                    grid.getHeader().requestSectionRefresh();
                 }
             }
             return this;
@@ -5035,7 +5035,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             if (this.resizable != resizable) {
                 this.resizable = resizable;
                 if (grid != null) {
-                    grid.refreshHeader();
+                    grid.getHeader().requestSectionRefresh();
                 }
             }
             return this;
@@ -8720,16 +8720,20 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     protected void onAttach() {
         super.onAttach();
 
-        if (getEscalator().getBody().getRowCount() == 0 && dataSource != null) {
-            setEscalatorSizeFromDataSource();
-        }
+        Scheduler.get().scheduleFinally(() -> {
+            if (getEscalator().getBody().getRowCount() == 0
+                    && dataSource != null) {
+                setEscalatorSizeFromDataSource();
+            }
 
-        // Grid was just attached to DOM. Column widths should be calculated.
-        recalculateColumnWidths();
-        for (int row : reattachVisibleDetails) {
-            setDetailsVisible(row, true);
-        }
-        reattachVisibleDetails.clear();
+            // Grid was just attached to DOM. Column widths should be
+            // calculated.
+            recalculateColumnWidths();
+            for (int row : reattachVisibleDetails) {
+                setDetailsVisible(row, true);
+            }
+            reattachVisibleDetails.clear();
+        });
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -8720,20 +8720,18 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     protected void onAttach() {
         super.onAttach();
 
-        Scheduler.get().scheduleFinally(() -> {
-            if (getEscalator().getBody().getRowCount() == 0
-                    && dataSource != null) {
-                setEscalatorSizeFromDataSource();
-            }
+        // Grid was just attached to DOM. Column widths should be
+        // calculated.
+        recalculateColumnWidths();
 
-            // Grid was just attached to DOM. Column widths should be
-            // calculated.
-            recalculateColumnWidths();
-            for (int row : reattachVisibleDetails) {
-                setDetailsVisible(row, true);
-            }
-            reattachVisibleDetails.clear();
-        });
+        if (getEscalator().getBody().getRowCount() == 0 && dataSource != null) {
+            setEscalatorSizeFromDataSource();
+        }
+
+        for (int row : reattachVisibleDetails) {
+            setDetailsVisible(row, true);
+        }
+        reattachVisibleDetails.clear();
     }
 
     @Override

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridManyColumns.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridManyColumns.java
@@ -1,0 +1,27 @@
+package com.vaadin.tests.components.grid;
+
+import java.util.stream.IntStream;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Grid;
+
+/**
+ * Test UI for Grid initial rendering performance profiling.
+ */
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class GridManyColumns extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        Grid<String> grid = new Grid<>();
+        grid.setSizeFull();
+        for (int i = 0; i < 80; i++) {
+            grid.addColumn(row -> "novalue").setCaption("Column_" + i)
+                    .setWidth(200);
+        }
+        grid.setItems(IntStream.range(0, 10).boxed().map(i -> ""));
+        addComponent(grid);
+    }
+}

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridManyColumnsV7.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridManyColumnsV7.java
@@ -1,0 +1,51 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.v7.data.Container.Indexed;
+import com.vaadin.v7.data.Item;
+import com.vaadin.v7.data.util.IndexedContainer;
+import com.vaadin.v7.ui.Grid;
+
+/**
+ * Test UI for Grid initial rendering performance profiling.
+ */
+@Widgetset("com.vaadin.v7.Vaadin7WidgetSet")
+public class GridManyColumnsV7 extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        Grid grid = new Grid();
+        grid.setSizeFull();
+        for (int i = 0; i < 80; i++) {
+            grid.addColumn("Column_" + i).setWidth(200);
+        }
+        grid.setContainerDataSource(createContainer());
+        addComponent(grid);
+    }
+
+    private Indexed createContainer() {
+        Indexed container = new IndexedContainer();
+
+        container.addContainerProperty("foo", String.class, "foo");
+        container.addContainerProperty("bar", Integer.class, 0);
+        // km contains double values from 0.0 to 2.0
+        container.addContainerProperty("km", Double.class, 0);
+        for (int i = 0; i < 80; ++i) {
+            container.addContainerProperty("Column_" + i, String.class,
+                    "novalue");
+        }
+
+        for (int i = 0; i <= 10; ++i) {
+            Object itemId = container.addItem();
+            Item item = container.getItem(itemId);
+            for (int j = 0; j < 80; ++j) {
+                item.getItemProperty("Column_" + j).setValue("novalue");
+            }
+        }
+
+        return container;
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridManyColumnsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridManyColumnsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.grid;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.testbench.parallel.TestCategory;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+/**
+ * Tests that Grid gets correct height based on height mode, and resizes
+ * properly with details row if height is undefined.
+ *
+ * @author Vaadin Ltd
+ */
+@TestCategory("grid")
+public class GridManyColumnsTest extends MultiBrowserTest {
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        openTestURL();
+        waitForElementPresent(By.className("v-grid"));
+    }
+
+    @Test
+    public void testGridPerformance() throws InterruptedException {
+        long renderingTime = testBench().totalTimeSpentRendering();
+        long requestTime = testBench().totalTimeSpentServicingRequests();
+        System.out.println("Grid with many columns spent " + renderingTime
+                + "ms rendering and " + requestTime + "ms servicing requests ("
+                + getDesiredCapabilities().getBrowserName() + ")");
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridManyColumnsV7Test.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridManyColumnsV7Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.grid;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.testbench.parallel.TestCategory;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+/**
+ * Tests that Grid gets correct height based on height mode, and resizes
+ * properly with details row if height is undefined.
+ *
+ * @author Vaadin Ltd
+ */
+@TestCategory("grid")
+public class GridManyColumnsV7Test extends MultiBrowserTest {
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        openTestURL();
+        waitForElementPresent(By.className("v-grid"));
+    }
+
+    @Test
+    public void testGridPerformance() throws InterruptedException {
+        long renderingTime = testBench().totalTimeSpentRendering();
+        long requestTime = testBench().totalTimeSpentServicingRequests();
+        System.out.println("Grid V7 with many columns spent " + renderingTime
+                + "ms rendering and " + requestTime + "ms servicing requests ("
+                + getDesiredCapabilities().getBrowserName() + ")");
+    }
+
+}


### PR DESCRIPTION
Do not calculate column widths unnecessarily, especially for columns
with fixed width.

Fixes #8678

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8848)
<!-- Reviewable:end -->
