### PR TITLE
Fix calendar dateclick does not work when in readonly mode (#4967)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/calendar/schedule/DateCellContainer.java
+++ b/client/src/main/java/com/vaadin/client/ui/calendar/schedule/DateCellContainer.java
@@ -106,7 +106,7 @@ public class DateCellContainer extends FlowPanel
     public void onMouseUp(MouseUpEvent event) {
         if (event.getSource() == clickTargetWidget
                 && clickTargetWidget instanceof WeeklyLongEventsDateCell
-                && !calendar.isDisabledOrReadOnly()) {
+                && !calendar.isDisabled()) {
             CalendarEvent calendarEvent = ((WeeklyLongEventsDateCell) clickTargetWidget)
                     .getEvent();
             if (calendar.getEventClickListener() != null) {


### PR DESCRIPTION
Fire click events in a read-only calendar in week mode alike already happen in month mode.
Fixes #4967 and part of #6691

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9065)
<!-- Reviewable:end -->
