### PR TITLE
Add missing methods to compatibility AbstractRendererConnector

### DIFF
--- a/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/AbstractRendererConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/AbstractRendererConnector.java
@@ -23,7 +23,9 @@ import com.vaadin.client.metadata.Type;
 import com.vaadin.client.metadata.TypeData;
 import com.vaadin.client.metadata.TypeDataStore;
 import com.vaadin.v7.client.renderers.Renderer;
+import com.vaadin.v7.client.widgets.Grid.Column;
 
+import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 
 /**
@@ -124,4 +126,47 @@ public abstract class AbstractRendererConnector<T>
     protected void extend(ServerConnector target) {
         // NOOP
     }
+
+    /**
+     * Gets the row key for a row object.
+     * <p>
+     * In case this renderer wants be able to identify a row in such a way that
+     * the server also understands it, the row key is used for that. Rows are
+     * identified by unified keys between the client and the server.
+     *
+     * @param row
+     *            the row object
+     * @return the row key for the given row
+     */
+    protected String getRowKey(JsonObject row) {
+        final ServerConnector parent = getParent();
+        if (parent instanceof GridConnector) {
+            return ((GridConnector) parent).getRowKey(row);
+        } else {
+            throw new IllegalStateException(
+                    "Renderers can only be used " + "with a Grid.");
+        }
+    }
+
+    /**
+     * Gets the column id for a column.
+     * <p>
+     * In case this renderer wants be able to identify a column in such a way
+     * that the server also understands it, the column id is used for that.
+     * Columns are identified by unified ids between the client and the server.
+     *
+     * @param column
+     *            the column object
+     * @return the column id for the given column
+     */
+    protected String getColumnId(Column<?, JsonObject> column) {
+        final ServerConnector parent = getParent();
+        if (parent instanceof GridConnector) {
+            return ((GridConnector) parent).getColumnId(column);
+        } else {
+            throw new IllegalStateException(
+                    "Renderers can only be used " + "with a Grid.");
+        }
+    }
+
 }


### PR DESCRIPTION
The methods are present in Vaadin 7, but not in the v7 compatibility
class.

Fixes #9096

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9098)
<!-- Reviewable:end -->
