### PR TITLE
Fix changing primary style name for NativeSelect

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VNativeSelect.java
+++ b/client/src/main/java/com/vaadin/client/ui/VNativeSelect.java
@@ -44,7 +44,7 @@ public class VNativeSelect extends FocusableFlowPanelComposite
     @Override
     public void setStylePrimaryName(String style) {
         super.setStylePrimaryName(style);
-        setStylePrimaryName(listBox.getElement(), style);
+        getListBox().setStyleName(style + "-select");
     }
 
     /**

--- a/uitest/src/test/java/com/vaadin/tests/components/listselect/ListSelectStyleNamesTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/listselect/ListSelectStyleNamesTest.java
@@ -77,7 +77,7 @@ public class ListSelectStyleNamesTest extends SingleBrowserTest {
         assertStyleNames(nativeSelect, "newprimary", "v-widget",
                 "custominitial", "newprimary-custominitial", "new",
                 "newprimary-new");
-        assertStyleNames(nativeSelectSelect, "newprimary");
+        assertStyleNames(nativeSelectSelect, "newprimary-select");
         assertStyleNames(listSelect, "newprimary", "v-widget", "custominitial",
                 "newprimary-custominitial", "new", "newprimary-new");
         assertStyleNames(listSelectSelect, "newprimary-select");


### PR DESCRIPTION
Depends on #9007

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9016)
<!-- Reviewable:end -->
