### PR TITLE
Add missing Implementation (FieldEvents.FocusNotifier & FieldEvents.BlurNotifier) 

### DIFF
--- a/server/src/main/java/com/vaadin/ui/AbstractTextField.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractTextField.java
@@ -19,6 +19,7 @@ package com.vaadin.ui;
 import java.util.Collection;
 import java.util.Objects;
 
+import com.vaadin.event.FieldEvents;
 import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.Element;
 
@@ -44,7 +45,7 @@ import elemental.json.Json;
  * @since 8.0
  */
 public abstract class AbstractTextField extends AbstractField<String>
-        implements HasValueChangeMode {
+        implements HasValueChangeMode, FieldEvents.FocusNotifier, FieldEvents.BlurNotifier {
 
     private final class AbstractTextFieldServerRpcImpl
             implements AbstractTextFieldServerRpc {
@@ -201,6 +202,7 @@ public abstract class AbstractTextField extends AbstractField<String>
      *
      * @see Registration
      */
+    @Override
     public Registration addFocusListener(FocusListener listener) {
         return addListener(FocusEvent.EVENT_ID, FocusEvent.class, listener,
                 FocusListener.focusMethod);
@@ -216,6 +218,7 @@ public abstract class AbstractTextField extends AbstractField<String>
      *
      * @see Registration
      */
+    @Override
     public Registration addBlurListener(BlurListener listener) {
         return addListener(BlurEvent.EVENT_ID, BlurEvent.class, listener,
                 BlurListener.blurMethod);


### PR DESCRIPTION
in AbstractTextField. The fields TextField, TextArea and PasswordField are the only focusable input fields where this Implementation is missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9269)
<!-- Reviewable:end -->
