### PR TITLE
Removes unnecessary X-UA-Compatible

### DIFF
--- a/server/src/main/java/com/vaadin/server/BootstrapHandler.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapHandler.java
@@ -515,12 +515,6 @@ public abstract class BootstrapHandler extends SynchronizedRequestHandler {
         head.appendElement("meta").attr("http-equiv", "Content-Type").attr(
                 "content", ApplicationConstants.CONTENT_TYPE_TEXT_HTML_UTF_8);
 
-        /*
-         * Enable Chrome Frame in all versions of IE if installed.
-         */
-        head.appendElement("meta").attr("http-equiv", "X-UA-Compatible")
-                .attr("content", "IE=11;chrome=1");
-
         Class<? extends UI> uiClass = context.getUIClass();
 
         String viewportContent = null;

--- a/server/src/main/java/com/vaadin/server/BootstrapHandler.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapHandler.java
@@ -515,6 +515,9 @@ public abstract class BootstrapHandler extends SynchronizedRequestHandler {
         head.appendElement("meta").attr("http-equiv", "Content-Type").attr(
                 "content", ApplicationConstants.CONTENT_TYPE_TEXT_HTML_UTF_8);
 
+        // Force IE 11 to use IE 11 mode.
+        head.appendElement("meta").attr("http-equiv", "X-UA-Compatible").attr("content", "IE=11");
+
         Class<? extends UI> uiClass = context.getUIClass();
 
         String viewportContent = null;


### PR DESCRIPTION
Intention behind the commit:
* remove unnecessary overload
* removes X-UA-Compatible because since Vaadin 8.0 you only support IE > 11 / Edge, so this is not needed anymore
* the chrome=1 project part of the X-UA-Compatible was never updated since 2014
* best practice would be (if needed by a client) that he should add it in a server config.

I would propose to remove the body scroll="auto" part as well, because it adds unnecessary validation errors to the site and adds little to no value for the end user, what do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9270)
<!-- Reviewable:end -->
