### PR TITLE
Fix parent version in some POMs

### DIFF
--- a/compatibility-server-gae/pom.xml
+++ b/compatibility-server-gae/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-compatibility-server-gae</artifactId>
     <name>vaadin-compatibility-server-gae</name>

--- a/liferay-integration/pom.xml
+++ b/liferay-integration/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/osgi-integration/pom.xml
+++ b/osgi-integration/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Use the correct snapshot version of the parent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9145)
<!-- Reviewable:end -->
