### PR TITLE
Use textContent instead of innerText in TextRenderer

### DIFF
--- a/client/src/main/java/com/vaadin/client/renderers/TextRenderer.java
+++ b/client/src/main/java/com/vaadin/client/renderers/TextRenderer.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.client.renderers;
 
+import com.google.gwt.dom.client.Element;
 import com.vaadin.client.widget.grid.RendererCellReference;
 
 /**
@@ -27,6 +28,12 @@ public class TextRenderer implements Renderer<String> {
 
     @Override
     public void render(RendererCellReference cell, String text) {
-        cell.getElement().setInnerText(text);
+        // optimization suggested by Oskar Hýbl, Cleverbee solutions
+        setTextContent(cell.getElement(), text);
     }
+
+    private native void setTextContent(Element elem, String text)
+    /*-{
+        elem.textContent = text;
+    }-*/;
 }


### PR DESCRIPTION
This improves standards compliance and reduces unnecessary layouting.

Optimization suggested by Oskar Hýbl, Cleverbee solutions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8936)
<!-- Reviewable:end -->
