### PR TITLE
Back port the fix for #8840 from 8.0 to 7.7 (#8840)

### DIFF
--- a/client/src/main/java/com/vaadin/client/data/AbstractRemoteDataSource.java
+++ b/client/src/main/java/com/vaadin/client/data/AbstractRemoteDataSource.java
@@ -560,7 +560,15 @@ public abstract class AbstractRemoteDataSource<T> implements DataSource<T> {
             Range remainsBefore = partitions[0];
             Range transposedRemainsAfter = partitions[2]
                     .offsetBy(-removedRange.length());
-            cached = remainsBefore.combineWith(transposedRemainsAfter);
+            // #8840 either can be empty if the removed range was over the
+            // cached range
+            if (remainsBefore.isEmpty()) {
+                cached = transposedRemainsAfter;
+            } else if (transposedRemainsAfter.isEmpty()) {
+                cached = remainsBefore;
+            } else {
+                cached = remainsBefore.combineWith(transposedRemainsAfter);
+            }
         } else if (removedRange.getEnd() <= cached.getStart()) {
             // Removal was before the cache. offset the cache.
             cached = cached.offsetBy(-removedRange.length());

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridRemoveCachedRows.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridRemoveCachedRows.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2000-2014 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.grid;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.vaadin.data.util.IndexedContainer;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.shared.ui.grid.HeightMode;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Grid;
+
+@SuppressWarnings("serial")
+public class GridRemoveCachedRows extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+
+        List<String> columnIds = Arrays.asList("Hello", "this", "are",
+                "multiple", "columns", "plus", "these", "resemble", "a",
+                "group", "here", "no", "more");
+
+        final Grid grid = new Grid(new CustomIndexedContainer());
+        grid.setHeightMode(HeightMode.ROW);
+        grid.setHeightByRows(20);
+        for (String columnId : columnIds) {
+            ((CustomIndexedContainer) grid.getContainerDataSource())
+                    .addContainerProperty(columnId, String.class, "");
+        }
+
+        // add a lot of rows to make sure that at least some of them are cached
+        for (int i = 0; i < 400; i++) {
+            grid.addRow(columnIds.toArray());
+        }
+
+        Button removeRowsButton = new Button("Remove a cached row");
+        removeRowsButton.addClickListener(new Button.ClickListener() {
+            @Override
+            public void buttonClick(Button.ClickEvent event) {
+                // remove a range of items starting from the visible items and
+                // ending into the cached items
+                ((CustomIndexedContainer) grid.getContainerDataSource())
+                        .removeItemRange(10, 300);
+            }
+        });
+
+        addComponents(grid, removeRowsButton);
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Test what happens when item range (starting from visible and ending to cached items) is removed from Grid.";
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 8840;
+    }
+
+    /**
+     * Customised IndexedContainer for removing item range
+     */
+    public class CustomIndexedContainer extends IndexedContainer {
+        public void removeItemRange(int startIndex, int count) {
+            Object firstItem = null;
+
+            for (int index = startIndex; index < startIndex + count; index++) {
+                Object itemId = getIdByIndex(startIndex);
+                getAllItemIds().remove(itemId);
+                if (firstItem == null) {
+                    firstItem = itemId;
+                }
+            }
+            fireItemsRemoved(startIndex, firstItem, count);
+        }
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridRemoveCachedRowsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridRemoveCachedRowsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2014 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.grid;
+
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+/**
+ * Verifies that there's no client side errors when removing a range of rows
+ * starting from the visible ones and ending into the cached ones.
+ */
+public class GridRemoveCachedRowsTest extends SingleBrowserTest {
+
+    @Test
+    public void testNoClientExceptionWhenRemovingARangeOfRows() {
+        setDebug(true);
+        openTestURL();
+
+        // do remove a range of rows
+        $(ButtonElement.class).first().click();
+
+        assertNoErrorNotifications();
+    }
+}


### PR DESCRIPTION
Added a new test that verifies the fix for Vaadin 7.7, since Vaadin 8.0
version used TreeGrid not available for 7.7. Used customised
IndexedContainer (with ability to remove a range of rows) to enable
easy reproducibility of the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9112)
<!-- Reviewable:end -->
