### PR TITLE
Fix issues in Grid with undefined height

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -702,13 +702,13 @@ public class Escalator extends Widget
         /*-{
             var vScroll = esc.@com.vaadin.client.widgets.Escalator::verticalScrollbar;
             var vScrollElem = vScroll.@com.vaadin.client.widget.escalator.ScrollbarBundle::getElement()();
-
+        
             var hScroll = esc.@com.vaadin.client.widgets.Escalator::horizontalScrollbar;
             var hScrollElem = hScroll.@com.vaadin.client.widget.escalator.ScrollbarBundle::getElement()();
-
+        
             return $entry(function(e) {
                 var target = e.target;
-
+        
                 // in case the scroll event was native (i.e. scrollbars were dragged, or
                 // the scrollTop/Left was manually modified), the bundles have old cache
                 // values. We need to make sure that the caches are kept up to date.
@@ -729,29 +729,29 @@ public class Escalator extends Widget
             return $entry(function(e) {
                 var deltaX = e.deltaX ? e.deltaX : -0.5*e.wheelDeltaX;
                 var deltaY = e.deltaY ? e.deltaY : -0.5*e.wheelDeltaY;
-
+        
                 // Delta mode 0 is in pixels; we don't need to do anything...
-
+        
                 // A delta mode of 1 means we're scrolling by lines instead of pixels
                 // We need to scale the number of lines by the default line height
                 if(e.deltaMode === 1) {
                     var brc = esc.@com.vaadin.client.widgets.Escalator::body;
                     deltaY *= brc.@com.vaadin.client.widgets.Escalator.AbstractRowContainer::getDefaultRowHeight()();
                 }
-
+        
                 // Other delta modes aren't supported
                 if((e.deltaMode !== undefined) && (e.deltaMode >= 2 || e.deltaMode < 0)) {
                     var msg = "Unsupported wheel delta mode \"" + e.deltaMode + "\"";
-
+        
                     // Print warning message
                     esc.@com.vaadin.client.widgets.Escalator::logWarning(*)(msg);
                 }
-
+        
                 // IE8 has only delta y
                 if (isNaN(deltaY)) {
                     deltaY = -0.5*e.wheelDelta;
                 }
-
+        
                 @com.vaadin.client.widgets.Escalator.JsniUtil::moveScrollFromEvent(*)(esc, deltaX, deltaY, e);
             });
         }-*/;
@@ -1189,9 +1189,6 @@ public class Escalator extends Widget
             assertArgumentsAreValidAndWithinRange(index, numberOfRows);
 
             rows -= numberOfRows;
-            if (heightMode == HeightMode.UNDEFINED) {
-                heightByRows = rows;
-            }
 
             if (!isAttached()) {
                 return;
@@ -1207,8 +1204,9 @@ public class Escalator extends Widget
          * range of logical indices. This may be fewer than {@code numberOfRows}
          * , even zero, if not all the removed rows are actually visible.
          * <p>
-         * The implementation must call {@link #paintRemoveRow(TableRowElement, int)}
-         * for each row that is removed from the DOM.
+         * The implementation must call
+         * {@link #paintRemoveRow(TableRowElement, int)} for each row that is
+         * removed from the DOM.
          *
          * @param index
          *            the logical index of the first removed row
@@ -1315,10 +1313,6 @@ public class Escalator extends Widget
             }
 
             rows += numberOfRows;
-            if (heightMode == HeightMode.UNDEFINED) {
-                heightByRows = rows;
-            }
-
             /*
              * only add items in the DOM if the widget itself is attached to the
              * DOM. We can't calculate sizes otherwise.
@@ -2677,6 +2671,24 @@ public class Escalator extends Widget
         }
 
         @Override
+        public void insertRows(int index, int numberOfRows) {
+            super.insertRows(index, numberOfRows);
+
+            if (heightMode == HeightMode.UNDEFINED) {
+                setHeightByRows(getRowCount());
+            }
+        }
+
+        @Override
+        public void removeRows(int index, int numberOfRows) {
+            super.removeRows(index, numberOfRows);
+
+            if (heightMode == HeightMode.UNDEFINED) {
+                setHeightByRows(getRowCount());
+            }
+        }
+
+        @Override
         protected void paintInsertRows(final int index,
                 final int numberOfRows) {
             if (numberOfRows == 0) {
@@ -3000,7 +3012,8 @@ public class Escalator extends Widget
                     y += spacerContainer.getSpacerHeight(i);
                 }
 
-                // Execute the registered callback function for newly created rows
+                // Execute the registered callback function for newly created
+                // rows
                 Optional.ofNullable(newEscalatorRowCallback)
                         .ifPresent(callback -> callback.accept(addedRows));
 
@@ -3131,7 +3144,8 @@ public class Escalator extends Widget
                     }
 
                     // Move rest of the rows to the Escalator's top
-                    Range visualRange = Range.withLength(0, visualRowOrder.size());
+                    Range visualRange = Range.withLength(0,
+                            visualRowOrder.size());
                     moveAndUpdateEscalatorRows(visualRange, 0, 0);
 
                     sortDomElements();
@@ -6447,6 +6461,7 @@ public class Escalator extends Widget
      * @see #setHeightMode(HeightMode)
      */
     public void setHeightByRows(double rows) throws IllegalArgumentException {
+        getLogger().warning("HeightByRows: " + rows);
         if (rows <= 0) {
             throw new IllegalArgumentException(
                     "The number of rows must be a positive number.");

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Escalator.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Escalator.java
@@ -703,13 +703,13 @@ public class Escalator extends Widget
         /*-{
             var vScroll = esc.@com.vaadin.v7.client.widgets.Escalator::verticalScrollbar;
             var vScrollElem = vScroll.@com.vaadin.v7.client.widget.escalator.ScrollbarBundle::getElement()();
-        
+
             var hScroll = esc.@com.vaadin.v7.client.widgets.Escalator::horizontalScrollbar;
             var hScrollElem = hScroll.@com.vaadin.v7.client.widget.escalator.ScrollbarBundle::getElement()();
-        
+
             return $entry(function(e) {
                 var target = e.target;
-        
+
                 // in case the scroll event was native (i.e. scrollbars were dragged, or
                 // the scrollTop/Left was manually modified), the bundles have old cache
                 // values. We need to make sure that the caches are kept up to date.
@@ -730,29 +730,29 @@ public class Escalator extends Widget
             return $entry(function(e) {
                 var deltaX = e.deltaX ? e.deltaX : -0.5*e.wheelDeltaX;
                 var deltaY = e.deltaY ? e.deltaY : -0.5*e.wheelDeltaY;
-        
+
                 // Delta mode 0 is in pixels; we don't need to do anything...
-        
+
                 // A delta mode of 1 means we're scrolling by lines instead of pixels
                 // We need to scale the number of lines by the default line height
                 if(e.deltaMode === 1) {
                     var brc = esc.@com.vaadin.v7.client.widgets.Escalator::body;
                     deltaY *= brc.@com.vaadin.v7.client.widgets.Escalator.AbstractRowContainer::getDefaultRowHeight()();
                 }
-        
+
                 // Other delta modes aren't supported
                 if((e.deltaMode !== undefined) && (e.deltaMode >= 2 || e.deltaMode < 0)) {
                     var msg = "Unsupported wheel delta mode \"" + e.deltaMode + "\"";
-        
+
                     // Print warning message
                     esc.@com.vaadin.v7.client.widgets.Escalator::logWarning(*)(msg);
                 }
-        
+
                 // IE8 has only delta y
                 if (isNaN(deltaY)) {
                     deltaY = -0.5*e.wheelDelta;
                 }
-        
+
                 @com.vaadin.v7.client.widgets.Escalator.JsniUtil::moveScrollFromEvent(*)(esc, deltaX, deltaY, e);
             });
         }-*/;
@@ -1208,9 +1208,6 @@ public class Escalator extends Widget
             assertArgumentsAreValidAndWithinRange(index, numberOfRows);
 
             rows -= numberOfRows;
-            if (heightMode == HeightMode.UNDEFINED) {
-                heightByRows = rows;
-            }
 
             if (!isAttached()) {
                 return;
@@ -1334,9 +1331,6 @@ public class Escalator extends Widget
             }
 
             rows += numberOfRows;
-            if (heightMode == HeightMode.UNDEFINED) {
-                heightByRows = rows;
-            }
 
             /*
              * only add items in the DOM if the widget itself is attached to the
@@ -2511,6 +2505,24 @@ public class Escalator extends Widget
 
         public BodyRowContainerImpl(final TableSectionElement bodyElement) {
             super(bodyElement);
+        }
+
+        @Override
+        public void insertRows(int index, int numberOfRows) {
+            super.insertRows(index, numberOfRows);
+
+            if (heightMode == HeightMode.UNDEFINED) {
+                heightByRows = getRowCount();
+            }
+        }
+
+        @Override
+        public void removeRows(int index, int numberOfRows) {
+            super.removeRows(index, numberOfRows);
+
+            if (heightMode == HeightMode.UNDEFINED) {
+                heightByRows = getRowCount();
+            }
         }
 
         @Override

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridUndefinedHeight.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridUndefinedHeight.java
@@ -1,0 +1,21 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.shared.ui.grid.HeightMode;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Grid;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class GridUndefinedHeight extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        Grid<String> grid = new Grid<>();
+        grid.setItems("Foo", "Bar", "Baz");
+        grid.setHeightMode(HeightMode.UNDEFINED);
+        grid.addColumn(Object::toString).setCaption("toString()");
+        addComponent(grid);
+    }
+
+}

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridUndefinedHeight.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridUndefinedHeight.java
@@ -1,21 +1,39 @@
 package com.vaadin.tests.components.grid;
 
-import com.vaadin.annotations.Widgetset;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.shared.ui.grid.HeightMode;
 import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
 import com.vaadin.ui.Grid;
+import com.vaadin.ui.VerticalLayout;
 
-@Widgetset("com.vaadin.DefaultWidgetSet")
 public class GridUndefinedHeight extends AbstractTestUI {
 
     @Override
     protected void setup(VaadinRequest request) {
+        VerticalLayout layout = new VerticalLayout();
+
         Grid<String> grid = new Grid<>();
         grid.setItems("Foo", "Bar", "Baz");
         grid.setHeightMode(HeightMode.UNDEFINED);
         grid.addColumn(Object::toString).setCaption("toString()");
-        addComponent(grid);
+
+        com.vaadin.v7.ui.Grid oldGrid = new com.vaadin.v7.ui.Grid();
+        oldGrid.addColumn("toString", String.class);
+        oldGrid.addRow("Foo");
+        oldGrid.addRow("Bar");
+        oldGrid.addRow("Baz");
+        oldGrid.setHeightMode(
+                com.vaadin.v7.shared.ui.grid.HeightMode.UNDEFINED);
+
+        layout.addComponents(grid, oldGrid, new Button("Add header row", e -> {
+            grid.appendHeaderRow();
+            oldGrid.appendHeaderRow();
+        }));
+        layout.setHeight("600px");
+        layout.setExpandRatio(grid, 1.0f);
+        layout.setExpandRatio(oldGrid, 1.0f);
+        addComponent(layout);
     }
 
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridUndefinedHeightTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridUndefinedHeightTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vaadin.testbench.elements.ButtonElement;
 import com.vaadin.testbench.elements.GridElement;
 import com.vaadin.testbench.parallel.TestCategory;
 import com.vaadin.tests.tb3.SingleBrowserTest;
@@ -23,6 +24,48 @@ public class GridUndefinedHeightTest extends SingleBrowserTest {
         int oneRow = grid.getRow(0).getSize().getHeight();
         int gridHeight = grid.getSize().getHeight();
         int rows = 4; // Header Row + 3 Body Rows
+
+        Assert.assertEquals("Grid height mismatch", oneRow * rows, gridHeight);
+
+        assertNoErrorNotifications();
+    }
+
+    @Test
+    public void gridv7_undefined_height() {
+        GridElement grid = $(GridElement.class).get(1);
+        int oneRow = grid.getRow(0).getSize().getHeight();
+        int gridHeight = grid.getSize().getHeight();
+        int rows = 4; // Header Row + 3 Body Rows
+
+        Assert.assertEquals("Grid height mismatch", oneRow * rows, gridHeight);
+
+        assertNoErrorNotifications();
+    }
+
+    @Test
+    public void grid_undefined_height_add_header() {
+        // Add header row to Grid
+        $(ButtonElement.class).first().click();
+
+        GridElement grid = $(GridElement.class).first();
+        int oneRow = grid.getRow(0).getSize().getHeight();
+        int gridHeight = grid.getSize().getHeight();
+        int rows = 5; // 2 Header Rows + 3 Body Rows
+
+        Assert.assertEquals("Grid height mismatch", oneRow * rows, gridHeight);
+
+        assertNoErrorNotifications();
+    }
+
+    @Test
+    public void gridv7_undefined_height_add_header() {
+        // Add header row to Grid
+        $(ButtonElement.class).first().click();
+
+        GridElement grid = $(GridElement.class).get(1);
+        int oneRow = grid.getRow(0).getSize().getHeight();
+        int gridHeight = grid.getSize().getHeight();
+        int rows = 5; // 2 Header Rows + 3 Body Rows
 
         Assert.assertEquals("Grid height mismatch", oneRow * rows, gridHeight);
 

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridUndefinedHeightTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridUndefinedHeightTest.java
@@ -1,0 +1,31 @@
+package com.vaadin.tests.components.grid;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.GridElement;
+import com.vaadin.testbench.parallel.TestCategory;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+@TestCategory("grid")
+public class GridUndefinedHeightTest extends SingleBrowserTest {
+
+    @Before
+    public void before() {
+        setDebug(true);
+        openTestURL();
+    }
+
+    @Test
+    public void grid_undefined_height() {
+        GridElement grid = $(GridElement.class).first();
+        int oneRow = grid.getRow(0).getSize().getHeight();
+        int gridHeight = grid.getSize().getHeight();
+        int rows = 4; // Header Row + 3 Body Rows
+
+        Assert.assertEquals("Grid height mismatch", oneRow * rows, gridHeight);
+
+        assertNoErrorNotifications();
+    }
+}


### PR DESCRIPTION
The undefined height mode in Grid is applying new height when changing the size of headers or footers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9104)
<!-- Reviewable:end -->
