### PR TITLE
Make getValueProvider return ValueProvider

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -69,7 +69,6 @@ import com.vaadin.server.EncodeResult;
 import com.vaadin.server.Extension;
 import com.vaadin.server.JsonCodec;
 import com.vaadin.server.SerializableComparator;
-import com.vaadin.server.SerializableFunction;
 import com.vaadin.server.SerializableSupplier;
 import com.vaadin.server.Setter;
 import com.vaadin.server.VaadinServiceClassLoaderUtil;
@@ -820,7 +819,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      */
     public static class Column<T, V> extends AbstractGridExtension<T> {
 
-        private final SerializableFunction<T, ? extends V> valueProvider;
+        private final ValueProvider<T, V> valueProvider;
 
         private SortOrderProvider sortOrderProvider = direction -> {
             String id = getId();
@@ -1126,7 +1125,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
          *
          * @since 8.0.3
          */
-        public SerializableFunction<T, ? extends V> getValueProvider() {
+        public ValueProvider<T, V> getValueProvider() {
             return valueProvider;
         }
 

--- a/server/src/test/java/com/vaadin/tests/components/grid/GridValueProvider.java
+++ b/server/src/test/java/com/vaadin/tests/components/grid/GridValueProvider.java
@@ -15,9 +15,16 @@
  */
 package com.vaadin.tests.components.grid;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.data.provider.DataProvider;
+import com.vaadin.data.provider.ListDataProvider;
+import com.vaadin.data.provider.Query;
 import com.vaadin.tests.data.bean.Person;
 import com.vaadin.tests.data.bean.Sex;
 import com.vaadin.ui.Grid;
@@ -44,5 +51,27 @@ public class GridValueProvider {
                 Sex.UNKNOWN, null);
         Assert.assertEquals("eeemaaail", col.getValueProvider().apply(person));
 
+    }
+
+    @Test
+    public void reuseValueProviderForFilter() {
+        Grid<Person> grid = new Grid<>(Person.class);
+        Column<Person, String> col = (Column<Person, String>) grid
+                .getColumn("email");
+
+        Person lowerCasePerson = new Person("first", "last", "email", 123,
+                Sex.UNKNOWN, null);
+        Person upperCasePerson = new Person("FIRST", "LAST", "EMAIL", 123,
+                Sex.UNKNOWN, null);
+        ListDataProvider<Person> persons = DataProvider.ofItems(lowerCasePerson,
+                upperCasePerson);
+
+        persons.addFilter(col.getValueProvider(),
+                value -> value.toUpperCase(Locale.ENGLISH).equals(value));
+
+        List<Person> queryPersons = persons.fetch(new Query<>())
+                .collect(Collectors.toList());
+        Assert.assertEquals(1, queryPersons.size());
+        Assert.assertSame(upperCasePerson, queryPersons.get(0));
     }
 }


### PR DESCRIPTION
The instance can only be a ValueProvider, but the getter previously
returned a less specific type. Making the getter return ValueProvider
makes it easier to reuse the provider in other contexts that require
ValueProvider, e.g. when adding filters to a ListDataProvider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8983)
<!-- Reviewable:end -->
