### PR TITLE
fix 3944 - so that a click on the checkbox label calls the focus listener

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VCheckBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCheckBox.java
@@ -55,7 +55,7 @@ public class VCheckBox extends com.google.gwt.user.client.ui.CheckBox
             el = DOM.getNextSibling(el);
         }
 
-        if (BrowserInfo.get().isWebkit()) {
+        if (BrowserInfo.get().isWebkit() || BrowserInfo.get().isFirefox()) {
             // Webkit does not focus non-text input elements on click
             // (#11854)
             addClickHandler(new ClickHandler() {

--- a/client/src/main/java/com/vaadin/client/ui/VCheckBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCheckBox.java
@@ -56,8 +56,8 @@ public class VCheckBox extends com.google.gwt.user.client.ui.CheckBox
         }
 
         if (BrowserInfo.get().isWebkit() || BrowserInfo.get().isFirefox()) {
-            // Webkit does not focus non-text input elements on click
-            // (#11854)
+            // Webkit and Firefox do not focus non-text input elements on click
+            // (#3944)
             addClickHandler(new ClickHandler() {
                 @Override
                 public void onClick(ClickEvent event) {

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCheckBox.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCheckBox.java
@@ -61,8 +61,8 @@ public class VCheckBox extends com.google.gwt.user.client.ui.CheckBox
         }
 
         if (BrowserInfo.get().isWebkit() || BrowserInfo.get().isFirefox()) {
-            // Webkit does not focus non-text input elements on click
-            // (#11854)
+            // Webkit and Firefox do not focus non-text input elements on click
+            // (#3944)
             addClickHandler(new ClickHandler() {
                 @Override
                 public void onClick(ClickEvent event) {

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCheckBox.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCheckBox.java
@@ -60,7 +60,7 @@ public class VCheckBox extends com.google.gwt.user.client.ui.CheckBox
             el = DOM.getNextSibling(el);
         }
 
-        if (BrowserInfo.get().isWebkit()) {
+        if (BrowserInfo.get().isWebkit() || BrowserInfo.get().isFirefox()) {
             // Webkit does not focus non-text input elements on click
             // (#11854)
             addClickHandler(new ClickHandler() {

--- a/uitest/src/main/java/com/vaadin/tests/components/checkbox/CheckboxFocusClick.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/checkbox/CheckboxFocusClick.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.checkbox;
+
+import com.vaadin.event.FieldEvents;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUIWithLog;
+import com.vaadin.ui.CheckBox;
+
+public class CheckboxFocusClick extends AbstractTestUIWithLog {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        final CheckBox cb = new CheckBox("Click me", true);
+        cb.addFocusListener((FieldEvents.FocusListener) event -> log("checkbox focused"));
+        addComponent(cb);
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/checkbox/CheckboxFocusClickTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/checkbox/CheckboxFocusClickTest.java
@@ -21,16 +21,8 @@ import com.vaadin.tests.tb3.MultiBrowserTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.DesiredCapabilities;
-
-import java.util.List;
 
 public class CheckboxFocusClickTest extends MultiBrowserTest {
-
-    @Override
-    public List<DesiredCapabilities> getBrowsersToTest() {
-        return getBrowsersSupportingContextMenu();
-    }
 
     @Test
     public void contextClickCheckboxAndText() {
@@ -42,5 +34,4 @@ public class CheckboxFocusClickTest extends MultiBrowserTest {
         clickElement(label);
         Assert.assertEquals("checkbox focused", getLogRow(0));
     }
-
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/checkbox/CheckboxFocusClickTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/checkbox/CheckboxFocusClickTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.checkbox;
+
+import com.vaadin.testbench.By;
+import com.vaadin.testbench.elements.CheckBoxElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.util.List;
+
+public class CheckboxFocusClickTest extends MultiBrowserTest {
+
+    @Override
+    public List<DesiredCapabilities> getBrowsersToTest() {
+        return getBrowsersSupportingContextMenu();
+    }
+
+    @Test
+    public void contextClickCheckboxAndText() {
+        openTestURL();
+        CheckBoxElement checkbox = $(CheckBoxElement.class).first();
+        Assert.assertEquals("checked", checkbox.getValue());
+        WebElement label = checkbox.findElement(By.xpath("label"));
+
+        clickElement(label);
+        Assert.assertEquals("checkbox focused", getLogRow(0));
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/checkbox/CheckboxFocusClickTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/checkbox/CheckboxFocusClickTest.java
@@ -32,6 +32,6 @@ public class CheckboxFocusClickTest extends MultiBrowserTest {
         WebElement label = checkbox.findElement(By.xpath("label"));
 
         clickElement(label);
-        Assert.assertEquals("checkbox focused", getLogRow(0));
+        Assert.assertEquals("1. checkbox focused", getLogRow(0));
     }
 }


### PR DESCRIPTION
* Fixed #3944
* Tested this fix on a local machine against a Firefox and Firefox Dev Edition, both works now ( The FocusListener get's called even when the User clicks the Label or Input to change the Value from true to false or vice versa)
 * I didn't want to remove the whole if-block to reduce the chance that this could break something in IE (Don't have one to test it.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9271)
<!-- Reviewable:end -->
