### PR TITLE
Use separate identifier for push connections

### DIFF
--- a/client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
+++ b/client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
@@ -207,10 +207,10 @@ public class AtmospherePushConnection implements PushConnection {
         String extraParams = UIConstants.UI_ID_PARAMETER + "="
                 + connection.getConfiguration().getUIId();
 
-        String csrfToken = connection.getMessageHandler().getCsrfToken();
-        if (!csrfToken.equals(ApplicationConstants.CSRF_TOKEN_DEFAULT_VALUE)) {
-            extraParams += "&" + ApplicationConstants.CSRF_TOKEN_PARAMETER + "="
-                    + csrfToken;
+        String pushId = connection.getMessageHandler().getPushId();
+        if (pushId != null) {
+            extraParams += "&" + ApplicationConstants.PUSH_ID_PARAMETER + "="
+                    + pushId;
         }
 
         // uri is needed to identify the right connection when closing
@@ -526,7 +526,7 @@ public class AtmospherePushConnection implements PushConnection {
             JavaScriptObject config)
     /*-{
         var self = this;
-    
+
         config.url = uri;
         config.onOpen = $entry(function(response) {
             self.@com.vaadin.client.communication.AtmospherePushConnection::onOpen(*)(response);
@@ -552,7 +552,7 @@ public class AtmospherePushConnection implements PushConnection {
         config.onClientTimeout = $entry(function(request) {
             self.@com.vaadin.client.communication.AtmospherePushConnection::onClientTimeout(*)(request);
         });
-    
+
         return $wnd.vaadinPush.atmosphere.subscribe(config);
     }-*/;
 

--- a/client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -134,6 +134,9 @@ public class MessageHandler {
     // will hold the CSRF token once received
     private String csrfToken = ApplicationConstants.CSRF_TOKEN_DEFAULT_VALUE;
 
+    // holds the push identifier once received
+    private String pushId = null;
+
     /** Timer for automatic redirect to SessionExpiredURL */
     private Timer redirectTimer;
 
@@ -350,6 +353,12 @@ public class MessageHandler {
             csrfToken = json
                     .getString(ApplicationConstants.UIDL_SECURITY_TOKEN_ID);
         }
+
+        // Get push id if present
+        if (json.containsKey(ApplicationConstants.UIDL_PUSH_ID)) {
+            pushId = json.getString(ApplicationConstants.UIDL_PUSH_ID);
+        }
+
         getLogger().info(" * Handling resources from server");
 
         if (json.containsKey("resources")) {
@@ -1685,6 +1694,16 @@ public class MessageHandler {
      */
     public String getCsrfToken() {
         return csrfToken;
+    }
+
+    /**
+     * Gets the push connection identifier for this session. Used when
+     * establishing a push connection with the client.
+     *
+     * @return the push connection identifier string
+     */
+    public String getPushId() {
+        return pushId;
     }
 
     /**

--- a/server/src/main/java/com/vaadin/server/VaadinSession.java
+++ b/server/src/main/java/com/vaadin/server/VaadinSession.java
@@ -744,6 +744,8 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      */
     private final String csrfToken = UUID.randomUUID().toString();
 
+    private final String pushId = UUID.randomUUID().toString();
+
     /**
      * Generate an id for the given Connector. Connectors must not call this
      * method more than once, the first time they need an id.
@@ -1415,6 +1417,17 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
     public String getCsrfToken() {
         assert hasLock();
         return csrfToken;
+    }
+
+    /**
+     * Gets the push connection identifier for this session. Used when
+     * establishing a push connection with the client.
+     *
+     * @return the push connection identifier string
+     */
+    public String getPushId() {
+        assert hasLock();
+        return pushId;
     }
 
     /**

--- a/server/src/main/java/com/vaadin/server/communication/PushHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushHandler.java
@@ -90,10 +90,10 @@ public class PushHandler {
         }
 
         String requestToken = resource.getRequest()
-                .getParameter(ApplicationConstants.CSRF_TOKEN_PARAMETER);
-        if (!VaadinService.isCsrfTokenValid(session, requestToken)) {
+                .getParameter(ApplicationConstants.PUSH_ID_PARAMETER);
+        if (!isPushIdValid(session, requestToken)) {
             getLogger().log(Level.WARNING,
-                    "Invalid CSRF token in new connection received from {0}",
+                    "Invalid identifier in new connection received from {0}",
                     resource.getRequest().getRemoteHost());
             // Refresh on client side, create connection just for
             // sending a message
@@ -465,6 +465,25 @@ public class PushHandler {
 
     private static final Logger getLogger() {
         return Logger.getLogger(PushHandler.class.getName());
+    }
+
+    /**
+     * Checks whether a given push id matches the session's push id.
+     *
+     * @param session
+     *            the vaadin session for which the check should be done
+     * @param requestPushId
+     *            the push id provided in the request
+     * @return {@code true} if the id is valid, {@code false} otherwise
+     */
+    private static boolean isPushIdValid(VaadinSession session,
+            String requestPushId) {
+
+        String sessionPushId = session.getPushId();
+        if (requestPushId == null || !requestPushId.equals(sessionPushId)) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
@@ -287,6 +287,7 @@ public abstract class UIInitHandler extends SynchronizedRequestHandler {
             if (session.getConfiguration().isXsrfProtectionEnabled()) {
                 writer.write(getSecurityKeyUIDL(session));
             }
+            writer.write(getPushIdUIDL(session));
             new UidlWriter().write(uI, writer, false);
             writer.write("}");
 
@@ -308,6 +309,18 @@ public abstract class UIInitHandler extends SynchronizedRequestHandler {
 
         return "\"" + ApplicationConstants.UIDL_SECURITY_TOKEN_ID + "\":\""
                 + seckey + "\",";
+    }
+
+    /**
+     * Gets the push connection identifier as UIDL.
+     *
+     * @param session
+     *            the vaadin session to which the security key belongs
+     * @return the push identifier UIDL
+     */
+    private static String getPushIdUIDL(VaadinSession session) {
+        return "\"" + ApplicationConstants.UIDL_PUSH_ID + "\":\""
+                + session.getPushId() + "\",";
     }
 
     private static final Logger getLogger() {

--- a/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
@@ -287,7 +287,9 @@ public abstract class UIInitHandler extends SynchronizedRequestHandler {
             if (session.getConfiguration().isXsrfProtectionEnabled()) {
                 writer.write(getSecurityKeyUIDL(session));
             }
-            writer.write(getPushIdUIDL(session));
+            if (uI.getPushConfiguration().getPushMode().isEnabled()) {
+                writer.write(getPushIdUIDL(session));
+            }
             new UidlWriter().write(uI, writer, false);
             writer.write("}");
 

--- a/shared/src/main/java/com/vaadin/shared/ApplicationConstants.java
+++ b/shared/src/main/java/com/vaadin/shared/ApplicationConstants.java
@@ -55,6 +55,8 @@ public class ApplicationConstants implements Serializable {
 
     public static final String UIDL_SECURITY_TOKEN_ID = "Vaadin-Security-Key";
 
+    public static final String UIDL_PUSH_ID = "Vaadin-Push-ID";
+
     @Deprecated
     public static final String UPDATE_VARIABLE_INTERFACE = "v";
     @Deprecated
@@ -80,7 +82,7 @@ public class ApplicationConstants implements Serializable {
     /**
      * Configuration parameter giving the (in some cases relative) URL to the
      * web application context root.
-     * 
+     *
      * @since 8.0.3
      */
     public static final String CONTEXT_ROOT_URL = "contextRootUrl";
@@ -121,6 +123,11 @@ public class ApplicationConstants implements Serializable {
      * Name of the parameter used to transmit the CSRF token.
      */
     public static final String CSRF_TOKEN_PARAMETER = "v-csrfToken";
+
+    /**
+     * Name of the parameter used to transmit the push connection identifier.
+     */
+    public static final String PUSH_ID_PARAMETER = "v-pushId";
 
     /**
      * The name of the parameter used to transmit RPC invocations


### PR DESCRIPTION
By using a separate id we can avoid sending the sessions
csrf token as a GET parameter when initializing a push connection.

Closes #8700

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9069)
<!-- Reviewable:end -->
