### PR TITLE
Make it possible to set a Resource as drag image

### DIFF
--- a/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
@@ -18,9 +18,11 @@ package com.vaadin.client.extensions;
 import com.google.gwt.dom.client.DataTransfer;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.client.ComponentConnector;
 import com.vaadin.client.ServerConnector;
+import com.vaadin.client.annotations.OnStateChange;
 import com.vaadin.event.dnd.DragSourceExtension;
 import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.ui.dnd.DragSourceRpc;
@@ -118,6 +120,14 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
         removeDragListeners(dragSource);
     }
 
+    @OnStateChange("resources")
+    private void prefetchDragImage() {
+        String dragImageUrl = getResourceUrl(DragSourceState.RESOURCE_DRAG_IMAGE);
+        if (dragImageUrl != null && !dragImageUrl.isEmpty()) {
+            Image.prefetch(dragImageUrl);
+        }
+    }
+
     /**
      * Event handler for the {@code dragstart} event. Called when {@code
      * dragstart} event occurs.
@@ -134,6 +144,9 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
             setEffectAllowed(nativeEvent.getDataTransfer(),
                     getState().effectAllowed.getValue());
         }
+
+        // Set drag image
+        setDragImage(event);
 
         // Set text data parameter
         nativeEvent.getDataTransfer().setData(DragSourceState.DATA_TYPE_TEXT,
@@ -172,6 +185,21 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      */
     protected void sendDragStartEventToServer(Event dragStartEvent) {
         getRpcProxy(DragSourceRpc.class).dragStart();
+    }
+
+    /**
+     * Sets the drag image to be displayed.
+     *
+     * @param dragStartEvent
+     *         The drag start event.
+     */
+    protected void setDragImage(Event dragStartEvent) {
+        String imageUrl = getResourceUrl(DragSourceState.RESOURCE_DRAG_IMAGE);
+        if (imageUrl != null && !imageUrl.isEmpty()) {
+            Image dragImage = new Image(imageUrl);
+            ((NativeEvent) dragStartEvent).getDataTransfer()
+                    .setDragImage(dragImage.getElement(), 0, 0);
+        }
     }
 
     /**

--- a/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
@@ -122,9 +122,10 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
 
     @OnStateChange("resources")
     private void prefetchDragImage() {
-        String dragImageUrl = getResourceUrl(DragSourceState.RESOURCE_DRAG_IMAGE);
+        String dragImageUrl = getResourceUrl(
+                DragSourceState.RESOURCE_DRAG_IMAGE);
         if (dragImageUrl != null && !dragImageUrl.isEmpty()) {
-            Image.prefetch(dragImageUrl);
+            Image.prefetch(getConnection().translateVaadinUri(dragImageUrl));
         }
     }
 
@@ -196,7 +197,8 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
     protected void setDragImage(Event dragStartEvent) {
         String imageUrl = getResourceUrl(DragSourceState.RESOURCE_DRAG_IMAGE);
         if (imageUrl != null && !imageUrl.isEmpty()) {
-            Image dragImage = new Image(imageUrl);
+            Image dragImage = new Image(
+                    getConnection().translateVaadinUri(imageUrl));
             ((NativeEvent) dragStartEvent).getDataTransfer()
                     .setDragImage(dragImage.getElement(), 0, 0);
         }

--- a/server/src/main/java/com/vaadin/event/dnd/DragSourceExtension.java
+++ b/server/src/main/java/com/vaadin/event/dnd/DragSourceExtension.java
@@ -18,6 +18,7 @@ package com.vaadin.event.dnd;
 import java.util.Objects;
 
 import com.vaadin.server.AbstractExtension;
+import com.vaadin.server.Resource;
 import com.vaadin.shared.Registration;
 import com.vaadin.shared.ui.dnd.DragSourceRpc;
 import com.vaadin.shared.ui.dnd.DragSourceState;
@@ -218,6 +219,16 @@ public class DragSourceExtension<T extends AbstractComponent> extends
     public Registration addDragEndListener(DragEndListener<T> listener) {
         return addListener(DragSourceState.EVENT_DRAGEND, DragEndEvent.class,
                 listener, DragEndListener.DRAGEND_METHOD);
+    }
+
+    /**
+     * Set a custom drag image for the current drag source.
+     *
+     * @param imageResource
+     *         Resource of the image to be displayed as drag image.
+     */
+    public void setDragImage(Resource imageResource) {
+        setResource(DragSourceState.RESOURCE_DRAG_IMAGE, imageResource);
     }
 
     @Override

--- a/shared/src/main/java/com/vaadin/shared/ui/dnd/DragSourceState.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/dnd/DragSourceState.java
@@ -40,6 +40,8 @@ public class DragSourceState extends SharedState {
      */
     public static final String DATA_TYPE_TEXT = "text";
 
+    public static final String RESOURCE_DRAG_IMAGE = "drag-image";
+
     /**
      * {@code DataTransfer.effectAllowed} parameter for the drag event.
      */


### PR DESCRIPTION
This PR is for #8892 but works only for browsers that support setting HTML5 dnd drag image, i.e. IE and Edge excluded.

See also #8977

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9088)
<!-- Reviewable:end -->
