### PR TITLE
Ignore all external events in the Profiler

### DIFF
--- a/client/src/main/java/com/vaadin/client/Profiler.java
+++ b/client/src/main/java/com/vaadin/client/Profiler.java
@@ -475,7 +475,13 @@ public class Profiler {
         Set<Node> extendedTimeNodes = new HashSet<>();
         for (int i = 0; i < gwtStatsEvents.length(); i++) {
             GwtStatsEvent gwtStatsEvent = gwtStatsEvents.get(i);
+            if (!evtGroup.equals(gwtStatsEvent.getEvtGroup())) {
+                // Only log our own events to avoid problems with events which
+                // are not of type start+end
+                continue;
+            }
             String eventName = gwtStatsEvent.getEventName();
+
             String type = gwtStatsEvent.getType();
             boolean isExtendedEvent = gwtStatsEvent.isExtendedEvent();
             boolean isBeginEvent = "begin".equals(type);


### PR DESCRIPTION
This fixes problems with profiling the initial paint:
"SEVERE: Got end event for leftoversDownload.runAsync but is currently in null"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9033)
<!-- Reviewable:end -->
