### PR TITLE
Fix documentation: Change fromCollection -> ofCollection

### DIFF
--- a/documentation/datamodel/datamodel-providers.asciidoc
+++ b/documentation/datamodel/datamodel-providers.asciidoc
@@ -94,7 +94,7 @@ All components will automatically update themselves when the sorting of the data
 [source, java]
 ----
 ListDataProvider<Person> dataProvider =
-  DataProvider.fromCollection(persons);
+  DataProvider.ofCollection(persons);
 
 dataProvider.setSortOrder(Person::getName,
   SortDirection.ASCENDING);
@@ -116,7 +116,7 @@ You can configure the data provider to always apply some specific filter to limi
 [source, java]
 ----
 ListDataProvider<Person> dataProvider =
-  DataProvider.fromCollection(persons);
+  DataProvider.ofCollection(persons);
 
 ComboBox<Person> comboBox = new ComboBox<>();
 comboBox.setDataProvider(dataProvider);
@@ -141,7 +141,7 @@ To configure filtering through a component beyond what is possible with `Caption
 [source, java]
 ----
 ListDataProvider<Person> dataProvider =
-  DataProvider.fromCollection(persons);
+  DataProvider.ofCollection(persons);
 
 comboBox.setDataProvider(dataProvider.filteringBy(
   (person, filterText) -> {


### PR DESCRIPTION
Maybe the examples were based on API draft or something like that? I could not find a method DataProvider.fromCollection but there is a DataProvider.ofCollection

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8882)
<!-- Reviewable:end -->
