### PR TITLE
Always send a push identifier on UI initialization

### DIFF
--- a/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
@@ -287,9 +287,7 @@ public abstract class UIInitHandler extends SynchronizedRequestHandler {
             if (session.getConfiguration().isXsrfProtectionEnabled()) {
                 writer.write(getSecurityKeyUIDL(session));
             }
-            if (uI.getPushConfiguration().getPushMode().isEnabled()) {
-                writer.write(getPushIdUIDL(session));
-            }
+            writer.write(getPushIdUIDL(session));
             new UidlWriter().write(uI, writer, false);
             writer.write("}");
 


### PR DESCRIPTION
The push mode of an UI can be changed from disabled to enabled,
thus the identifier should be sent during initialization even
though push is initially disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9082)
<!-- Reviewable:end -->
