### PR TITLE
Notify resource onload listeners once for each time added

### DIFF
--- a/client/src/main/java/com/vaadin/client/ResourceLoader.java
+++ b/client/src/main/java/com/vaadin/client/ResourceLoader.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.client;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -401,12 +402,12 @@ public class ResourceLoader {
                     if (rules === undefined) {
                         rules = sheet.rules;
                     }
-    
+
                     if (rules === null) {
                         // Style sheet loaded, but can't access length because of XSS -> assume there's something there
                         return 1;
                     }
-    
+
                     // Return length so we can distinguish 0 (probably 404 error) from normal case.
                     return rules.length;
                 } catch (err) {
@@ -423,7 +424,7 @@ public class ResourceLoader {
             Map<String, Collection<ResourceLoadListener>> listenerMap) {
         Collection<ResourceLoadListener> listeners = listenerMap.get(url);
         if (listeners == null) {
-            listeners = new HashSet<>();
+            listeners = new ArrayList<>();
             listeners.add(listener);
             listenerMap.put(url, listeners);
             return true;

--- a/uitest/src/main/java/com/vaadin/tests/components/javascriptcomponent/DuplicateJavascriptDependencies.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/javascriptcomponent/DuplicateJavascriptDependencies.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.javascriptcomponent;
+
+import com.vaadin.annotations.JavaScript;
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUIWithLog;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Label;
+
+@JavaScript({ "notfound.js", "notfound.js" })
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class DuplicateJavascriptDependencies extends AbstractTestUIWithLog {
+
+    @JavaScript({ "notfound2.js", "notfound2.js" })
+    public static class ResultLabel extends Label {
+
+        public ResultLabel(String text) {
+            super(text);
+            setId("result");
+        }
+    }
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        addComponent(new Button("Test", e -> {
+            addComponent(new ResultLabel("It works"));
+        }));
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/javascriptcomponent/DuplicateJavascriptDependenciesTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/javascriptcomponent/DuplicateJavascriptDependenciesTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.javascriptcomponent;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.LabelElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class DuplicateJavascriptDependenciesTest extends SingleBrowserTest {
+
+    @Test
+    public void duplicateJavascriptsDoNotCauseProblems() {
+        openTestURL();
+        $(ButtonElement.class).first().click();
+        Assert.assertEquals("It works",
+                $(LabelElement.class).id("result").getText());
+    }
+}


### PR DESCRIPTION
This is what the javadoc promises and what DependencyLoader relies on

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9075)
<!-- Reviewable:end -->
