### PR TITLE
HierarchicalDataProvider cache invalidation fix

### DIFF
--- a/server/src/main/java/com/vaadin/data/provider/HierarchicalDataCommunicator.java
+++ b/server/src/main/java/com/vaadin/data/provider/HierarchicalDataCommunicator.java
@@ -288,7 +288,9 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
             String itemKey = keys.getString(i);
             if (!mapper.isKeyStored(itemKey)
                     && !rowKeysPendingExpand.contains(itemKey)) {
-                getActiveDataHandler().dropActiveData(itemKey);
+                // FIXME: cache invalidated incorrectly, active keys being
+                // dropped prematurely
+                // getActiveDataHandler().dropActiveData(itemKey);
             }
         }
     }

--- a/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridClientSortTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridClientSortTest.java
@@ -1,0 +1,32 @@
+package com.vaadin.tests.components.treegrid;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.TreeGridElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class TreeGridClientSortTest extends SingleBrowserTest {
+
+    @Override
+    public Class<?> getUIClass() {
+        return TreeGridBasicFeatures.class;
+    }
+
+    @Test
+    public void client_sorting_with_collapse_and_expand() {
+        openTestURL();
+        TreeGridElement grid = $(TreeGridElement.class).first();
+        selectMenuPath("Component", "Features", "Set data provider",
+                "InMemoryHierarchicalDataProvider");
+        grid.getHeaderCell(0, 0).doubleClick();
+        grid.expandWithClick(0);
+        grid.expandWithClick(1);
+        grid.collapseWithClick(0);
+        grid.expandWithClick(0);
+        assertEquals("0 | 2", grid.getCell(0, 0).getText());
+        assertEquals("1 | 2", grid.getCell(1, 0).getText());
+        assertEquals("2 | 2", grid.getCell(2, 0).getText());
+    }
+}


### PR DESCRIPTION
Workaround for issue in data communication where
active keys are dropped incorrectly on the server.

See issue #9217

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9218)
<!-- Reviewable:end -->
