### PR TITLE
Moved docs comment to own row

### DIFF
--- a/documentation/advanced/advanced-logging.asciidoc
+++ b/documentation/advanced/advanced-logging.asciidoc
@@ -58,9 +58,9 @@ SLF4J site.
 
 In order to get the [package]#java.util.logging# to SLF4J bridge installed, you
 need to add the following snippet of code to your [classname]#UI# class at the
-very top://TODO: Sure it's UI class and not the
-servlet?
+very top:
 
+//TODO: Sure it's UI class and not the servlet?
 
 [source, java]
 ----


### PR DESCRIPTION
Anyone can read the TODO comment on https://vaadin.com/docs/-/part/framework/advanced/advanced-logging.html. The comment is directly on same row as normal text, which means that it will be printed out when asciidoc is transformed to html. I moved it now to a new row which will make the asciidoc parser treat is as a comment. Please make a proper fix for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/8993)
<!-- Reviewable:end -->
