### PR TITLE
ApplicationRunnerServlet to correctly get last modified application

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following preferences need to be set to keep the project consistent. You nee
 1. In a Project Explorer  right-click *vaadin-uitest*
 1. Open *Run As* -> *Maven build...*
 1. Type in <code>jetty:run-exploded</code> into *Goals* and click *Run*
-1. Open URL *http://localhost:8080/run/&lt;testUI&gt;*
+1. Open URL *http://localhost:8888/run/&lt;testUI&gt;*
 
 ## Setting up IntelliJ IDEA to Develop Vaadin 7
 
@@ -75,7 +75,7 @@ The following preferences need to be set to keep the project consistent. You nee
 
 1. Open *Maven Projects*
 1. Open *vaadin-uitest* -> *Plugins* -> *jetty* -> *jetty:run-exploded*
-1. Open URL *http://localhost:8080/run/&lt;testUI&gt;*
+1. Open URL *http://localhost:8888/run/&lt;testUI&gt;*
 
 ## Running a Development Server
 

--- a/uitest/src/main/java/com/vaadin/launcher/ApplicationRunnerServlet.java
+++ b/uitest/src/main/java/com/vaadin/launcher/ApplicationRunnerServlet.java
@@ -337,7 +337,7 @@ public class ApplicationRunnerServlet extends LegacyVaadinServlet {
     private static String findLastModifiedApplication() {
         String lastModifiedClassName = null;
 
-        File uitestDir = new File("uitest/src");
+        File uitestDir = new File("src/main/java");
         if (uitestDir.isDirectory()) {
             LinkedList<File> stack = new LinkedList<>();
             stack.add(uitestDir);
@@ -358,7 +358,6 @@ public class ApplicationRunnerServlet extends LegacyVaadinServlet {
                             lastModifiedTimestamp = file.lastModified();
                             lastModifiedClassName = className;
                         }
-
                     }
                 }
             }


### PR DESCRIPTION
Also, change `README.txt` to have the correct test port `8888`.

This was detected by going to the URL `http://localhost:8888/run/<testUI>`,
and then going to
`http://localhost:8888/run`

Then an exception thrown:
```
Caused by: java.lang.IllegalArgumentException: No application specified
	at com.vaadin.launcher.ApplicationRunnerServlet.findLastModifiedApplication(ApplicationRunnerServlet.java:368)
	at com.vaadin.launcher.ApplicationRunnerServlet.getApplicationRunnerURIs(ApplicationRunnerServlet.java:324)
	at com.vaadin.launcher.ApplicationRunnerServlet.getApplicationRunnerApplicationClassName(ApplicationRunnerServlet.java:232)
	at com.vaadin.launcher.ApplicationRunnerServlet.getClassToRun(ApplicationRunnerServlet.java:398)
```


This is because the search folder for the last modified application was changed, mostly after migrating to maven structure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8852)
<!-- Reviewable:end -->
