### PR TITLE
Fix race condition between rendering TreeGrid and setting up headers

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
@@ -202,6 +202,11 @@ public class GridConnector extends AbstractListingConnector
     protected void init() {
         super.init();
 
+        // Remove default headers when initializing Grid widget
+        while (getWidget().getHeaderRowCount() > 0) {
+            getWidget().removeHeaderRow(0);
+        }
+
         registerRpc(GridClientRpc.class, new GridClientRpc() {
 
             @Override
@@ -311,22 +316,15 @@ public class GridConnector extends AbstractListingConnector
         final Grid<JsonObject> grid = getWidget();
         final SectionState state = getState().header;
 
-        while (grid.getHeaderRowCount() > 0) {
-            grid.removeHeaderRow(0);
-        }
+        for (RowState rowState : state.rows) {
+            HeaderRow row = grid.appendHeaderRow();
 
-        Scheduler.get().scheduleFinally(() -> {
-
-            for (RowState rowState : state.rows) {
-                HeaderRow row = grid.appendHeaderRow();
-
-                if (rowState.defaultHeader) {
-                    grid.setDefaultHeaderRow(row);
-                }
-
-                updateStaticRow(rowState, row);
+            if (rowState.defaultHeader) {
+                grid.setDefaultHeaderRow(row);
             }
-        });
+
+            updateStaticRow(rowState, row);
+        }
     }
 
     @OnStateChange("rowHeight")

--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
@@ -316,6 +316,10 @@ public class GridConnector extends AbstractListingConnector
         final Grid<JsonObject> grid = getWidget();
         final SectionState state = getState().header;
 
+        while (grid.getHeaderRowCount() > 0) {
+            grid.removeHeaderRow(0);
+        }
+
         for (RowState rowState : state.rows) {
             HeaderRow row = grid.appendHeaderRow();
 

--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
@@ -308,13 +308,14 @@ public class GridConnector extends AbstractListingConnector
      */
     @OnStateChange("header")
     void updateHeader() {
-        Scheduler.get().scheduleFinally(() -> {
-            final Grid<JsonObject> grid = getWidget();
-            final SectionState state = getState().header;
+        final Grid<JsonObject> grid = getWidget();
+        final SectionState state = getState().header;
 
-            while (grid.getHeaderRowCount() > 0) {
-                grid.removeHeaderRow(0);
-            }
+        while (grid.getHeaderRowCount() > 0) {
+            grid.removeHeaderRow(0);
+        }
+
+        Scheduler.get().scheduleFinally(() -> {
 
             for (RowState rowState : state.rows) {
                 HeaderRow row = grid.appendHeaderRow();

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -3028,8 +3028,10 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
          * Sets the select all checkbox visible or hidden.
          */
         protected void doSetSelectAllCheckBoxVisible() {
-            assert selectAllCheckBox != null : "Select All Checkbox has not been created for selection column.";
-            assert selectionCell != null : "Default header cell for selection column not been set.";
+            if (selectAllCheckBox == null || selectionCell == null) {
+                // There is no default header row to display select all checkbox
+                return;
+            }
 
             if (selectAllCheckBoxVisible) {
                 selectionCell.setWidget(selectAllCheckBox);

--- a/uitest/src/main/java/com/vaadin/tests/components/treegrid/TreeGridNoHeaderOnInit.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/treegrid/TreeGridNoHeaderOnInit.java
@@ -17,6 +17,7 @@ public class TreeGridNoHeaderOnInit extends AbstractTestUI {
         grid.addColumn(t -> new Label(t), new ComponentRenderer());
         grid.setItems("Foo", "Bar", "Baz");
         grid.removeHeaderRow(0);
+        grid.appendFooterRow();
         addComponent(grid);
     }
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/treegrid/TreeGridNoHeaderOnInit.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/treegrid/TreeGridNoHeaderOnInit.java
@@ -1,0 +1,22 @@
+package com.vaadin.tests.components.treegrid;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.TreeGrid;
+import com.vaadin.ui.renderers.ComponentRenderer;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class TreeGridNoHeaderOnInit extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        TreeGrid<String> grid = new TreeGrid<>();
+        grid.addColumn(Object::toString).setCaption("toString with Caption");
+        grid.addColumn(t -> new Label(t), new ComponentRenderer());
+        grid.setItems("Foo", "Bar", "Baz");
+        grid.removeHeaderRow(0);
+        addComponent(grid);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridNoHeaderOnInitTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridNoHeaderOnInitTest.java
@@ -12,5 +12,4 @@ public class TreeGridNoHeaderOnInitTest extends SingleBrowserTest {
         openTestURL();
         assertNoErrorNotifications();
     }
-
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridNoHeaderOnInitTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridNoHeaderOnInitTest.java
@@ -1,0 +1,16 @@
+package com.vaadin.tests.components.treegrid;
+
+import org.junit.Test;
+
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class TreeGridNoHeaderOnInitTest extends SingleBrowserTest {
+
+    @Test
+    public void no_exception_thrown() {
+        setDebug(true);
+        openTestURL();
+        assertNoErrorNotifications();
+    }
+
+}


### PR DESCRIPTION
Setting the hierarchy column and its renderer conflicts with Grid header setup. This causes Grid to attempt to render headers too early.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9105)
<!-- Reviewable:end -->
