### PR TITLE
Check Trident version to detect compatibility mode

### DIFF
--- a/client/src/test/java/com/vaadin/client/VBrowserDetailsUserAgentParserTest.java
+++ b/client/src/test/java/com/vaadin/client/VBrowserDetailsUserAgentParserTest.java
@@ -24,6 +24,9 @@ public class VBrowserDetailsUserAgentParserTest {
     private static final String KONQUEROR_LINUX = "Mozilla/5.0 (compatible; Konqueror/3.5; Linux) KHTML/3.5.5 (like Gecko) (Exabot-Thumbnails)";
 
     private static final String IE11_WINDOWS_7 = "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; rv:11.0) like Gecko";
+    private static final String IE11_WINDOWS_7_COMPATIBILITY_VIEW_IE7 = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E)";
+    private static final String IE11_WINDOWS_10_COMPATIBILITY_VIEW_IE7 = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E)";
+    private static final String IE11_INITIAL_WINDOWS_10_COMPATIBILITY_VIEW_IE7 = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; WOW64; Trident/8.0; .NET4.0C; .NET4.0E)";
     private static final String IE11_WINDOWS_PHONE_8_1_UPDATE = "Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920) Like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537";
 
     // "Version/" was added in 10.00
@@ -336,6 +339,39 @@ public class VBrowserDetailsUserAgentParserTest {
     @Test
     public void testIE11() {
         VBrowserDetails bd = new VBrowserDetails(IE11_WINDOWS_7);
+        assertTrident(bd);
+        assertEngineVersion(bd, 7);
+        assertIE(bd);
+        assertBrowserMajorVersion(bd, 11);
+        assertBrowserMinorVersion(bd, 0);
+        assertWindows(bd);
+    }
+
+    @Test
+    public void testIE11Windows7CompatibilityViewIE7() {
+        VBrowserDetails bd = new VBrowserDetails(IE11_WINDOWS_7_COMPATIBILITY_VIEW_IE7);
+        assertTrident(bd);
+        assertEngineVersion(bd, 7);
+        assertIE(bd);
+        assertBrowserMajorVersion(bd, 11);
+        assertBrowserMinorVersion(bd, 0);
+        assertWindows(bd);
+    }
+
+    @Test
+    public void testIE11Windows10CompatibilityViewIE7() {
+        VBrowserDetails bd = new VBrowserDetails(IE11_WINDOWS_10_COMPATIBILITY_VIEW_IE7);
+        assertTrident(bd);
+        assertEngineVersion(bd, 7);
+        assertIE(bd);
+        assertBrowserMajorVersion(bd, 11);
+        assertBrowserMinorVersion(bd, 0);
+        assertWindows(bd);
+    }
+
+    @Test
+    public void testIE11InitialWindows10CompatibilityViewIE7() {
+        VBrowserDetails bd = new VBrowserDetails(IE11_INITIAL_WINDOWS_10_COMPATIBILITY_VIEW_IE7);
         assertTrident(bd);
         assertEngineVersion(bd, 7);
         assertIE(bd);

--- a/shared/src/main/java/com/vaadin/shared/VBrowserDetails.java
+++ b/shared/src/main/java/com/vaadin/shared/VBrowserDetails.java
@@ -566,7 +566,8 @@ public class VBrowserDetails implements Serializable {
      */
     public boolean isTooOldToFunctionProperly() {
         // Check Trident version to detect compatibility mode
-        if (isIE() && getBrowserMajorVersion() < 11) {
+        if (isIE() && getBrowserMajorVersion() < 11
+                && getBrowserEngineVersion() < 7) {
             return true;
         }
         // Webkit 533 in Safari 4.1+, Android 2.2+, iOS 4+

--- a/shared/src/main/java/com/vaadin/shared/VBrowserDetails.java
+++ b/shared/src/main/java/com/vaadin/shared/VBrowserDetails.java
@@ -124,7 +124,7 @@ public class VBrowserDetails implements Serializable {
                 int tridentPos = userAgent.indexOf("trident/");
                 if (tridentPos >= 0) {
                     String tmp = userAgent
-                            .substring(tridentPos + "Trident/".length());
+                            .substring(tridentPos + "trident/".length());
                     tmp = tmp.replaceFirst("([0-9]+\\.[0-9]+).*", "$1");
                     browserEngineVersion = Float.parseFloat(tmp);
                 }
@@ -148,6 +148,13 @@ public class VBrowserDetails implements Serializable {
                         tmp = tmp.replaceFirst("(\\.[0-9]+).+", "$1");
                         parseVersionString(tmp);
                     }
+                } else if (isTrident) {
+                    // Check Trident version to detect compatibility mode
+                    int majorVersion = browserMajorVersion = 11;
+                    if (browserEngineVersion <= 7) {
+                        majorVersion = (int) (browserEngineVersion + 4);
+                    }
+                    setIEMode(majorVersion);
                 } else {
                     String ieVersionString = userAgent
                             .substring(userAgent.indexOf("msie ") + 5);
@@ -565,9 +572,7 @@ public class VBrowserDetails implements Serializable {
      *         supported or might work
      */
     public boolean isTooOldToFunctionProperly() {
-        // Check Trident version to detect compatibility mode
-        if (isIE() && getBrowserMajorVersion() < 11
-                && getBrowserEngineVersion() < 7) {
+        if (isIE() && getBrowserMajorVersion() < 11) {
             return true;
         }
         // Webkit 533 in Safari 4.1+, Android 2.2+, iOS 4+

--- a/shared/src/main/java/com/vaadin/shared/VBrowserDetails.java
+++ b/shared/src/main/java/com/vaadin/shared/VBrowserDetails.java
@@ -149,12 +149,8 @@ public class VBrowserDetails implements Serializable {
                         parseVersionString(tmp);
                     }
                 } else if (isTrident) {
-                    // Check Trident version to detect compatibility mode
-                    int majorVersion = browserMajorVersion = 11;
-                    if (browserEngineVersion <= 7) {
-                        majorVersion = (int) (browserEngineVersion + 4);
-                    }
-                    setIEMode(majorVersion);
+                    // See https://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx#TriToken
+                    setIEMode((int) browserEngineVersion + 4);
                 } else {
                     String ieVersionString = userAgent
                             .substring(userAgent.indexOf("msie ") + 5);

--- a/shared/src/main/java/com/vaadin/shared/VBrowserDetails.java
+++ b/shared/src/main/java/com/vaadin/shared/VBrowserDetails.java
@@ -120,13 +120,13 @@ public class VBrowserDetails implements Serializable {
                         .substring(userAgent.indexOf("webkit/") + 7);
                 tmp = tmp.replaceFirst("([0-9]+)[^0-9].+", "$1");
                 browserEngineVersion = Float.parseFloat(tmp);
-            } else if (isIE) {
-                int tridentPos = userAgent.indexOf("trident/");
-                if (tridentPos >= 0) {
-                    String tmp = userAgent
-                            .substring(tridentPos + "trident/".length());
-                    tmp = tmp.replaceFirst("([0-9]+\\.[0-9]+).*", "$1");
-                    browserEngineVersion = Float.parseFloat(tmp);
+            } else if (isTrident) {
+                String tmp = userAgent
+                        .substring(userAgent.indexOf("trident/") + 8);
+                tmp = tmp.replaceFirst("([0-9]+\\.[0-9]+).*", "$1");
+                browserEngineVersion = Float.parseFloat(tmp);
+                if (browserEngineVersion > 7) {
+                    browserEngineVersion = 7;
                 }
             } else if (isEdge) {
                 browserEngineVersion = 0;


### PR DESCRIPTION
IE11 in compatibility mode is actually not too old. It's just not recognized as IE11 if you leave the Trident version out of the equation.
Checking the Trident version is something Vaadin 7 (since 7.0.0.beta5) does: https://github.com/vaadin/framework/commit/fc15f166742737cabfa80e9d548e6d8a1a1f7a04
Trident 4 -> IE8
Trident 5 -> IE9
Trident 6 -> IE10
Trident 7 -> IE11 (windows 7, 10)
Trident 8 -> IE11 (windows 10 initial release only)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8884)
<!-- Reviewable:end -->
