### PR TITLE
Load the debug window implementation asynchronously

### DIFF
--- a/client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -714,56 +714,6 @@ public class ApplicationConfiguration implements EntryPoint {
         // Register pointer events (must be done before any events are used)
         PointerEventSupport.init();
 
-        // Prepare the debugging window
-        if (isDebugMode()) {
-            /*
-             * XXX Lots of implementation details here right now. This should be
-             * cleared up when an API for extending the debug window is
-             * implemented.
-             */
-            VDebugWindow window = VDebugWindow.get();
-
-            if (LogConfiguration.loggingIsEnabled()) {
-                window.addSection((Section) GWT.create(LogSection.class));
-            }
-            window.addSection((Section) GWT.create(InfoSection.class));
-            window.addSection((Section) GWT.create(HierarchySection.class));
-            window.addSection((Section) GWT.create(NetworkSection.class));
-            window.addSection((Section) GWT.create(TestBenchSection.class));
-            if (Profiler.isEnabled()) {
-                window.addSection((Section) GWT.create(ProfilerSection.class));
-            }
-
-            if (isQuietDebugMode()) {
-                window.close();
-            } else {
-                // Load debug window styles asynchronously
-                GWT.runAsync(new RunAsyncCallback() {
-                    @Override
-                    public void onSuccess() {
-                        DebugWindowStyles dws = GWT
-                                .create(DebugWindowStyles.class);
-                        dws.css().ensureInjected();
-                    }
-
-                    @Override
-                    public void onFailure(Throwable reason) {
-                        Window.alert(
-                                "Failed to load Vaadin debug window styles");
-                    }
-                });
-
-                window.init();
-            }
-
-            // Connect to the legacy API
-            VConsole.setImplementation(window);
-
-            Handler errorNotificationHandler = GWT
-                    .create(ErrorNotificationHandler.class);
-            Logger.getLogger("").addHandler(errorNotificationHandler);
-        }
-
         if (LogConfiguration.loggingIsEnabled()) {
             GWT.setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
 
@@ -791,7 +741,62 @@ public class ApplicationConfiguration implements EntryPoint {
             // page once done compiling
             return;
         }
-        registerCallback(GWT.getModuleName());
+
+        if (isDebugMode()) {
+            // Load debug window bundle and continue the bootstrap sequence once
+            // it's loaded
+            GWT.runAsync(VDebugWindow.class, new RunAsyncCallback() {
+                @Override
+                public void onSuccess() {
+                    initDebugWindow();
+                    registerCallback(GWT.getModuleName());
+                }
+
+                @Override
+                public void onFailure(Throwable reason) {
+                    Window.alert("Failed to load Vaadin debug window");
+                    registerCallback(GWT.getModuleName());
+                }
+            });
+        } else {
+            // Continue the bootstrap sequence right away
+            registerCallback(GWT.getModuleName());
+        }
+    }
+
+    private static void initDebugWindow() {
+        /*
+         * XXX Lots of implementation details here right now. This should be
+         * cleared up when an API for extending the debug window is implemented.
+         */
+        VDebugWindow window = VDebugWindow.get();
+
+        if (LogConfiguration.loggingIsEnabled()) {
+            window.addSection((Section) GWT.create(LogSection.class));
+        }
+        window.addSection((Section) GWT.create(InfoSection.class));
+        window.addSection((Section) GWT.create(HierarchySection.class));
+        window.addSection((Section) GWT.create(NetworkSection.class));
+        window.addSection((Section) GWT.create(TestBenchSection.class));
+        if (Profiler.isEnabled()) {
+            window.addSection((Section) GWT.create(ProfilerSection.class));
+        }
+
+        if (isQuietDebugMode()) {
+            window.close();
+        } else {
+            DebugWindowStyles dws = GWT.create(DebugWindowStyles.class);
+            dws.css().ensureInjected();
+
+            window.init();
+        }
+
+        // Connect to the legacy API
+        VConsole.setImplementation(window);
+
+        Handler errorNotificationHandler = GWT
+                .create(ErrorNotificationHandler.class);
+        Logger.getLogger("").addHandler(errorNotificationHandler);
     }
 
     /**
@@ -907,5 +912,4 @@ public class ApplicationConfiguration implements EntryPoint {
     private static final Logger getLogger() {
         return Logger.getLogger(ApplicationConfiguration.class.getName());
     }
-
 }


### PR DESCRIPTION
Reduces the gzipped DefaultWidgetset eager bundle size from 345kb to
325kb. The relative impact is greater for optimized widgetsets that might
have down to around 150kb in the eager bundle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9026)
<!-- Reviewable:end -->
