### PR TITLE
Fix ComponentLocator with inherited classes without custom connector

### DIFF
--- a/client/src/main/java/com/vaadin/client/JavaScriptConnectorHelper.java
+++ b/client/src/main/java/com/vaadin/client/JavaScriptConnectorHelper.java
@@ -50,7 +50,6 @@ public class JavaScriptConnectorHelper {
     private final Map<Element, Map<JavaScriptObject, ElementResizeListener>> resizeListeners = new HashMap<>();
 
     private JavaScriptObject connectorWrapper;
-    private int tag;
 
     private String initFunctionName;
     private String tagName;
@@ -407,10 +406,6 @@ public class JavaScriptConnectorHelper {
         return new Object[] { Util.json2jso(parametersJson) };
     }
 
-    public void setTag(int tag) {
-        this.tag = tag;
-    }
-
     public void invokeJsRpc(MethodInvocation invocation,
             JsonArray parametersJson) {
         String iface = invocation.getInterfaceName();
@@ -496,7 +491,7 @@ public class JavaScriptConnectorHelper {
         ApplicationConfiguration conf = connector.getConnection()
                 .getConfiguration();
         ArrayList<String> initFunctionNames = new ArrayList<String>();
-        Integer tag = Integer.valueOf(this.tag);
+        Integer tag = Integer.valueOf(connector.getTag());
         while (tag != null) {
             String initFunctionName = conf.getServerSideClassNameForTag(tag);
             initFunctionName = initFunctionName.replaceAll("\\.", "_");

--- a/client/src/main/java/com/vaadin/client/ServerConnector.java
+++ b/client/src/main/java/com/vaadin/client/ServerConnector.java
@@ -217,4 +217,19 @@ public interface ServerConnector extends Connector {
      */
     public boolean hasEventListener(String eventIdentifier);
 
+    /**
+     * Sets the connector type tag for this connector.
+     *
+     * @param tag
+     *            the connector type tag
+     */
+    public void setTag(int tag);
+
+    /**
+     * Gets the connector type tag for this connector.
+     *
+     * @return the connector type tag
+     */
+    public int getTag();
+
 }

--- a/client/src/main/java/com/vaadin/client/ServerConnector.java
+++ b/client/src/main/java/com/vaadin/client/ServerConnector.java
@@ -218,17 +218,37 @@ public interface ServerConnector extends Connector {
     public boolean hasEventListener(String eventIdentifier);
 
     /**
-     * Sets the connector type tag for this connector.
+     * Sets the connector type tag for this connector. This should only be
+     * called from
+     * {@link WidgetSet#createConnector(int, ApplicationConfiguration)}
+     *
+     * @see #getTag()
      *
      * @param tag
      *            the connector type tag
+     *
+     * @deprecated This is an internal method and should not be called by an
+     *             application developer.
+     *
+     * @since 8.1
      */
+    @Deprecated
     public void setTag(int tag);
 
     /**
-     * Gets the connector type tag for this connector.
+     * Gets the connector type tag for this connector. This type tag is an
+     * identifier used to map client-side connectors to their server-side
+     * classes. The server-side class information is stored in
+     * {@link ApplicationConfiguration} and contains class names and their
+     * hierarchy.
+     *
+     * @see ApplicationConfiguration#getServerSideClassNameForTag(Integer)
+     * @see ApplicationConfiguration#getTagsForServerSideClassName(String)
+     * @see ApplicationConfiguration#getParentTag(int)
      *
      * @return the connector type tag
+     *
+     * @since 8.1
      */
     public int getTag();
 

--- a/client/src/main/java/com/vaadin/client/WidgetSet.java
+++ b/client/src/main/java/com/vaadin/client/WidgetSet.java
@@ -20,7 +20,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.google.gwt.core.client.GWT;
-import com.vaadin.client.communication.HasJavaScriptConnectorHelper;
 import com.vaadin.client.metadata.BundleLoadCallback;
 import com.vaadin.client.metadata.ConnectorBundleLoader;
 import com.vaadin.client.metadata.NoDataException;
@@ -80,10 +79,7 @@ public class WidgetSet {
                  */
                 ServerConnector connector = (ServerConnector) TypeData
                         .getType(classType).createInstance();
-                if (connector instanceof HasJavaScriptConnectorHelper) {
-                    ((HasJavaScriptConnectorHelper) connector)
-                            .getJavascriptConnectorHelper().setTag(tag);
-                }
+                connector.setTag(tag);
                 return connector;
             }
         } catch (NoDataException e) {

--- a/client/src/main/java/com/vaadin/client/componentlocator/VaadinFinderLocatorStrategy.java
+++ b/client/src/main/java/com/vaadin/client/componentlocator/VaadinFinderLocatorStrategy.java
@@ -608,12 +608,17 @@ public class VaadinFinderLocatorStrategy implements LocatorStrategy {
             String widgetName) {
 
         List<String> ids = getIDsForConnector(connector);
+        String exactClass = connector.getConnection().getConfiguration()
+                .getServerSideClassNameForTag(connector.getTag());
+        if (!ids.contains(exactClass)) {
+            ids.add(exactClass);
+        }
 
         List<Integer> widgetTags = new ArrayList<>();
         widgetTags.addAll(getTags(widgetName));
 
         if (widgetTags.size() == 0) {
-            widgetTags.addAll(getTags("com.vaadin.ui" + widgetName));
+            widgetTags.addAll(getTags("com.vaadin.ui." + widgetName));
         }
 
         for (int i = 0, l = ids.size(); i < l; ++i) {

--- a/client/src/main/java/com/vaadin/client/ui/AbstractConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/AbstractConnector.java
@@ -61,6 +61,7 @@ public abstract class AbstractConnector
 
     private ApplicationConnection connection;
     private String id;
+    private int tag;
 
     private HandlerManager handlerManager;
     private FastStringMap<HandlerManager> statePropertyHandlerManagers;
@@ -522,5 +523,15 @@ public abstract class AbstractConnector
             return true;
         }
 
+    }
+
+    @Override
+    public int getTag() {
+        return tag;
+    }
+
+    @Override
+    public void setTag(int tag) {
+        this.tag = tag;
     }
 }

--- a/uitest/src/main/java/com/vaadin/tests/componentlocator/ComponentLocatorInheritedClasses.java
+++ b/uitest/src/main/java/com/vaadin/tests/componentlocator/ComponentLocatorInheritedClasses.java
@@ -1,0 +1,36 @@
+package com.vaadin.tests.componentlocator;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.UI;
+import com.vaadin.ui.VerticalLayout;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class ComponentLocatorInheritedClasses extends UI {
+
+    public static class DefaultLabel extends Label {
+
+        protected DefaultLabel(String content) {
+            super(content);
+        }
+
+        public DefaultLabel() {
+            this("Default Custom Label");
+        }
+    }
+
+    public static class MyCustomLabel extends DefaultLabel {
+        public MyCustomLabel(String content) {
+            super(content);
+        }
+    }
+
+    @Override
+    protected void init(VaadinRequest request) {
+        VerticalLayout layout = new VerticalLayout();
+        layout.addComponents(new Label("Vaadin Basic Label"),
+                new DefaultLabel(), new MyCustomLabel("My Custom Label"));
+        setContent(layout);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/componentlocator/ComponentLocatorInheritedClassesTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/componentlocator/ComponentLocatorInheritedClassesTest.java
@@ -1,0 +1,37 @@
+package com.vaadin.tests.componentlocator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.LabelElement;
+import com.vaadin.testbench.elementsbase.ServerClass;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class ComponentLocatorInheritedClassesTest extends SingleBrowserTest {
+
+    @ServerClass("com.vaadin.tests.componentlocator.ComponentLocatorInheritedClasses.DefaultLabel")
+    public static class DefaultLabelElement extends LabelElement {
+    }
+
+    @ServerClass("com.vaadin.tests.componentlocator.ComponentLocatorInheritedClasses.MyCustomLabel")
+    public static class MyCustomLabelElement extends DefaultLabelElement {
+    }
+
+    @Test
+    public void label_finds_all_three() {
+        openTestURL();
+        Assert.assertEquals(3, $(LabelElement.class).all().size());
+    }
+
+    @Test
+    public void defaultlabel_finds_two() {
+        openTestURL();
+        Assert.assertEquals(2, $(DefaultLabelElement.class).all().size());
+    }
+
+    @Test
+    public void mycustomlabel_finds_one() {
+        openTestURL();
+        Assert.assertEquals(1, $(MyCustomLabelElement.class).all().size());
+    }
+}


### PR DESCRIPTION
Logic for finding elements corresponding a server-side classname does
not work with inherited classes. For example making MyGrid extends Grid,
you could not find the specific MyGrid, but only the common Grid.

In most cases this is not a problem since these components are usually
the only instance of said superclass, but the Composite introduced in
the same UI, which makes testing them impossible.

This patch adds the specific classname information for ServerConnectors
that can be used to find the correct connector instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9176)
<!-- Reviewable:end -->
