### PR TITLE
Check for NullPointer to remove exception spam

### DIFF
--- a/server/src/main/java/com/vaadin/server/communication/PushHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushHandler.java
@@ -313,15 +313,15 @@ public class PushHandler {
                     "Could not get event. This should never happen.");
             return;
         }
-            
+
         AtmosphereResource resource = event.getResource();
-        
+
         if(resource == null){
             getLogger().log(Level.SEVERE,
                     "Could not get resource. This should never happen.");
             return;
-        }        
-        
+        }
+
         VaadinServletRequest vaadinRequest = new VaadinServletRequest(
                 resource.getRequest(), service);
         VaadinSession session = null;

--- a/server/src/main/java/com/vaadin/server/communication/PushHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushHandler.java
@@ -310,7 +310,7 @@ public class PushHandler {
         // things.
         if(event == null){
             getLogger().log(Level.SEVERE,
-                    "Could not get event. This should never happen", e);
+                    "Could not get event. This should never happen.");
             return;
         }
             
@@ -318,7 +318,7 @@ public class PushHandler {
         
         if(resource == null){
             getLogger().log(Level.SEVERE,
-                    "Could not get resource. This should never happen", e);
+                    "Could not get resource. This should never happen.");
             return;
         }        
         

--- a/server/src/main/java/com/vaadin/server/communication/PushHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushHandler.java
@@ -308,8 +308,20 @@ public class PushHandler {
         // We don't want to use callWithUi here, as it assumes there's a client
         // request active and does requestStart and requestEnd among other
         // things.
-
+        if(event == null){
+            getLogger().log(Level.SEVERE,
+                    "Could not get event. This should never happen", e);
+            return;
+        }
+            
         AtmosphereResource resource = event.getResource();
+        
+        if(resource == null){
+            getLogger().log(Level.SEVERE,
+                    "Could not get resource. This should never happen", e);
+            return;
+        }        
+        
         VaadinServletRequest vaadinRequest = new VaadinServletRequest(
                 resource.getRequest(), service);
         VaadinSession session = null;


### PR DESCRIPTION
Vaadin Version: 8.0.5
Jetty Version: 9.3.9.v20160517

Fix to remove exception spam in test environment with jetty and push enabled:

> com.vaadin.server.communication.PushAtmosphereHandler$AtmosphereResourceListener onThrowable
> SCHWERWIEGEND: Exception in push connection
> java.lang.NullPointerException
> 	at com.vaadin.server.communication.PushHandler.connectionLost(PushHandler.java:314)
> 	at com.vaadin.server.communication.PushAtmosphereHandler$AtmosphereResourceListener.onThrowable(PushAtmosphereHandler.java:116)
> 	at org.atmosphere.cpr.AtmosphereResourceImpl.onThrowable(AtmosphereResourceImpl.java:704)
> 	at org.atmosphere.cpr.AtmosphereResourceImpl.notifyListeners(AtmosphereResourceImpl.java:654)
> 	at org.atmosphere.cpr.DefaultBroadcaster.onException(DefaultBroadcaster.java:1130)
> 	at org.atmosphere.cpr.DefaultBroadcaster.onException(DefaultBroadcaster.java:1112)
> 	at org.atmosphere.cpr.DefaultBroadcaster.invokeOnStateChange(DefaultBroadcaster.java:1050)
> 	at org.atmosphere.cpr.DefaultBroadcaster.prepareInvokeOnStateChange(DefaultBroadcaster.java:1067)
> 	at org.atmosphere.cpr.DefaultBroadcaster.executeAsyncWrite(DefaultBroadcaster.java:872)
> 	at org.atmosphere.cpr.DefaultBroadcaster$2.run(DefaultBroadcaster.java:474)
> 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
> 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
> 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
> 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
> 	at java.lang.Thread.run(Thread.java:745)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9057)
<!-- Reviewable:end -->
