### PR TITLE
Fix problem when reading a nested Design based on a GridLayout

### DIFF
--- a/server/src/main/java/com/vaadin/ui/GridLayout.java
+++ b/server/src/main/java/com/vaadin/ui/GridLayout.java
@@ -1264,11 +1264,24 @@ public class GridLayout extends AbstractLayout
         super.readDesign(design, designContext);
 
         setMargin(readMargin(design, getMargin(), designContext));
+        if (design.childNodeSize() > 0) {
+            // Touch content only if there is some content specified. This is
+            // needed to be able to use extended GridLayouts which add
+            // components in the constructor (e.g. Designs based on GridLayout).
+            readChildComponents(design.children(), designContext);
+        }
 
+        // Set cursor position explicitly
+        setCursorY(getRows());
+        setCursorX(0);
+    }
+
+    private void readChildComponents(Elements childElements,
+            DesignContext designContext) {
         List<Element> rowElements = new ArrayList<>();
         List<Map<Integer, Component>> rows = new ArrayList<>();
         // Prepare a 2D map for reading column contents
-        for (Element e : design.children()) {
+        for (Element e : childElements) {
             if (e.tagName().equalsIgnoreCase("row")) {
                 rowElements.add(e);
                 rows.add(new HashMap<>());
@@ -1394,9 +1407,6 @@ public class GridLayout extends AbstractLayout
                 setComponentAlignment(child, alignments.get(child));
             }
         }
-        // Set cursor position explicitly
-        setCursorY(getRows());
-        setCursorX(0);
     }
 
     @Override
@@ -1442,7 +1452,7 @@ public class GridLayout extends AbstractLayout
 
             // Row Expand
             DesignAttributeHandler.writeAttribute("expand", row.attributes(),
-                     getRowExpandRatio(i), 0.0f, float.class, designContext);
+                    getRowExpandRatio(i), 0.0f, float.class, designContext);
 
             int colspan = 1;
             Element col;

--- a/server/src/test/java/com/vaadin/tests/server/component/gridlayout/GridLayoutDeclarativeTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/gridlayout/GridLayoutDeclarativeTest.java
@@ -71,7 +71,7 @@ public class GridLayoutDeclarativeTest
 
     @Test
     public void testReadIntegerExpandRatioGridLayout() {
-        //To make sure that it can read from old declarative which use
+        // To make sure that it can read from old declarative which use
         // integer expand ratio
         Button b1 = new Button("Button 0,0");
         b1.setCaptionAsHtml(true);
@@ -342,4 +342,19 @@ public class GridLayoutDeclarativeTest
         Assert.assertEquals(null, context.getCustomAttributes(
                 context.getComponentByLocalId("marginBottomComponent")));
     }
+
+    @Test
+    public void designWithPreconfiguredGridLayout() throws Exception {
+        String design = "<html>" //
+                + "<head>" //
+                + "<meta name='package-mapping' content='my:com.vaadin.tests.server.component.gridlayout'>"
+                + "</meta>" + "</head>" + "<body>"
+                + "<my-preconfigured-grid-layout></my-preconfigured-grid-layout>";
+
+        PreconfiguredGridLayout myLayout = (PreconfiguredGridLayout) Design
+                .read(new ByteArrayInputStream(design.getBytes("UTF-8")));
+        Assert.assertEquals(2, myLayout.getRows());
+        Assert.assertEquals(2, myLayout.getColumns());
+    }
+
 }

--- a/server/src/test/java/com/vaadin/tests/server/component/gridlayout/PreconfiguredGridLayout.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/gridlayout/PreconfiguredGridLayout.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.server.component.gridlayout;
+
+import com.vaadin.ui.Button;
+import com.vaadin.ui.GridLayout;
+
+public class PreconfiguredGridLayout extends GridLayout {
+    public PreconfiguredGridLayout() {
+        setRows(2);
+        setColumns(2);
+
+        addComponent(new Button("1-1"));
+        addComponent(new Button("2-1"));
+        addComponent(new Button("1-2"));
+        addComponent(new Button("2-2"));
+    }
+}


### PR DESCRIPTION
The parent Design must leave child handling to the nested design, when
there are no children defined in the parent Design. This fixes a problem
with com.vaadin.ui.GridLayout$OutOfBoundsException when the reading
operation of the parent design tries to set number of rows according to
its empty content.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9092)
<!-- Reviewable:end -->
