### PR TITLE
add necessary override and implementations (FocusNotifier & BlurNotifier)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VCheckBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCheckBox.java
@@ -55,7 +55,7 @@ public class VCheckBox extends com.google.gwt.user.client.ui.CheckBox
             el = DOM.getNextSibling(el);
         }
 
-        if (BrowserInfo.get().isWebkit()) {
+        if (BrowserInfo.get().isWebkit() || BrowserInfo.get().isFirefox()) {
             // Webkit does not focus non-text input elements on click
             // (#11854)
             addClickHandler(new ClickHandler() {

--- a/server/src/main/java/com/vaadin/server/BootstrapHandler.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapHandler.java
@@ -387,12 +387,6 @@ public abstract class BootstrapHandler extends SynchronizedRequestHandler {
         head.appendElement("meta").attr("http-equiv", "Content-Type").attr(
                 "content", ApplicationConstants.CONTENT_TYPE_TEXT_HTML_UTF_8);
 
-        /*
-         * Enable Chrome Frame in all versions of IE if installed.
-         */
-        head.appendElement("meta").attr("http-equiv", "X-UA-Compatible")
-                .attr("content", "IE=11;chrome=1");
-
         Class<? extends UI> uiClass = context.getUIClass();
 
         String viewportContent = null;

--- a/server/src/main/java/com/vaadin/ui/AbstractTextField.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractTextField.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.Element;
 
+import com.vaadin.event.FieldEvents;
 import com.vaadin.event.FieldEvents.BlurEvent;
 import com.vaadin.event.FieldEvents.BlurListener;
 import com.vaadin.event.FieldEvents.FocusEvent;
@@ -44,7 +45,7 @@ import elemental.json.Json;
  * @since 8.0
  */
 public abstract class AbstractTextField extends AbstractField<String>
-        implements HasValueChangeMode {
+        implements HasValueChangeMode, FieldEvents.FocusNotifier, FieldEvents.BlurNotifier {
 
     private final class AbstractTextFieldServerRpcImpl
             implements AbstractTextFieldServerRpc {
@@ -201,6 +202,7 @@ public abstract class AbstractTextField extends AbstractField<String>
      *
      * @see Registration
      */
+    @Override 
     public Registration addFocusListener(FocusListener listener) {
         return addListener(FocusEvent.EVENT_ID, FocusEvent.class, listener,
                 FocusListener.focusMethod);
@@ -216,6 +218,7 @@ public abstract class AbstractTextField extends AbstractField<String>
      *
      * @see Registration
      */
+    @Override
     public Registration addBlurListener(BlurListener listener) {
         return addListener(BlurEvent.EVENT_ID, BlurEvent.class, listener,
                 BlurListener.blurMethod);


### PR DESCRIPTION
Fix the missing Implementation (FieldEvents.FocusNotifier & FieldEvents.BlurNotifier)  in AbstractTextField. The fields TextField, TextArea and PasswordField are the only focusable input fields where this Implementation is missing.

Update (1):

Well, okay. My intention was to create another pull request for the new commit. But now it's all here. Sorry about that.

- Removes X-UA-Compatible because since Vaadin 8.0 you only support IE > 11 / Edge, so this is not needed anymore
- The chrome=1 project part of the X-UA-Compatible was never updated since 2014 
- Best practice would be (if needed by a client) that he should add it in a server config.

Update (2):

- I would propose to remove the body scroll="auto" part as well, because it adds unnecessary validation errors to the site and adds little to no value for the end user, what do you think?

Update (3):

- Fixed #3944 
- Tested this fix on a local machine against a Firefox and Firefox Dev Edition, both works now ( The FocusListener get's called even when the User clicks the Label or Input to change the Value from true to false or vice versa)
- I didn't want to remove the whole if-block to reduce the chance that this could break something in IE (Don't have one to test it.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9131)
<!-- Reviewable:end -->
