### PR TITLE
Fix default header content changes on init

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
@@ -308,22 +308,24 @@ public class GridConnector extends AbstractListingConnector
      */
     @OnStateChange("header")
     void updateHeader() {
-        final Grid<JsonObject> grid = getWidget();
-        final SectionState state = getState().header;
+        Scheduler.get().scheduleFinally(() -> {
+            final Grid<JsonObject> grid = getWidget();
+            final SectionState state = getState().header;
 
-        while (grid.getHeaderRowCount() > 0) {
-            grid.removeHeaderRow(0);
-        }
-
-        for (RowState rowState : state.rows) {
-            HeaderRow row = grid.appendHeaderRow();
-
-            if (rowState.defaultHeader) {
-                grid.setDefaultHeaderRow(row);
+            while (grid.getHeaderRowCount() > 0) {
+                grid.removeHeaderRow(0);
             }
 
-            updateStaticRow(rowState, row);
-        }
+            for (RowState rowState : state.rows) {
+                HeaderRow row = grid.appendHeaderRow();
+
+                if (rowState.defaultHeader) {
+                    grid.setDefaultHeaderRow(row);
+                }
+
+                updateStaticRow(rowState, row);
+            }
+        });
     }
 
     private void updateStaticRow(RowState rowState,

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridAddColumn.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridAddColumn.java
@@ -4,6 +4,8 @@ import com.vaadin.data.ValueProvider;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.tests.components.AbstractTestUI;
 import com.vaadin.ui.Grid;
+import com.vaadin.ui.Grid.Column;
+import com.vaadin.ui.Label;
 import com.vaadin.ui.renderers.NumberRenderer;
 
 public class GridAddColumn extends AbstractTestUI {
@@ -11,7 +13,10 @@ public class GridAddColumn extends AbstractTestUI {
     @Override
     protected void setup(VaadinRequest request) {
         Grid<String> grid = new Grid<>();
-        grid.addColumn(ValueProvider.identity());
+        Column<String, String> col0 = grid.addColumn(ValueProvider.identity())
+                .setCaption("First column");
+        grid.getDefaultHeaderRow().getCell(col0)
+                .setComponent(new Label("Label Header"));
         grid.addColumn(String::length, new NumberRenderer());
         grid.addColumn(String::length);
         grid.addColumn(string -> -string.length());

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridAddColumnTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridAddColumnTest.java
@@ -60,7 +60,7 @@ public class GridAddColumnTest extends SingleBrowserTest {
         GridCellElement firstHeader = grid.getHeaderCell(0, 0);
         Assert.assertTrue("No label element in header",
                 firstHeader.isElementPresent(By.className("v-label")));
-        Assert.assertEquals("Unexpected text in label", "Label Header",
+        Assert.assertEquals("Text in label does not match", "Label Header",
                 firstHeader.getText());
     }
 

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridAddColumnTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridAddColumnTest.java
@@ -2,10 +2,11 @@ package com.vaadin.tests.components.grid;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
+import com.vaadin.testbench.By;
 import com.vaadin.testbench.elements.GridElement;
+import com.vaadin.testbench.elements.GridElement.GridCellElement;
 import com.vaadin.tests.tb3.SingleBrowserTest;
 
 public class GridAddColumnTest extends SingleBrowserTest {
@@ -42,7 +43,6 @@ public class GridAddColumnTest extends SingleBrowserTest {
     }
 
     @Test
-    @Ignore // TODO re-enable once #8128 is resolved
     public void sort_column_with_automatic_conversion() {
         grid.getHeaderCell(0, 2).click();
         assertCellEquals(0, 0, "a");
@@ -53,6 +53,15 @@ public class GridAddColumnTest extends SingleBrowserTest {
         assertCellEquals(0, 0, "aaa");
         assertCellEquals(1, 0, "aa");
         assertCellEquals(2, 0, "a");
+    }
+
+    @Test
+    public void initial_header_content() {
+        GridCellElement firstHeader = grid.getHeaderCell(0, 0);
+        Assert.assertTrue("No label element in header",
+                firstHeader.isElementPresent(By.className("v-label")));
+        Assert.assertEquals("Unexpected text in label", "Label Header",
+                firstHeader.getText());
     }
 
     private void assertCellEquals(int rowIndex, int colIndex, String content) {


### PR DESCRIPTION
This patch also enables an old test that was pending #8128

Fixes vaadin/framework8-issues#556

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8921)
<!-- Reviewable:end -->
