### PR TITLE
remove a & button styling from _global

### DIFF
--- a/themes/src/main/themes/VAADIN/themes/valo/components/_link.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_link.scss
@@ -30,6 +30,7 @@ $v-link-cursor: pointer !default;
     @include valo-link-style;
 
     a {
+      @include valo-link-style;
       cursor: inherit;
       color: inherit;
       text-decoration: inherit;

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_nativebutton.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_nativebutton.scss
@@ -6,6 +6,13 @@
  * @group nativebutton
  */
 @mixin valo-nativebutton ($primary-stylename: v-nativebutton) {
+
+  button {
+    font: inherit;
+    font-weight: 400;
+    line-height: $v-line-height;
+  }
+
   .#{$primary-stylename} {
     -webkit-touch-callout: none;
   }

--- a/themes/src/main/themes/VAADIN/themes/valo/shared/_global.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/shared/_global.scss
@@ -329,10 +329,6 @@ $valo-shared-pathPrefix: null;
     @include valo-nativeselect-select-style;
   }
 
-  a {
-    @include valo-link-style;
-  }
-
   .v-disabled {
     cursor: default !important;
   }

--- a/themes/src/main/themes/VAADIN/themes/valo/shared/_global.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/shared/_global.scss
@@ -329,12 +329,6 @@ $valo-shared-pathPrefix: null;
     @include valo-nativeselect-select-style;
   }
 
-  button {
-    font: inherit;
-    font-weight: 400;
-    line-height: $v-line-height;
-  }
-
   a {
     @include valo-link-style;
   }


### PR DESCRIPTION
When creating a theme and removing link and button from $v-included-components, I would expect that there is no styling left that could interfere with the new style. 

At the moment: There a still some styling left that changes the look and feel of the components.

This pull requests moves those styling from global in the _link & _button files, so that a developer don't have to deal with overwriting the styles if he doesn't want them in the first place.

ping theme guru @jouni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9136)
<!-- Reviewable:end -->
