### PR TITLE
Add LoadStyle.NONE for completely omitting a connector

### DIFF
--- a/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/ConnectorBundleLoaderFactory.java
+++ b/client-compiler/src/main/java/com/vaadin/server/widgetsetutils/ConnectorBundleLoaderFactory.java
@@ -1158,6 +1158,12 @@ public class ConnectorBundleLoaderFactory extends Generator {
             bundles.add(bundle);
         }
 
+        Collection<JClassType> none = connectorsByLoadStyle.get(LoadStyle.NONE);
+        for (JClassType type : none) {
+            logger.log(Type.TRACE,
+                    "Ignoring " + type.getName() + " with LoadStyle.NONE");
+        }
+
         return bundles;
     }
 

--- a/shared/src/main/java/com/vaadin/shared/ui/Connect.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/Connect.java
@@ -98,6 +98,10 @@ public @interface Connect {
         /**
          * Loaded to the client only if needed.
          */
-        LAZY
+        LAZY,
+        /**
+         * Completely left out of the widgetset.
+         */
+        NONE
     }
 }

--- a/shared/src/main/java/com/vaadin/shared/ui/Connect.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/Connect.java
@@ -101,6 +101,8 @@ public @interface Connect {
         LAZY,
         /**
          * Completely left out of the widgetset.
+         *
+         * @since 8.1
          */
         NONE
     }

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/NoneLoadStyleConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/NoneLoadStyleConnector.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.widgetset.client;
+
+import com.google.gwt.user.client.ui.Label;
+import com.vaadin.client.ui.AbstractComponentConnector;
+import com.vaadin.shared.ui.Connect;
+import com.vaadin.shared.ui.Connect.LoadStyle;
+import com.vaadin.tests.widgetset.server.NoneLoadStyleComponent;
+
+@Connect(value = NoneLoadStyleComponent.class, loadStyle = LoadStyle.NONE)
+public class NoneLoadStyleConnector extends AbstractComponentConnector {
+
+    @Override
+    protected void init() {
+        super.init();
+
+        getWidget().setText(NoneLoadStyleConnector.class.getSimpleName());
+    }
+
+    @Override
+    public Label getWidget() {
+        return (Label) super.getWidget();
+    }
+}

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/server/NoneLoadStyle.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/server/NoneLoadStyle.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.widgetset.server;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.tests.widgetset.TestingWidgetSet;
+
+@Widgetset(TestingWidgetSet.NAME)
+public class NoneLoadStyle extends AbstractTestUI {
+
+    @Override
+    protected String getTestDescription() {
+        return NoneLoadStyleComponent.class.getName()
+                + " should resolve to UnknownComponentConnector";
+    }
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        NoneLoadStyleComponent component = new NoneLoadStyleComponent();
+        component.setId("component");
+        addComponent(component);
+    }
+}

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/server/NoneLoadStyleComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/server/NoneLoadStyleComponent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.widgetset.server;
+
+import com.vaadin.ui.AbstractComponent;
+
+public class NoneLoadStyleComponent extends AbstractComponent {
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/widgetset/server/NoneLoadStyleTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/widgetset/server/NoneLoadStyleTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.widgetset.server;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class NoneLoadStyleTest extends SingleBrowserTest {
+    @Test
+    public void connectorNotLoaded() {
+        openTestURL();
+
+        String componentText = findElement(By.id("component")).getText();
+
+        Assert.assertTrue(componentText.contains("does not contain"));
+    }
+}


### PR DESCRIPTION
When optimizing the widgetset by setting all unused connectors as lazy,
the eager bundle will still contain some metadata needed for actually
lazy loading the bundle containing the connector. An even bigger problem
is that the leftovers fragment will contain all code that is shared
between multiple lazy connectors. This can lead to lots of redundant
data that must be downloaded before the DEFERRED bundle is ready.

This patch introduces a LoadStyle.NONE that can be used in a custom
ConnectorBundleLoaderFactory implementation to completely exclude
connectors that are not used at all by an application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9025)
<!-- Reviewable:end -->
