### PR TITLE
Editor not saving values by pressing Enter (#8945); 

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -7466,8 +7466,8 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             if (editor.focusedColumnIndexDOM < 0) {
                 widget = null;
             } else {
-                widget = editor
-                        .getWidget(getColumn(editor.focusedColumnIndexDOM));
+                widget = editor.getWidget(
+                        getVisibleColumn(editor.focusedColumnIndexDOM));
             }
 
             EditorDomEvent<T> editorEvent = new EditorDomEvent<>(

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorBufferedTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorBufferedTest.java
@@ -65,8 +65,8 @@ public class GridEditorBufferedTest extends GridEditorTest {
 
     @Test
     public void testKeyboardSaveWithHiddenColumn() {
-        editRow(100);
         selectMenuPath("Component", "Columns", "Column 0", "Hidden");
+        editRow(100);
 
         WebElement textField = getEditor().getField(1);
 

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorBufferedTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorBufferedTest.java
@@ -81,7 +81,7 @@ public class GridEditorBufferedTest extends GridEditorTest {
         new Actions(getDriver()).sendKeys(Keys.ENTER).perform();
 
         assertEditorClosed();
-        assertEquals("<b>100</b> changed",
+        assertEquals("100 changed",
                 getGridElement().getCell(100, 4).getText());
     }
 

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorBufferedTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorBufferedTest.java
@@ -68,7 +68,7 @@ public class GridEditorBufferedTest extends GridEditorTest {
         selectMenuPath("Component", "Columns", "Column 0", "Hidden");
         editRow(100);
 
-        WebElement textField = getEditor().getField(1);
+        WebElement textField = getEditor().getField(4);
 
         textField.click();
         // without this, the click in the middle of the field might not be after
@@ -81,8 +81,8 @@ public class GridEditorBufferedTest extends GridEditorTest {
         new Actions(getDriver()).sendKeys(Keys.ENTER).perform();
 
         assertEditorClosed();
-        assertEquals("(100, 2) changed",
-                getGridElement().getCell(100, 1).getText());
+        assertEquals("<b>100</b> changed",
+                getGridElement().getCell(100, 4).getText());
     }
 
     @Test

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorBufferedTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorBufferedTest.java
@@ -64,6 +64,28 @@ public class GridEditorBufferedTest extends GridEditorTest {
     }
 
     @Test
+    public void testKeyboardSaveWithHiddenColumn() {
+        editRow(100);
+        selectMenuPath("Component", "Columns", "Column 0", "Hidden");
+
+        WebElement textField = getEditor().getField(1);
+
+        textField.click();
+        // without this, the click in the middle of the field might not be after
+        // the old text on some browsers
+        new Actions(getDriver()).sendKeys(Keys.END).perform();
+
+        textField.sendKeys(" changed");
+
+        // Save from keyboard
+        new Actions(getDriver()).sendKeys(Keys.ENTER).perform();
+
+        assertEditorClosed();
+        assertEquals("(100, 2) changed",
+                getGridElement().getCell(100, 1).getText());
+    }
+
+    @Test
     public void testKeyboardSaveWithInvalidEdition() {
         makeInvalidEdition();
 

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorBufferedTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorBufferedTest.java
@@ -68,7 +68,7 @@ public class GridEditorBufferedTest extends GridEditorTest {
         selectMenuPath("Component", "Columns", "Column 0", "Hidden");
         editRow(100);
 
-        WebElement textField = getEditor().getField(4);
+        WebElement textField = getEditor().getField(5);
 
         textField.click();
         // without this, the click in the middle of the field might not be after

--- a/uitest/src/test/java/com/vaadin/v7/tests/components/grid/basicfeatures/server/GridEditorBufferedTest.java
+++ b/uitest/src/test/java/com/vaadin/v7/tests/components/grid/basicfeatures/server/GridEditorBufferedTest.java
@@ -64,6 +64,28 @@ public class GridEditorBufferedTest extends GridEditorTest {
     }
 
     @Test
+    public void testKeyboardSaveWithHiddenColumn() {
+        selectMenuPath("Component", "Columns", "Column 0", "Hidden");
+        selectMenuPath(EDIT_ITEM_100);
+
+        WebElement textField = getEditorWidgets().get(1);
+
+        textField.click();
+        // without this, the click in the middle of the field might not be after
+        // the old text on some browsers
+        new Actions(getDriver()).sendKeys(Keys.END).perform();
+
+        textField.sendKeys(" changed");
+
+        // Save from keyboard
+        new Actions(getDriver()).sendKeys(Keys.ENTER).perform();
+
+        assertEditorClosed();
+        assertEquals("(100, 2) changed",
+                getGridElement().getCell(100, 1).getText());
+    }
+
+    @Test
     public void testKeyboardSaveWithInvalidEdition() {
         makeInvalidEdition();
 


### PR DESCRIPTION
Copied Artur's fix for #8266 on 7.7.7 to 8

Looks like the fix was cherry-picked from 7 to the compatibility project in 8, but not to the new Grid in 8.
I've also copied the test to com/vaadin/v7/tests/components/grid/basicfeatures/server/GridEditorBufferedTest.java

Sorry I couldn't actually run the ui tests myself because I don't have a TestBench licence

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8946)
<!-- Reviewable:end -->
