### PR TITLE
Fix client-side memory leak caused by Grid events

### DIFF
--- a/all/src/main/templates/release-notes.html
+++ b/all/src/main/templates/release-notes.html
@@ -116,6 +116,7 @@
                 See also <a href="http://dev.vaadin.com/ticket/8171">#8171</a></li>
             <li>The way we handle GWT dependencies has been completely changed. See <a href="#gwtdep">this section</a> for more details.</li>
             <li>Client side compilation with Maven is now in strict mode by default, failing the compilation on any errors.</li>
+            <li>Client side classes extending either AbstractGridMouseEvent or AbstractGridKeyEvent must now override the method getAssociatedType.</li>
         </ul>
         <h3 id="knownissues">Known Issues and Limitations</h3>
         <ul>

--- a/client/src/main/java/com/vaadin/client/widget/grid/EventCellReference.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/EventCellReference.java
@@ -87,7 +87,7 @@ public class EventCellReference<T> extends CellReference<T> {
      * Is the cell reference for a cell in the header of the Grid.
      *
      * @since 7.5
-     * @return <code>true</true> if referenced cell is in the header, 
+     * @return <code>true</true> if referenced cell is in the header,
      *         <code>false</code> if not
      */
     public boolean isHeader() {
@@ -98,7 +98,7 @@ public class EventCellReference<T> extends CellReference<T> {
      * Is the cell reference for a cell in the body of the Grid.
      *
      * @since 7.5
-     * @return <code>true</true> if referenced cell is in the body, 
+     * @return <code>true</true> if referenced cell is in the body,
      *         <code>false</code> if not
      */
     public boolean isBody() {
@@ -109,7 +109,7 @@ public class EventCellReference<T> extends CellReference<T> {
      * Is the cell reference for a cell in the footer of the Grid.
      *
      * @since 7.5
-     * @return <code>true</true> if referenced cell is in the footer, 
+     * @return <code>true</true> if referenced cell is in the footer,
      *         <code>false</code> if not
      */
     public boolean isFooter() {

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridClickEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridClickEvent.java
@@ -30,8 +30,16 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
  */
 public class GridClickEvent extends AbstractGridMouseEvent<GridClickHandler> {
 
+    public static final Type<GridClickHandler> TYPE = new Type<GridClickHandler>(
+            BrowserEvents.CLICK, new GridClickEvent(null, null));
+
     public GridClickEvent(Grid<?> grid, CellReference<?> targetCell) {
         super(grid, targetCell);
+    }
+
+    @Override
+    public Type<GridClickHandler> getAssociatedType() {
+        return TYPE;
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridClickEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridClickEvent.java
@@ -31,10 +31,20 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
 public class GridClickEvent extends AbstractGridMouseEvent<GridClickHandler> {
 
     public static final Type<GridClickHandler> TYPE = new Type<GridClickHandler>(
-            BrowserEvents.CLICK, new GridClickEvent(null, null));
+            BrowserEvents.CLICK, new GridClickEvent());
 
+    /**
+     * @since 7.7.9
+     */
+    public GridClickEvent() {
+    }
+
+    /**
+     * @deprecated This constructor's arguments are no longer used. Use the
+     *             no-args constructor instead.
+     */
+    @Deprecated
     public GridClickEvent(Grid<?> grid, CellReference<?> targetCell) {
-        super(grid, targetCell);
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridDoubleClickEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridDoubleClickEvent.java
@@ -31,8 +31,16 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
 public class GridDoubleClickEvent
         extends AbstractGridMouseEvent<GridDoubleClickHandler> {
 
+    public static final Type<GridDoubleClickHandler> TYPE = new Type<GridDoubleClickHandler>(
+            BrowserEvents.DBLCLICK, new GridDoubleClickEvent(null, null));
+
     public GridDoubleClickEvent(Grid<?> grid, CellReference<?> targetCell) {
         super(grid, targetCell);
+    }
+
+    @Override
+    public Type<GridDoubleClickHandler> getAssociatedType() {
+        return TYPE;
     }
 
     @Override
@@ -51,5 +59,4 @@ public class GridDoubleClickEvent
             handler.onDoubleClick(this);
         }
     }
-
 }

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridDoubleClickEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridDoubleClickEvent.java
@@ -32,10 +32,20 @@ public class GridDoubleClickEvent
         extends AbstractGridMouseEvent<GridDoubleClickHandler> {
 
     public static final Type<GridDoubleClickHandler> TYPE = new Type<GridDoubleClickHandler>(
-            BrowserEvents.DBLCLICK, new GridDoubleClickEvent(null, null));
+            BrowserEvents.DBLCLICK, new GridDoubleClickEvent());
 
+    /**
+     * @since 7.7.9
+     */
+    public GridDoubleClickEvent() {
+    }
+
+    /**
+     * @deprecated This constructor's arguments are no longer used. Use the
+     *             no-args constructor instead.
+     */
+    @Deprecated
     public GridDoubleClickEvent(Grid<?> grid, CellReference<?> targetCell) {
-        super(grid, targetCell);
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyDownEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyDownEvent.java
@@ -32,10 +32,20 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
 public class GridKeyDownEvent extends AbstractGridKeyEvent<GridKeyDownHandler> {
 
     public static final Type<GridKeyDownHandler> TYPE = new Type<GridKeyDownHandler>(
-            BrowserEvents.KEYDOWN, new GridKeyDownEvent(null, null));
+            BrowserEvents.KEYDOWN, new GridKeyDownEvent());
 
+    /**
+     * @since 7.7.9
+     */
+    public GridKeyDownEvent() {
+    }
+
+    /**
+     * @deprecated This constructor's arguments are no longer used. Use the
+     *             no-args constructor instead.
+     */
+    @Deprecated
     public GridKeyDownEvent(Grid<?> grid, CellReference<?> targetCell) {
-        super(grid, targetCell);
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyDownEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyDownEvent.java
@@ -31,8 +31,16 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
  */
 public class GridKeyDownEvent extends AbstractGridKeyEvent<GridKeyDownHandler> {
 
+    public static final Type<GridKeyDownHandler> TYPE = new Type<GridKeyDownHandler>(
+            BrowserEvents.KEYDOWN, new GridKeyDownEvent(null, null));
+
     public GridKeyDownEvent(Grid<?> grid, CellReference<?> targetCell) {
         super(grid, targetCell);
+    }
+
+    @Override
+    public Type<GridKeyDownHandler> getAssociatedType() {
+        return TYPE;
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyPressEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyPressEvent.java
@@ -32,10 +32,20 @@ public class GridKeyPressEvent
         extends AbstractGridKeyEvent<GridKeyPressHandler> {
 
     public static final Type<GridKeyPressHandler> TYPE = new Type<GridKeyPressHandler>(
-            BrowserEvents.KEYPRESS, new GridKeyPressEvent(null, null));
+            BrowserEvents.KEYPRESS, new GridKeyPressEvent());
 
+    /**
+     * @since 7.7.9
+     */
+    public GridKeyPressEvent() {
+    }
+
+    /**
+     * @deprecated This constructor's arguments are no longer used. Use the
+     *             no-args constructor instead.
+     */
+    @Deprecated
     public GridKeyPressEvent(Grid<?> grid, CellReference<?> targetCell) {
-        super(grid, targetCell);
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyPressEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyPressEvent.java
@@ -31,8 +31,16 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
 public class GridKeyPressEvent
         extends AbstractGridKeyEvent<GridKeyPressHandler> {
 
+    public static final Type<GridKeyPressHandler> TYPE = new Type<GridKeyPressHandler>(
+            BrowserEvents.KEYPRESS, new GridKeyPressEvent(null, null));
+
     public GridKeyPressEvent(Grid<?> grid, CellReference<?> targetCell) {
         super(grid, targetCell);
+    }
+
+    @Override
+    public Type<GridKeyPressHandler> getAssociatedType() {
+        return TYPE;
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyUpEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyUpEvent.java
@@ -31,6 +31,9 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
  */
 public class GridKeyUpEvent extends AbstractGridKeyEvent<GridKeyUpHandler> {
 
+    public static final Type<GridKeyUpHandler> TYPE = new Type<GridKeyUpHandler>(
+            BrowserEvents.KEYUP, new GridKeyUpEvent(null, null));
+
     public GridKeyUpEvent(Grid<?> grid, CellReference<?> targetCell) {
         super(grid, targetCell);
     }
@@ -44,6 +47,11 @@ public class GridKeyUpEvent extends AbstractGridKeyEvent<GridKeyUpHandler> {
                         && handler instanceof FooterKeyUpHandler)) {
             handler.onKeyUp(this);
         }
+    }
+
+    @Override
+    public Type<GridKeyUpHandler> getAssociatedType() {
+        return TYPE;
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyUpEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyUpEvent.java
@@ -32,10 +32,20 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
 public class GridKeyUpEvent extends AbstractGridKeyEvent<GridKeyUpHandler> {
 
     public static final Type<GridKeyUpHandler> TYPE = new Type<GridKeyUpHandler>(
-            BrowserEvents.KEYUP, new GridKeyUpEvent(null, null));
+            BrowserEvents.KEYUP, new GridKeyUpEvent());
 
+    /**
+     * @since 7.7.9
+     */
+    public GridKeyUpEvent() {
+    }
+
+    /**
+     * @deprecated This constructor's arguments are no longer used. Use the
+     *             no-args constructor instead.
+     */
+    @Deprecated
     public GridKeyUpEvent(Grid<?> grid, CellReference<?> targetCell) {
-        super(grid, targetCell);
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -2317,6 +2317,9 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     public static abstract class AbstractGridKeyEvent<HANDLER extends AbstractGridKeyEventHandler>
             extends KeyEvent<HANDLER> {
 
+        /**
+         * @since 7.7.9
+         */
         public AbstractGridKeyEvent() {
         }
 
@@ -2380,6 +2383,9 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     public static abstract class AbstractGridMouseEvent<HANDLER extends AbstractGridMouseEventHandler>
             extends MouseEvent<HANDLER> {
 
+        /**
+         * @since 7.7.9
+         */
         public AbstractGridMouseEvent() {
         }
 

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -2317,6 +2317,14 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     public static abstract class AbstractGridKeyEvent<HANDLER extends AbstractGridKeyEventHandler>
             extends KeyEvent<HANDLER> {
 
+        public AbstractGridKeyEvent() {
+        }
+
+        /**
+         * @deprecated This constructor's arguments are no longer used. Use the
+         *             no-args constructor instead.
+         */
+        @Deprecated
         public AbstractGridKeyEvent(Grid<?> grid, CellReference<?> targetCell) {
         }
 
@@ -2350,12 +2358,13 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         @Override
         protected void dispatch(HANDLER handler) {
             EventTarget target = getNativeEvent().getEventTarget();
-            if (Element.is(target) && getGrid() != null
-                    && !getGrid().isElementInChildWidget(Element.as(target))) {
+            Grid<?> grid = getGrid();
+            if (Element.is(target) && grid != null
+                    && !grid.isElementInChildWidget(Element.as(target))) {
 
                 Section section = Section.FOOTER;
-                final RowContainer container = getGrid().cellFocusHandler.containerWithFocus;
-                if (container == getGrid().escalator.getHeader()) {
+                final RowContainer container = grid.cellFocusHandler.containerWithFocus;
+                if (container == grid.escalator.getHeader()) {
                     section = Section.HEADER;
                 } else if (container == getGrid().escalator.getBody()) {
                     section = Section.BODY;
@@ -2371,6 +2380,14 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     public static abstract class AbstractGridMouseEvent<HANDLER extends AbstractGridMouseEventHandler>
             extends MouseEvent<HANDLER> {
 
+        public AbstractGridMouseEvent() {
+        }
+
+        /**
+         * @deprecated This constructor's arguments are no longer used. Use the
+         *             no-args constructor instead.
+         */
+        @Deprecated
         public AbstractGridMouseEvent(Grid<?> grid,
                 CellReference<?> targetCell) {
         }
@@ -2399,10 +2416,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
          *         from a grid
          */
         public CellReference<?> getTargetCell() {
-            if (getGrid() == null) {
+            Grid<?> grid = getGrid();
+            if (grid == null) {
                 return null;
             }
-            return getGrid().getEventCell();
+            return grid.getEventCell();
         }
 
         @Override
@@ -2413,18 +2431,19 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 return;
             }
 
-            if (getGrid() == null) {
+            Grid<?> grid = getGrid();
+            if (grid == null) {
                 // Target is not an element of a grid
                 return;
             }
 
             Element targetElement = Element.as(target);
-            if (getGrid().isElementInChildWidget(targetElement)) {
+            if (grid.isElementInChildWidget(targetElement)) {
                 // Target is some widget inside of Grid
                 return;
             }
 
-            final RowContainer container = getGrid().escalator
+            final RowContainer container = grid.escalator
                     .findRowContainer(targetElement);
             if (container == null) {
                 // No container for given element
@@ -2432,9 +2451,9 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
 
             Section section = Section.FOOTER;
-            if (container == getGrid().escalator.getHeader()) {
+            if (container == grid.escalator.getHeader()) {
                 section = Section.HEADER;
-            } else if (container == getGrid().escalator.getBody()) {
+            } else if (container == grid.escalator.getBody()) {
                 section = Section.BODY;
             }
 

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -2317,47 +2317,47 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     public static abstract class AbstractGridKeyEvent<HANDLER extends AbstractGridKeyEventHandler>
             extends KeyEvent<HANDLER> {
 
-        private Grid<?> grid;
-        private final Type<HANDLER> associatedType = new Type<HANDLER>(
-                getBrowserEventType(), this);
-        private final CellReference<?> targetCell;
-
         public AbstractGridKeyEvent(Grid<?> grid, CellReference<?> targetCell) {
-            this.grid = grid;
-            this.targetCell = targetCell;
         }
 
         protected abstract String getBrowserEventType();
 
         /**
-         * Gets the Grid instance for this event.
+         * Gets the Grid instance for this event, if it originated from a Grid.
          *
-         * @return grid
+         * @return the grid this event originated from, or {@code null} if this
+         *         event did not originate from a grid
          */
         public Grid<?> getGrid() {
-            return grid;
+            EventTarget target = getNativeEvent().getEventTarget();
+            if (!Element.is(target)) {
+                return null;
+            }
+            return WidgetUtil.findWidget(Element.as(target), Grid.class);
         }
 
         /**
-         * Gets the focused cell for this event.
+         * Gets the reference of target cell for this event, if this event
+         * originated from a Grid.
          *
-         * @return focused cell
+         * @return target cell, or {@code null} if this event did not originate
+         *         from a grid
          */
         public CellReference<?> getFocusedCell() {
-            return targetCell;
+            return getGrid().getEventCell();
         }
 
         @Override
         protected void dispatch(HANDLER handler) {
             EventTarget target = getNativeEvent().getEventTarget();
-            if (Element.is(target)
-                    && !grid.isElementInChildWidget(Element.as(target))) {
+            if (Element.is(target) && getGrid() != null
+                    && !getGrid().isElementInChildWidget(Element.as(target))) {
 
                 Section section = Section.FOOTER;
-                final RowContainer container = grid.cellFocusHandler.containerWithFocus;
-                if (container == grid.escalator.getHeader()) {
+                final RowContainer container = getGrid().cellFocusHandler.containerWithFocus;
+                if (container == getGrid().escalator.getHeader()) {
                     section = Section.HEADER;
-                } else if (container == grid.escalator.getBody()) {
+                } else if (container == getGrid().escalator.getBody()) {
                     section = Section.BODY;
                 }
 
@@ -2366,45 +2366,43 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         }
 
         protected abstract void doDispatch(HANDLER handler, Section section);
-
-        @Override
-        public Type<HANDLER> getAssociatedType() {
-            return associatedType;
-        }
     }
 
     public static abstract class AbstractGridMouseEvent<HANDLER extends AbstractGridMouseEventHandler>
             extends MouseEvent<HANDLER> {
 
-        private Grid<?> grid;
-        private final CellReference<?> targetCell;
-        private final Type<HANDLER> associatedType = new Type<HANDLER>(
-                getBrowserEventType(), this);
-
         public AbstractGridMouseEvent(Grid<?> grid,
                 CellReference<?> targetCell) {
-            this.grid = grid;
-            this.targetCell = targetCell;
         }
 
         protected abstract String getBrowserEventType();
 
         /**
-         * Gets the Grid instance for this event.
+         * Gets the Grid instance for this event, if it originated from a Grid.
          *
-         * @return grid
+         * @return the grid this event originated from, or {@code null} if this
+         *         event did not originate from a grid
          */
         public Grid<?> getGrid() {
-            return grid;
+            EventTarget target = getNativeEvent().getEventTarget();
+            if (!Element.is(target)) {
+                return null;
+            }
+            return WidgetUtil.findWidget(Element.as(target), Grid.class);
         }
 
         /**
-         * Gets the reference of target cell for this event.
+         * Gets the reference of target cell for this event, if this event
+         * originated from a Grid.
          *
-         * @return target cell
+         * @return target cell, or {@code null} if this event did not originate
+         *         from a grid
          */
         public CellReference<?> getTargetCell() {
-            return targetCell;
+            if (getGrid() == null) {
+                return null;
+            }
+            return getGrid().getEventCell();
         }
 
         @Override
@@ -2415,13 +2413,18 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 return;
             }
 
+            if (getGrid() == null) {
+                // Target is not an element of a grid
+                return;
+            }
+
             Element targetElement = Element.as(target);
-            if (grid.isElementInChildWidget(targetElement)) {
+            if (getGrid().isElementInChildWidget(targetElement)) {
                 // Target is some widget inside of Grid
                 return;
             }
 
-            final RowContainer container = grid.escalator
+            final RowContainer container = getGrid().escalator
                     .findRowContainer(targetElement);
             if (container == null) {
                 // No container for given element
@@ -2429,9 +2432,9 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
 
             Section section = Section.FOOTER;
-            if (container == grid.escalator.getHeader()) {
+            if (container == getGrid().escalator.getHeader()) {
                 section = Section.HEADER;
-            } else if (container == grid.escalator.getBody()) {
+            } else if (container == getGrid().escalator.getBody()) {
                 section = Section.BODY;
             }
 
@@ -2439,11 +2442,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         }
 
         protected abstract void doDispatch(HANDLER handler, Section section);
-
-        @Override
-        public Type<HANDLER> getAssociatedType() {
-            return associatedType;
-        }
     }
 
     private static final String CUSTOM_STYLE_PROPERTY_NAME = "customStyle";
@@ -2457,12 +2455,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     private static final double DETAILS_ROW_INITIAL_HEIGHT = 50;
 
     private EventCellReference<T> eventCell = new EventCellReference<T>(this);
-    private GridKeyDownEvent keyDown = new GridKeyDownEvent(this, eventCell);
-    private GridKeyUpEvent keyUp = new GridKeyUpEvent(this, eventCell);
-    private GridKeyPressEvent keyPress = new GridKeyPressEvent(this, eventCell);
-    private GridClickEvent clickEvent = new GridClickEvent(this, eventCell);
-    private GridDoubleClickEvent doubleClickEvent = new GridDoubleClickEvent(
-            this, eventCell);
 
     private class CellFocusHandler {
 
@@ -3091,7 +3083,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
         /**
          * Sets whether the user is allowed to change the selection.
-         * 
+         *
          * @param userSelectionAllowed
          *            <code>true</code> if the user is allowed to change the
          *            selection, <code>false</code> otherwise
@@ -6228,7 +6220,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      * {@link ColumnResizeMode.ANIMATED}.
      *
      * @return a ColumnResizeMode value
-     * 
+     *
      * @since 7.7.5
      */
     public ColumnResizeMode getColumnResizeMode() {
@@ -6895,7 +6887,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
     /**
      * Gets the {@link Escalator} used by this Grid instnace.
-     * 
+     *
      * @return the escalator instance, never <code>null</code>
      */
     public Escalator getEscalator() {
@@ -8184,7 +8176,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addBodyKeyDownHandler(
             BodyKeyDownHandler handler) {
-        return addHandler(handler, keyDown.getAssociatedType());
+        return addHandler(handler, GridKeyDownEvent.TYPE);
     }
 
     /**
@@ -8197,7 +8189,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      * @return the registration for the event
      */
     public HandlerRegistration addBodyKeyUpHandler(BodyKeyUpHandler handler) {
-        return addHandler(handler, keyUp.getAssociatedType());
+        return addHandler(handler, GridKeyUpEvent.TYPE);
     }
 
     /**
@@ -8211,7 +8203,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addBodyKeyPressHandler(
             BodyKeyPressHandler handler) {
-        return addHandler(handler, keyPress.getAssociatedType());
+        return addHandler(handler, GridKeyPressEvent.TYPE);
     }
 
     /**
@@ -8225,7 +8217,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addHeaderKeyDownHandler(
             HeaderKeyDownHandler handler) {
-        return addHandler(handler, keyDown.getAssociatedType());
+        return addHandler(handler, GridKeyDownEvent.TYPE);
     }
 
     /**
@@ -8239,7 +8231,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addHeaderKeyUpHandler(
             HeaderKeyUpHandler handler) {
-        return addHandler(handler, keyUp.getAssociatedType());
+        return addHandler(handler, GridKeyUpEvent.TYPE);
     }
 
     /**
@@ -8253,7 +8245,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addHeaderKeyPressHandler(
             HeaderKeyPressHandler handler) {
-        return addHandler(handler, keyPress.getAssociatedType());
+        return addHandler(handler, GridKeyPressEvent.TYPE);
     }
 
     /**
@@ -8267,7 +8259,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addFooterKeyDownHandler(
             FooterKeyDownHandler handler) {
-        return addHandler(handler, keyDown.getAssociatedType());
+        return addHandler(handler, GridKeyDownEvent.TYPE);
     }
 
     /**
@@ -8281,7 +8273,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addFooterKeyUpHandler(
             FooterKeyUpHandler handler) {
-        return addHandler(handler, keyUp.getAssociatedType());
+        return addHandler(handler, GridKeyUpEvent.TYPE);
     }
 
     /**
@@ -8295,7 +8287,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addFooterKeyPressHandler(
             FooterKeyPressHandler handler) {
-        return addHandler(handler, keyPress.getAssociatedType());
+        return addHandler(handler, GridKeyPressEvent.TYPE);
     }
 
     /**
@@ -8307,7 +8299,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      * @return the registration for the event
      */
     public HandlerRegistration addBodyClickHandler(BodyClickHandler handler) {
-        return addHandler(handler, clickEvent.getAssociatedType());
+        return addHandler(handler, GridClickEvent.TYPE);
     }
 
     /**
@@ -8320,7 +8312,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addHeaderClickHandler(
             HeaderClickHandler handler) {
-        return addHandler(handler, clickEvent.getAssociatedType());
+        return addHandler(handler, GridClickEvent.TYPE);
     }
 
     /**
@@ -8333,7 +8325,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addFooterClickHandler(
             FooterClickHandler handler) {
-        return addHandler(handler, clickEvent.getAssociatedType());
+        return addHandler(handler, GridClickEvent.TYPE);
     }
 
     /**
@@ -8347,7 +8339,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addBodyDoubleClickHandler(
             BodyDoubleClickHandler handler) {
-        return addHandler(handler, doubleClickEvent.getAssociatedType());
+        return addHandler(handler, GridDoubleClickEvent.TYPE);
     }
 
     /**
@@ -8361,7 +8353,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addHeaderDoubleClickHandler(
             HeaderDoubleClickHandler handler) {
-        return addHandler(handler, doubleClickEvent.getAssociatedType());
+        return addHandler(handler, GridDoubleClickEvent.TYPE);
     }
 
     /**
@@ -8375,7 +8367,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public HandlerRegistration addFooterDoubleClickHandler(
             FooterDoubleClickHandler handler) {
-        return addHandler(handler, doubleClickEvent.getAssociatedType());
+        return addHandler(handler, GridDoubleClickEvent.TYPE);
     }
 
     /**
@@ -8829,7 +8821,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         for (int row : details) {
             setDetailsVisible(row, false);
         }
-
         super.onDetach();
     }
 
@@ -9245,7 +9236,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
     /**
      * Checks if selection by the user is allowed in the grid.
-     * 
+     *
      * @return <code>true</code> if selection by the user is allowed by the
      *         selection model (the default), <code>false</code> otherwise
      * @since 7.7.7

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridClientMemoryLeak.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridClientMemoryLeak.java
@@ -1,30 +1,41 @@
 package com.vaadin.tests.components.grid;
 
 import com.vaadin.server.VaadinRequest;
+import com.vaadin.shared.ui.label.ContentMode;
 import com.vaadin.tests.components.AbstractTestUI;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Grid;
+import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
 
 public class GridClientMemoryLeak extends AbstractTestUI {
 
+    private static final String INSTRUCTIONS = "This UI is for manually testing that the client side grid does not leak memory. "
+            + "Steps to take:\n"
+            + "\t1. Click the newGrid button 1-n times\n"
+            + "\t2. Capture a JS heap dump in your browser\n"
+            + "\t3. The heap dump should only contain 1 instance of each of the following:\n"
+            + "\t\tGrid, GridKeyDownEvent, GridKeyPressEvent, GridKeyUpEvent, GridClickEvent, GridDoubleClickEvent";
+
     @Override
     protected void setup(VaadinRequest request) {
-        final VerticalLayout l = new VerticalLayout();
-        Button btn = new Button("newGrid");
+        final Label instructionLabel = new Label(INSTRUCTIONS,
+                ContentMode.PREFORMATTED);
+        final VerticalLayout layout = new VerticalLayout();
+        final Button btn = new Button("newGrid");
         btn.addClickListener(new Button.ClickListener() {
 
             @Override
             public void buttonClick(ClickEvent event) {
-                l.removeComponent(l.getComponent(1));
-                l.addComponent(grid());
+                layout.removeComponent(layout.getComponent(1));
+                layout.addComponent(grid());
             }
         });
-        l.addComponent(btn);
-        l.addComponent(grid());
-        setContent(l);
-        return;
+        layout.addComponent(instructionLabel);
+        layout.addComponent(btn);
+        layout.addComponent(grid());
+        addComponent(layout);
     }
 
     private Grid grid() {

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridClientMemoryLeak.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridClientMemoryLeak.java
@@ -1,0 +1,38 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Button.ClickEvent;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.VerticalLayout;
+
+public class GridClientMemoryLeak extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        final VerticalLayout l = new VerticalLayout();
+        Button btn = new Button("newGrid");
+        btn.addClickListener(new Button.ClickListener() {
+
+            @Override
+            public void buttonClick(ClickEvent event) {
+                l.removeComponent(l.getComponent(1));
+                l.addComponent(grid());
+            }
+        });
+        l.addComponent(btn);
+        l.addComponent(grid());
+        setContent(l);
+        return;
+    }
+
+    private Grid grid() {
+        Grid grid = new Grid();
+        grid.addColumn("col1", String.class);
+        grid.addColumn("col2", String.class);
+        grid.addRow("a", "b" + System.currentTimeMillis());
+        grid.addRow("d", "e");
+        return grid;
+    }
+}


### PR DESCRIPTION
Refactors AbstractGridKeyEvent, AbstractGridMouseEvent and their
descendants to follow the pattern used in other GWT DomEvents.

Fixes #7633

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9062)
<!-- Reviewable:end -->
