### PR TITLE
Use setCaption Javadocs inherited from Component

### DIFF
--- a/server/src/main/java/com/vaadin/ui/AbstractComponent.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractComponent.java
@@ -290,13 +290,6 @@ public abstract class AbstractComponent extends AbstractClientConnector
         return getState(false).caption;
     }
 
-    /**
-     * Sets the component's caption <code>String</code>. Caption is the visible
-     * name of the component.
-     *
-     * @param caption
-     *            the new caption <code>String</code> for the component.
-     */
     @Override
     public void setCaption(String caption) {
         getState().caption = caption;

--- a/server/src/main/java/com/vaadin/ui/Panel.java
+++ b/server/src/main/java/com/vaadin/ui/Panel.java
@@ -100,15 +100,6 @@ public class Panel extends AbstractSingleComponentContainer
         setCaption(caption);
     }
 
-    /**
-     * Sets the caption of the panel.
-     *
-     * Note that the caption is interpreted as HTML and therefore care should be
-     * taken not to enable HTML injection and XSS attacks using panel captions.
-     * This behavior may change in future versions.
-     *
-     * @see AbstractComponent#setCaption(String)
-     */
     @Override
     public void setCaption(String caption) {
         super.setCaption(caption);


### PR DESCRIPTION
Component.setCaption has thorough Javadocs that are shadowed by a very
brief snippet in AbstractComponent and an erroneous description in
Panel. By removing those snippets, component classes will instead
inherit a much more useful description of the method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9066)
<!-- Reviewable:end -->
