### PR TITLE
8988: Removed custom padding from Primary button style

### DIFF
--- a/themes/src/main/themes/VAADIN/themes/valo/components/_button.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_button.scss
@@ -16,8 +16,6 @@
   @if $include-additional-styles {
     .#{$primary-stylename}-primary {
       @include valo-button-style($background-color: $v-selection-color);
-      $padding-width: round($v-unit-size/2);
-      padding: 0 $padding-width;
       font-weight: bold;
       $min-width: round($v-unit-size * 2.2);
       min-width: $min-width;


### PR DESCRIPTION
Proposed fix for issue #8988: removed the custom padding from the Primary button style

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9015)
<!-- Reviewable:end -->
