### PR TITLE
Fix HTML5 DnD regression for FF

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridDropTargetConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridDropTargetConnector.java
@@ -82,7 +82,7 @@ public class GridDropTargetConnector extends DropTargetExtensionConnector {
 
     @Override
     protected void sendDropEventToServer(String dataTransferText,
-            Event dropEvent) {
+            String dropEffect, Event dropEvent) {
 
         String rowKey = null;
         DropLocation dropLocation = null;
@@ -96,8 +96,8 @@ public class GridDropTargetConnector extends DropTargetExtensionConnector {
                     (NativeEvent) dropEvent);
         }
 
-        getRpcProxy(GridDropTargetRpc.class).drop(dataTransferText, rowKey,
-                dropLocation);
+        getRpcProxy(GridDropTargetRpc.class).drop(dataTransferText, dropEffect,
+                rowKey, dropLocation);
     }
 
     private JsonObject getRowData(TableRowElement row) {
@@ -147,7 +147,7 @@ public class GridDropTargetConnector extends DropTargetExtensionConnector {
     }
 
     @Override
-    protected void setTargetIndicator(Event event) {
+    protected void setTargetClassIndicator(Event event) {
         getTargetRow(((Element) event.getTarget())).ifPresent(target -> {
 
             // Get required class name
@@ -184,7 +184,7 @@ public class GridDropTargetConnector extends DropTargetExtensionConnector {
     }
 
     @Override
-    protected void removeTargetIndicator(Event event) {
+    protected void removeTargetClassIndicator(Event event) {
 
         // Remove all possible style names
         getTargetRow((Element) event.getTarget()).ifPresent(e -> {

--- a/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
@@ -77,7 +77,7 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * Sets the given element draggable and adds class name.
      *
      * @param element
-     *         Element to be set draggable.
+     *            Element to be set draggable.
      */
     protected void setDraggable(Element element) {
         element.setDraggable(Element.DRAGGABLE_TRUE);
@@ -91,7 +91,7 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * Removes draggable and class name from the given element.
      *
      * @param element
-     *         Element to remove draggable from.
+     *            Element to remove draggable from.
      */
     protected void removeDraggable(Element element) {
         element.setDraggable(Element.DRAGGABLE_FALSE);
@@ -104,7 +104,7 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * Adds dragstart and dragend event listeners to the given DOM element.
      *
      * @param element
-     *         DOM element to attach event listeners to.
+     *            DOM element to attach event listeners to.
      */
     protected void addDragListeners(Element element) {
         EventTarget target = element.cast();
@@ -117,7 +117,7 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * Removes dragstart and dragend event listeners from the given DOM element.
      *
      * @param element
-     *         DOM element to remove event listeners from.
+     *            DOM element to remove event listeners from.
      */
     protected void removeDragListeners(Element element) {
         EventTarget target = element.cast();
@@ -150,7 +150,7 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * dragstart} event occurs.
      *
      * @param event
-     *         browser event to be handled
+     *            browser event to be handled
      */
     protected void onDragStart(Event event) {
         // Convert elemental event to have access to dataTransfer
@@ -167,10 +167,12 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
 
         // Set text data parameter
         String dataTransferText = createDataTransferText(event);
-        if (dataTransferText != null && !dataTransferText.isEmpty()) {
-            nativeEvent.getDataTransfer()
-                    .setData(DragSourceState.DATA_TYPE_TEXT, dataTransferText);
+        // Always set something as the text data, or DnD won't work in FF !
+        if (dataTransferText == null) {
+            dataTransferText = "";
         }
+        nativeEvent.getDataTransfer().setData(DragSourceState.DATA_TYPE_TEXT,
+                dataTransferText);
 
         // Initiate firing server side dragstart event when there is a
         // DragStartListener attached on the server side
@@ -187,7 +189,7 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * of the given event.
      *
      * @param dragStartEvent
-     *         Event to set the data for.
+     *            Event to set the data for.
      * @return Textual data to be set for the event or {@literal null}.
      */
     protected String createDataTransferText(Event dragStartEvent) {
@@ -201,7 +203,7 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * handler attached.
      *
      * @param dragStartEvent
-     *         Client side dragstart event.
+     *            Client side dragstart event.
      */
     protected void sendDragStartEventToServer(Event dragStartEvent) {
         getRpcProxy(DragSourceRpc.class).dragStart();
@@ -211,7 +213,7 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * Sets the drag image to be displayed.
      *
      * @param dragStartEvent
-     *         The drag start event.
+     *            The drag start event.
      */
     protected void setDragImage(Event dragStartEvent) {
         String imageUrl = getResourceUrl(DragSourceState.RESOURCE_DRAG_IMAGE);
@@ -228,7 +230,7 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * event occurs.
      *
      * @param event
-     *         browser event to be handled
+     *            browser event to be handled
      */
     protected void onDragEnd(Event event) {
         // Initiate server start dragend event when there is a DragEndListener
@@ -248,9 +250,9 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * Initiates a server RPC for the drag end event.
      *
      * @param dragEndEvent
-     *         Client side dragend event.
+     *            Client side dragend event.
      * @param dropEffect
-     *         Drop effect of the dragend event, extracted from {@code
+     *            Drop effect of the dragend event, extracted from {@code
      *         DataTransfer.dropEffect} parameter.
      */
     protected void sendDragEndEventToServer(Event dragEndEvent,
@@ -269,11 +271,13 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
     }
 
     private native void setEffectAllowed(DataTransfer dataTransfer,
-            String effectAllowed)/*-{
+            String effectAllowed)
+    /*-{
         dataTransfer.effectAllowed = effectAllowed;
     }-*/;
 
-    private native String getDropEffect(DataTransfer dataTransfer)/*-{
+    static native String getDropEffect(DataTransfer dataTransfer)
+    /*-{
         return dataTransfer.dropEffect;
     }-*/;
 
@@ -282,7 +286,8 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
         return (DragSourceState) super.getState();
     }
 
-    private native boolean getStylePrimaryName(Element element)/*-{
+    private native boolean getStylePrimaryName(Element element)
+    /*-{
         return @com.google.gwt.user.client.ui.UIObject::getStylePrimaryName(Lcom/google/gwt/dom/client/Element;)(element);
     }-*/;
 }

--- a/client/src/main/java/com/vaadin/client/extensions/DropTargetExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/DropTargetExtensionConnector.java
@@ -154,7 +154,8 @@ public class DropTargetExtensionConnector extends AbstractExtensionConnector {
 
             setDropEffect(nativeEvent);
 
-            // To allow dropping need to call this
+            // According to spec, need to call this for allowing dropping, the
+            // default action would be to reject as target
             event.preventDefault();
         } else {
             // Remove drop effect
@@ -180,8 +181,12 @@ public class DropTargetExtensionConnector extends AbstractExtensionConnector {
      */
     protected void setDropEffect(NativeEvent event) {
         if (getState().dropEffect != null) {
-            event.getDataTransfer().setDropEffect(DataTransfer.DropEffect
-                    .valueOf(getState().dropEffect.name().toUpperCase()));
+
+            DataTransfer.DropEffect dropEffect = DataTransfer.DropEffect
+                    // the valueOf() needs to have equal string and name()
+                    // doesn't return in all upper case
+                    .valueOf(getState().dropEffect.name().toUpperCase());
+            event.getDataTransfer().setDropEffect(dropEffect);
         }
     }
 
@@ -252,10 +257,10 @@ public class DropTargetExtensionConnector extends AbstractExtensionConnector {
                 && getState().dropEffect == DropEffect.NONE) {
             return false;
         }
-        // TODO Should add verification for checking effectAllowed and
-        // dropEffect from event and comparing that to target's dropEffect
-        // currently Safari and IE don't follow the spec by allowing drop if
-        // those don't match
+        // TODO #9246: Should add verification for checking effectAllowed and
+        // dropEffect from event and comparing that to target's dropEffect.
+        // Currently Safari, Edge and IE don't follow the spec by allowing drop
+        // if those don't match
 
         if (getState().dropCriteria != null) {
             return executeScript(event, getState().dropCriteria);

--- a/documentation/advanced/advanced-dragndrop.asciidoc
+++ b/documentation/advanced/advanced-dragndrop.asciidoc
@@ -130,17 +130,16 @@ When data is dragged over a drop target, the __v-drag-over__ class name is appli
 
 The __drop effect__ allows you to specify the desired drop effect, and for a succesful drop it must match the allowed effect that has been set for the drag source. Note that you can allow multiple effects, and that you should not rely on the default effect since it may vary between browsers.
 
-The __drag over criteria__ allows you determine whether the current drag source is allowed as a drop target, when the source is moved on top of the target. It is a script that is executed always when the `dragover` event is fired for the first time for this source, and returning `false` will prevent showing any drop effect. The script gets the `dragover` event as a parameter named `event`.
+The __drop criteria__ allows you to determine whether the current drag data can be dropped on the drop target. It is executed on `dragenter`, `dragover` and `drop` events. The script gets the current event as a parameter named `event`. Returning `false` will prevent the drop and no drop event is fired on the server side.
 
-The __drop criteria__ is similar to __drag over criteria__, but it is executed when the user has dropped the data by releasing the mouse button. The script gets the `drop` event as a parameter named `event`. Returning `false` will prevent the drop and no drop event is fired on the server side.
+////
+TODO Add an example of drop criteria
+////
 
 === CSS Style Rules
 
 When dragging data over a drop target and the drag over criteria passes, a style name is applied to indicate that the element accepts drops. This style name is the primary style name with `-drag-center` suffix, e.g. `v-label-drag-center`.
 
-////
-TODO Add an example of drag over criteria and drop criteria
-////
 
 ===
 

--- a/server/src/main/java/com/vaadin/event/dnd/DropEvent.java
+++ b/server/src/main/java/com/vaadin/event/dnd/DropEvent.java
@@ -76,9 +76,10 @@ public class DropEvent<T extends AbstractComponent> extends Component.Event {
     /**
      * Get the desired dropEffect for the drop event.
      * <p>
-     * <em>NOTE: Currently you cannot trust this to work on all browsers! For
-     * Chrome it is never set and always returns {@link DropEffect#NONE} even
-     * though the drop succeeded!</em>
+     * <em>NOTE: Currently you cannot trust this to work on all browsers!
+     * https://github.com/vaadin/framework/issues/9247 For Chrome & IE11 it is
+     * never set and always returns {@link DropEffect#NONE} even though the drop
+     * succeeded!</em>
      *
      * @return the drop effect
      */

--- a/server/src/main/java/com/vaadin/event/dnd/DropEvent.java
+++ b/server/src/main/java/com/vaadin/event/dnd/DropEvent.java
@@ -25,7 +25,7 @@ import com.vaadin.ui.Component;
  * Server side drop event. Fired when an HTML5 drop happens.
  *
  * @param <T>
- *         Type of the drop target component.
+ *            Type of the drop target component.
  * @author Vaadin Ltd
  * @see DropTargetExtension#addDropListener(DropListener)
  * @since 8.1
@@ -34,24 +34,28 @@ public class DropEvent<T extends AbstractComponent> extends Component.Event {
     private final String dataTransferText;
     private final DragSourceExtension<? extends AbstractComponent> dragSourceExtension;
     private final AbstractComponent dragSource;
+    private final DropEffect dropEffect;
 
     /**
      * Creates a server side drop event.
      *
      * @param target
-     *         Component that received the drop.
+     *            Component that received the drop.
      * @param dataTransferText
-     *         Data of type {@code "text"} from the {@code DataTransfer}
-     *         object.
+     *            Data of type {@code "text"} from the {@code DataTransfer}
+     *            object.
+     * @param dropEffect
+     *            the desired drop effect
      * @param dragSourceExtension
-     *         Drag source extension of the component that initiated the drop
-     *         event.
+     *            Drag source extension of the component that initiated the drop
+     *            event.
      */
-    public DropEvent(T target, String dataTransferText,
+    public DropEvent(T target, String dataTransferText, DropEffect dropEffect,
             DragSourceExtension<? extends AbstractComponent> dragSourceExtension) {
         super(target);
 
         this.dataTransferText = dataTransferText;
+        this.dropEffect = dropEffect;
 
         this.dragSourceExtension = dragSourceExtension;
         this.dragSource = Optional.ofNullable(dragSourceExtension)
@@ -70,9 +74,21 @@ public class DropEvent<T extends AbstractComponent> extends Component.Event {
     }
 
     /**
-     * Returns the drag source component if the drag originated from a
-     * component in the same UI as the drop target component, or an empty
-     * optional.
+     * Get the desired dropEffect for the drop event.
+     * <p>
+     * <em>NOTE: Currently you cannot trust this to work on all browsers! For
+     * Chrome it is never set and always returns {@link DropEffect#NONE} even
+     * though the drop succeeded!</em>
+     *
+     * @return the drop effect
+     */
+    public DropEffect getDropEffect() {
+        return dropEffect;
+    }
+
+    /**
+     * Returns the drag source component if the drag originated from a component
+     * in the same UI as the drop target component, or an empty optional.
      *
      * @return Drag source component or an empty optional.
      */
@@ -81,9 +97,9 @@ public class DropEvent<T extends AbstractComponent> extends Component.Event {
     }
 
     /**
-     * Returns the extension of the drag source component if the drag
-     * originated from a component in the same UI as the drop target component,
-     * or an empty optional.
+     * Returns the extension of the drag source component if the drag originated
+     * from a component in the same UI as the drop target component, or an empty
+     * optional.
      *
      * @return Drag source extension or an empty optional
      */
@@ -97,7 +113,7 @@ public class DropEvent<T extends AbstractComponent> extends Component.Event {
      * drag source and drop target when they are in the same UI.
      *
      * @return Optional server side drag data if set and the drag source and the
-     * drop target are in the same UI, otherwise empty {@code Optional}.
+     *         drop target are in the same UI, otherwise empty {@code Optional}.
      * @see DragSourceExtension#setDragData(Object)
      */
     public Optional<Object> getDragData() {

--- a/server/src/main/java/com/vaadin/event/dnd/grid/GridDropEvent.java
+++ b/server/src/main/java/com/vaadin/event/dnd/grid/GridDropEvent.java
@@ -17,6 +17,7 @@ package com.vaadin.event.dnd.grid;
 
 import com.vaadin.event.dnd.DragSourceExtension;
 import com.vaadin.event.dnd.DropEvent;
+import com.vaadin.shared.ui.dnd.DropEffect;
 import com.vaadin.shared.ui.grid.DropLocation;
 import com.vaadin.ui.AbstractComponent;
 import com.vaadin.ui.Grid;
@@ -44,6 +45,8 @@ public class GridDropEvent<T> extends DropEvent<Grid<T>> {
      * @param dataTransferText
      *            Data of type {@code "text"} from the {@code DataTransfer}
      *            object.
+     * @param dropEffect
+     *            the desired drop effect
      * @param dragSourceExtension
      *            Drag source extension of the component that initiated the drop
      *            event.
@@ -53,9 +56,10 @@ public class GridDropEvent<T> extends DropEvent<Grid<T>> {
      *            Location of the drop within the target row.
      */
     public GridDropEvent(Grid<T> target, String dataTransferText,
+            DropEffect dropEffect,
             DragSourceExtension<? extends AbstractComponent> dragSourceExtension,
             T dropTargetRow, DropLocation dropLocation) {
-        super(target, dataTransferText, dragSourceExtension);
+        super(target, dataTransferText, dropEffect, dragSourceExtension);
 
         this.dropTargetRow = dropTargetRow;
         this.dropLocation = dropLocation;

--- a/server/src/main/java/com/vaadin/ui/GridDropTarget.java
+++ b/server/src/main/java/com/vaadin/ui/GridDropTarget.java
@@ -19,6 +19,7 @@ import com.vaadin.event.dnd.DropTargetExtension;
 import com.vaadin.event.dnd.grid.GridDropEvent;
 import com.vaadin.event.dnd.grid.GridDropListener;
 import com.vaadin.shared.Registration;
+import com.vaadin.shared.ui.dnd.DropEffect;
 import com.vaadin.shared.ui.grid.DropMode;
 import com.vaadin.shared.ui.grid.GridDropTargetRpc;
 import com.vaadin.shared.ui.grid.GridDropTargetState;
@@ -130,15 +131,16 @@ public class GridDropTarget<T> extends DropTargetExtension<Grid<T>> {
 
     @Override
     protected void registerDropTargetRpc(Grid<T> target) {
-        registerRpc((GridDropTargetRpc) (dataTransferText, rowKey,
+        registerRpc((GridDropTargetRpc) (dataTransferText, dropEffect, rowKey,
                 dropLocation) -> {
 
             T dropTargetRow = target.getDataCommunicator().getKeyMapper()
                     .get(rowKey);
 
             GridDropEvent<T> event = new GridDropEvent<>(target,
-                    dataTransferText, getUI().getActiveDragSource(),
-                    dropTargetRow, dropLocation);
+                    dataTransferText,
+                    DropEffect.valueOf(dropEffect.toUpperCase()),
+                    getUI().getActiveDragSource(), dropTargetRow, dropLocation);
 
             fireEvent(event);
         });

--- a/shared/src/main/java/com/vaadin/shared/ui/dnd/DropTargetRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/dnd/DropTargetRpc.java
@@ -30,8 +30,10 @@ public interface DropTargetRpc extends ServerRpc {
      * Called when drop event happens on client side.
      *
      * @param dataTransferText
-     *         Data of type {@code "text"} from the {@code DataTransfer}
-     *         object.
+     *            Data of type {@code "text"} from the {@code DataTransfer}
+     *            object.
+     * @param dropEffect
+     *            the desired drop effect
      */
-    public void drop(String dataTransferText);
+    public void drop(String dataTransferText, String dropEffect);
 }

--- a/shared/src/main/java/com/vaadin/shared/ui/dnd/DropTargetState.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/dnd/DropTargetState.java
@@ -30,11 +30,6 @@ public class DropTargetState extends SharedState {
     public DropEffect dropEffect;
 
     /**
-     * Criteria script to allow dragOver event on the element
-     */
-    public String dragOverCriteria;
-
-    /**
      * Criteria script to allow drop event on the element
      */
     public String dropCriteria;

--- a/shared/src/main/java/com/vaadin/shared/ui/grid/GridDropTargetRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/grid/GridDropTargetRpc.java
@@ -32,11 +32,13 @@ public interface GridDropTargetRpc extends ServerRpc {
      * @param dataTransferText
      *            Data of type {@code "text"} from the {@code DataTransfer}
      *            object.
+     * @param dropEffect
+     *            the desired drop effect
      * @param rowKey
      *            Key of the row on which the drop event occured.
      * @param dropLocation
      *            Location of the drop within the row.
      */
-    public void drop(String dataTransferText, String rowKey,
+    public void drop(String dataTransferText, String dropEffect, String rowKey,
             DropLocation dropLocation);
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridDragAndDrop.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridDragAndDrop.java
@@ -22,6 +22,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.annotations.Theme;
+import com.vaadin.annotations.Widgetset;
 import com.vaadin.data.provider.ListDataProvider;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.shared.ui.dnd.DropEffect;
@@ -41,6 +43,8 @@ import com.vaadin.ui.RadioButtonGroup;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 
+@Theme("valo")
+@Widgetset("com.vaadin.DefaultWidgetSet")
 public class GridDragAndDrop extends AbstractTestUIWithLog {
 
     private Set<Person> draggedItems;
@@ -61,13 +65,13 @@ public class GridDragAndDrop extends AbstractTestUIWithLog {
         grids.addComponents(left, right);
 
         // Selection modes
-        List<Grid.SelectionMode> selectionModes = Arrays.asList(
-                Grid.SelectionMode.SINGLE, Grid.SelectionMode.MULTI);
+        List<Grid.SelectionMode> selectionModes = Arrays
+                .asList(Grid.SelectionMode.SINGLE, Grid.SelectionMode.MULTI);
         RadioButtonGroup<Grid.SelectionMode> selectionModeSelect = new RadioButtonGroup<>(
                 "Selection mode", selectionModes);
         selectionModeSelect.setSelectedItem(Grid.SelectionMode.SINGLE);
-        selectionModeSelect.addValueChangeListener(event -> left
-                .setSelectionMode(event.getValue()));
+        selectionModeSelect.addValueChangeListener(
+                event -> left.setSelectionMode(event.getValue()));
 
         // Drop locations
         List<DropMode> dropLocations = Arrays.asList(DropMode.values());
@@ -113,9 +117,8 @@ public class GridDragAndDrop extends AbstractTestUIWithLog {
         });
 
         // Add drag start listener
-        dragSource.addGridDragStartListener(event ->
-                draggedItems = event.getDraggedItems()
-        );
+        dragSource.addGridDragStartListener(
+                event -> draggedItems = event.getDraggedItems());
 
         // Add drag end listener
         dragSource.addGridDragEndListener(event -> {
@@ -148,18 +151,17 @@ public class GridDragAndDrop extends AbstractTestUIWithLog {
                     List<Person> items = (List<Person>) dataProvider.getItems();
 
                     // Calculate the target row's index
-                    int index = items.indexOf(event.getDropTargetRow()) + (
-                            event.getDropLocation() == DropLocation.BELOW
-                                    ? 1 : 0);
+                    int index = items.indexOf(event.getDropTargetRow())
+                            + (event.getDropLocation() == DropLocation.BELOW ? 1
+                                    : 0);
 
                     // Add dragged items to the target Grid
                     items.addAll(index, draggedItems);
                     dataProvider.refreshAll();
 
-                    log("dragData=" + event.getDataTransferText()
-                            + ", target="
-                            + event.getDropTargetRow().getFirstName()
-                            + " " + event.getDropTargetRow().getLastName()
+                    log("dragData=" + event.getDataTransferText() + ", target="
+                            + event.getDropTargetRow().getFirstName() + " "
+                            + event.getDropTargetRow().getLastName()
                             + ", location=" + event.getDropLocation());
                 }
             });

--- a/uitest/src/main/java/com/vaadin/tests/dnd/DragAndDropCardShuffle.java
+++ b/uitest/src/main/java/com/vaadin/tests/dnd/DragAndDropCardShuffle.java
@@ -52,6 +52,8 @@ public class DragAndDropCardShuffle extends AbstractTestUIWithLog {
         NativeSelect<EffectAllowed> effectAllowed = new NativeSelect<>(
                 "Effect Allowed (source)");
         effectAllowed.setItems(EffectAllowed.values());
+        effectAllowed.setValue(EffectAllowed.UNINITIALIZED);
+        effectAllowed.setEmptySelectionAllowed(false);
         effectAllowed.addValueChangeListener(event -> sources
                 .forEach(source -> source.setEffectAllowed(event.getValue())));
 


### PR DESCRIPTION
- Always set some drag data
- Set the dropEffect on dragEnter and dragOver events on drop target
- Send the dropEffect to server on drop event with disclaimer of current support

Tested manually basic DnD and Grid DnD on Mac with Chrome, Firefox, Safari.
Safari is still missing drag image (regression).

Tested manually basic DnD and Grid Dnd on Windows IE11 and Edge.
Drop event for both is still not working properly #9174.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9245)
<!-- Reviewable:end -->
