### PR TITLE
Added constructor to Grid for compatibility with 8.0.6 (#9206)

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -2122,9 +2122,9 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      */
     protected Grid(Class<T> beanType, DataCommunicator<T> dataCommunicator) {
         this(BeanPropertySet.get(beanType));
-        this.beanType = beanType;        
+        this.beanType = beanType;
     }
-    
+
     /**
      * Creates a new grid with the given data communicator and without support
      * for creating columns based on property names.

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -2104,10 +2104,27 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      * @see #withPropertySet(PropertySet)
      */
     public Grid(Class<T> beanType) {
-        this(BeanPropertySet.get(beanType));
-        this.beanType = beanType;
+        this(beanType, new DataCommunicator<>());
     }
 
+    /**
+     * Creates a new grid that uses custom data communicator and provided bean type
+     * 
+     * It uses reflection of the provided bean type to automatically set up an initial set of columns. 
+     * All columns will be configured using the same {@link Object#toString()} renderer that is used
+     * by {@link #addColumn(ValueProvider)}.
+     *
+     * @param beanType
+     *            the bean type to use, not <code>null</code>
+     * @param dataCommunicator
+     *            the data communicator to use, not<code>null</code>
+     * @since 8.0.6
+     */
+    protected Grid(Class<T> beanType, DataCommunicator<T> dataCommunicator) {
+        this(BeanPropertySet.get(beanType));
+        this.beanType = beanType;        
+    }
+    
     /**
      * Creates a new grid with the given data communicator and without support
      * for creating columns based on property names.
@@ -2116,7 +2133,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      *            the custom data communicator to set
      * @see #Grid()
      * @see #Grid(PropertySet, DataCommunicator)
-     * @since 8.1
+     * @since 8.0.6
      */
     protected Grid(DataCommunicator<T> dataCommunicator) {
         this(new PropertySet<T>() {
@@ -2164,7 +2181,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      *            the property set implementation to use, not <code>null</code>.
      * @param dataCommunicator
      *            the data communicator to use, not<code>null</code>
-     * @since 8.1
+     * @since 8.0.6
      */
     protected Grid(PropertySet<T> propertySet,
             DataCommunicator<T> dataCommunicator) {


### PR DESCRIPTION
Constructor Grid(Class, DataCommunicator) was added to 8.0.6 and ported
to master to maintain backward compatibility.

Also fixed javadocs of constructors Grid(DataCommunicator) and
Grid(PropertySet, DataCommunicator) to reflect that constructors were
backported to 8.0.x and available since 8.0.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9209)
<!-- Reviewable:end -->
