### PR TITLE
Fix treegrid space selection

### DIFF
--- a/client/src/main/java/com/vaadin/client/WidgetUtil.java
+++ b/client/src/main/java/com/vaadin/client/WidgetUtil.java
@@ -828,6 +828,49 @@ public class WidgetUtil {
     }-*/;
 
     /**
+     * Helper method to find first instance of any Widget found by traversing
+     * DOM upwards from given element.
+     * <p>
+     * <strong>Note:</strong> If {@code element} is inside some widget {@code W}
+     * , <em>and</em> {@code W} in turn is wrapped in a {@link Composite}
+     * {@code C}, this method will not find {@code W} but returns {@code C}.
+     * This may also be the case with other Composite-like classes that hijack
+     * the event handling of their child widget(s).
+     *
+     * @param element
+     *            the element where to start seeking of Widget
+     * @since 8.1
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T findWidget(Element element) {
+        return findWidget(element, null);
+    }
+
+    /**
+     * Helper method to find first instance of given Widget type found by
+     * traversing DOM upwards from given element.
+     * <p>
+     * <strong>Note:</strong> If {@code element} is inside some widget {@code W}
+     * , <em>and</em> {@code W} in turn is wrapped in a {@link Composite}
+     * {@code C}, this method will not find {@code W}. It returns either
+     * {@code C} or null, depending on whether the class parameter matches. This
+     * may also be the case with other Composite-like classes that hijack the
+     * event handling of their child widget(s).
+     * <p>
+     * Only accepts the exact class {@code class1} if not null.
+     *
+     * @param element
+     *            the element where to start seeking of Widget
+     * @param class1
+     *            the Widget type to seek for, null for any
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T findWidget(Element element,
+            Class<? extends Widget> class1) {
+        return findWidget(element, class1, true);
+    }
+
+    /**
      * Helper method to find first instance of given Widget type found by
      * traversing DOM upwards from given element.
      * <p>
@@ -842,10 +885,14 @@ public class WidgetUtil {
      *            the element where to start seeking of Widget
      * @param class1
      *            the Widget type to seek for
+     * @param exactMatch
+     *            true to only accept class1, false to also accept its
+     *            superclasses
+     * @since 8.1
      */
     @SuppressWarnings("unchecked")
     public static <T> T findWidget(Element element,
-            Class<? extends Widget> class1) {
+            Class<? extends Widget> class1, boolean exactMatch) {
         if (element != null) {
             /* First seek for the first EventListener (~Widget) from dom */
             EventListener eventListener = null;
@@ -861,9 +908,19 @@ public class WidgetUtil {
                  * hierarchy
                  */
                 Widget w = (Widget) eventListener;
+                if (class1 == null && w != null) {
+                    return (T) w;
+                }
                 while (w != null) {
-                    if (class1 == null || w.getClass() == class1) {
-                        return (T) w;
+                    Class<?> widgetClass = w.getClass();
+                    while (widgetClass != null) {
+                        if (widgetClass == class1) {
+                            return (T) w;
+                        }
+                        // terminate after first check if looking for exact
+                        // match
+                        widgetClass = exactMatch ? null
+                                : widgetClass.getSuperclass();
                     }
                     w = w.getParent();
                 }
@@ -1086,7 +1143,7 @@ public class WidgetUtil {
          * Fixes infocusable form fields in Safari of iOS 5.x and some Android
          * browsers.
          */
-        Widget targetWidget = findWidget(target, null);
+        Widget targetWidget = findWidget(target);
         if (targetWidget instanceof com.google.gwt.user.client.ui.Focusable) {
             final com.google.gwt.user.client.ui.Focusable toBeFocusedWidget = (com.google.gwt.user.client.ui.Focusable) targetWidget;
             toBeFocusedWidget.setFocus(true);

--- a/client/src/main/java/com/vaadin/client/componentlocator/LegacyLocatorStrategy.java
+++ b/client/src/main/java/com/vaadin/client/componentlocator/LegacyLocatorStrategy.java
@@ -213,7 +213,7 @@ public class LegacyLocatorStrategy implements LocatorStrategy {
         // widget to which the path is relative. Otherwise, the current
         // implementation simply interprets the path as if baseElement was
         // null.
-        Widget baseWidget = WidgetUtil.findWidget(baseElement, null);
+        Widget baseWidget = WidgetUtil.findWidget(baseElement);
 
         Widget w = getWidgetFromPath(widgetPath, baseWidget);
         if (w == null || !WidgetUtil.isAttachedAndDisplayed(w)) {
@@ -337,8 +337,8 @@ public class LegacyLocatorStrategy implements LocatorStrategy {
                 String childIndexString = part.substring("domChild[".length(),
                         part.length() - 1);
 
-                if (WidgetUtil.findWidget(baseElement,
-                        null) instanceof VAbstractOrderedLayout) {
+                if (WidgetUtil.findWidget(
+                        baseElement) instanceof VAbstractOrderedLayout) {
                     if (element.hasChildNodes()) {
                         Element e = element.getFirstChildElement().cast();
                         String cn = e.getClassName();

--- a/client/src/main/java/com/vaadin/client/renderers/ClickableRenderer.java
+++ b/client/src/main/java/com/vaadin/client/renderers/ClickableRenderer.java
@@ -171,16 +171,15 @@ public abstract class ClickableRenderer<T, W extends Widget>
          * <strong>Note:</strong> This method may not work reliably if the grid
          * in question is wrapped in a {@link Composite} <em>unless</em> the
          * element is inside another widget that is a child of the wrapped grid;
-         * please refer to the note in
-         * {@link WidgetUtil#findWidget(Element, Class) Util.findWidget} for
-         * details.
+         * please refer to the note in {@link WidgetUtil#findWidget(Element)
+         * Util.findWidget} for details.
          *
          * @param e
          *            the element whose parent grid to find
          * @return the parent grid or null if none found.
          */
         private static Grid<?> findClosestParentGrid(Element e) {
-            Widget w = WidgetUtil.findWidget(e, null);
+            Widget w = WidgetUtil.findWidget(e);
 
             while (w != null && !(w instanceof Grid)) {
                 w = w.getParent();

--- a/client/src/main/java/com/vaadin/client/renderers/HierarchyRenderer.java
+++ b/client/src/main/java/com/vaadin/client/renderers/HierarchyRenderer.java
@@ -119,7 +119,8 @@ public class HierarchyRenderer extends ClickableRenderer<Object, Widget> {
             leaf = isLeaf(rowDescription);
             if (!leaf) {
                 collapsed = isCollapsed(rowDescription);
-                collapseAllowed = TreeGridConnector.isCollapseAllowed(rowDescription);
+                collapseAllowed = TreeGridConnector
+                        .isCollapseAllowed(rowDescription);
             }
         }
 
@@ -198,14 +199,14 @@ public class HierarchyRenderer extends ClickableRenderer<Object, Widget> {
      * @return Wrapped renderer.
      */
     public Renderer getInnerRenderer() {
-        return this.innerRenderer;
+        return innerRenderer;
     }
 
     /**
      * Decides whether the element was rendered by {@link HierarchyRenderer}
      */
     public static boolean isElementInHierarchyWidget(Element element) {
-        Widget w = WidgetUtil.findWidget(element, null);
+        Widget w = WidgetUtil.findWidget(element);
 
         while (w != null) {
             if (w instanceof HierarchyItem) {

--- a/client/src/main/java/com/vaadin/client/ui/VWindow.java
+++ b/client/src/main/java/com/vaadin/client/ui/VWindow.java
@@ -1314,7 +1314,7 @@ public class VWindow extends VOverlay implements ShortcutActionHandlerOwner,
             if (!DOM.isOrHasChild(getTopmostWindow().getElement(), target)) {
                 // not within the modal window, but let's see if it's in the
                 // debug window
-                Widget w = WidgetUtil.findWidget(target, null);
+                Widget w = WidgetUtil.findWidget(target);
                 while (w != null) {
                     if (w instanceof VDebugWindow) {
                         return true; // allow debug-window clicks

--- a/client/src/main/java/com/vaadin/client/ui/dd/VDragAndDropManager.java
+++ b/client/src/main/java/com/vaadin/client/ui/dd/VDragAndDropManager.java
@@ -56,7 +56,7 @@ import com.vaadin.shared.ui.dd.DragEventType;
  * {@link #get()} to get instance.
  *
  * TODO cancel drag and drop if more than one touches !?
- * 
+ *
  * @author Vaadin Ltd
  * @deprecated Replaced in 8.1 with {@link DropTargetExtensionConnector} and
  *             {@link DragSourceExtensionConnector}
@@ -419,7 +419,7 @@ public class VDragAndDropManager {
      */
     protected VDropHandler findDragTarget(Element element) {
         try {
-            Widget w = WidgetUtil.findWidget(element, null);
+            Widget w = WidgetUtil.findWidget(element);
             if (w == null) {
                 return null;
             }

--- a/client/src/main/java/com/vaadin/client/widget/treegrid/events/TreeGridClickEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/treegrid/events/TreeGridClickEvent.java
@@ -52,7 +52,7 @@ public class TreeGridClickEvent extends GridClickEvent {
         if (!Element.is(target)) {
             return null;
         }
-        return WidgetUtil.findWidget(Element.as(target), TreeGrid.class);
+        return WidgetUtil.findWidget(Element.as(target), TreeGrid.class, false);
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -702,13 +702,13 @@ public class Escalator extends Widget
         /*-{
             var vScroll = esc.@com.vaadin.client.widgets.Escalator::verticalScrollbar;
             var vScrollElem = vScroll.@com.vaadin.client.widget.escalator.ScrollbarBundle::getElement()();
-
+        
             var hScroll = esc.@com.vaadin.client.widgets.Escalator::horizontalScrollbar;
             var hScrollElem = hScroll.@com.vaadin.client.widget.escalator.ScrollbarBundle::getElement()();
-
+        
             return $entry(function(e) {
                 var target = e.target;
-
+        
                 // in case the scroll event was native (i.e. scrollbars were dragged, or
                 // the scrollTop/Left was manually modified), the bundles have old cache
                 // values. We need to make sure that the caches are kept up to date.
@@ -729,29 +729,29 @@ public class Escalator extends Widget
             return $entry(function(e) {
                 var deltaX = e.deltaX ? e.deltaX : -0.5*e.wheelDeltaX;
                 var deltaY = e.deltaY ? e.deltaY : -0.5*e.wheelDeltaY;
-
+        
                 // Delta mode 0 is in pixels; we don't need to do anything...
-
+        
                 // A delta mode of 1 means we're scrolling by lines instead of pixels
                 // We need to scale the number of lines by the default line height
                 if(e.deltaMode === 1) {
                     var brc = esc.@com.vaadin.client.widgets.Escalator::body;
                     deltaY *= brc.@com.vaadin.client.widgets.Escalator.AbstractRowContainer::getDefaultRowHeight()();
                 }
-
+        
                 // Other delta modes aren't supported
                 if((e.deltaMode !== undefined) && (e.deltaMode >= 2 || e.deltaMode < 0)) {
                     var msg = "Unsupported wheel delta mode \"" + e.deltaMode + "\"";
-
+        
                     // Print warning message
                     esc.@com.vaadin.client.widgets.Escalator::logWarning(*)(msg);
                 }
-
+        
                 // IE8 has only delta y
                 if (isNaN(deltaY)) {
                     deltaY = -0.5*e.wheelDelta;
                 }
-
+        
                 @com.vaadin.client.widgets.Escalator.JsniUtil::moveScrollFromEvent(*)(esc, deltaX, deltaY, e);
             });
         }-*/;
@@ -4012,7 +4012,7 @@ public class Escalator extends Widget
         @Override
         public void setNewEscalatorRowCallback(
                 Consumer<List<TableRowElement>> callback) {
-            this.newEscalatorRowCallback = callback;
+            newEscalatorRowCallback = callback;
         }
     }
 
@@ -6415,7 +6415,7 @@ public class Escalator extends Widget
             @SuppressWarnings("deprecation")
             com.google.gwt.user.client.Element castElement = (com.google.gwt.user.client.Element) possibleWidgetNode
                     .cast();
-            Widget w = WidgetUtil.findWidget(castElement, null);
+            Widget w = WidgetUtil.findWidget(castElement);
 
             // Ensure findWidget did not traverse past the cell element in the
             // DOM hierarchy

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -2318,7 +2318,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             if (!Element.is(target)) {
                 return null;
             }
-            return WidgetUtil.findWidget(Element.as(target), Grid.class);
+            return WidgetUtil.findWidget(Element.as(target), Grid.class, false);
         }
 
         /**
@@ -2385,7 +2385,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             if (!Element.is(target)) {
                 return null;
             }
-            return WidgetUtil.findWidget(Element.as(target), Grid.class);
+            return WidgetUtil.findWidget(Element.as(target), Grid.class, false);
         }
 
         /**
@@ -5623,7 +5623,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 if (renderer instanceof WidgetRenderer) {
                     try {
                         Widget w = WidgetUtil.findWidget(
-                                cell.getElement().getFirstChildElement(), null);
+                                cell.getElement().getFirstChildElement());
                         if (w != null) {
 
                             // Logical detach
@@ -7459,7 +7459,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     }
 
     private boolean isElementInChildWidget(Element e) {
-        Widget w = WidgetUtil.findWidget(e, null);
+        Widget w = WidgetUtil.findWidget(e);
 
         if (w == this) {
             return false;

--- a/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridBasicFeaturesTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridBasicFeaturesTest.java
@@ -193,6 +193,51 @@ public class TreeGridBasicFeaturesTest extends MultiBrowserTest {
     }
 
     @Test
+    public void keyboard_selection() {
+        grid.getRow(0).getCell(0).click();
+
+        // Should expand "0 | 0" without moving focus
+        new Actions(getDriver()).sendKeys(Keys.RIGHT).perform();
+        assertEquals(6, grid.getRowCount());
+        assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "1 | 2" });
+
+        // Should navigate 2 times down to "1 | 1"
+        new Actions(getDriver()).sendKeys(Keys.DOWN, Keys.DOWN).perform();
+        assertEquals(6, grid.getRowCount());
+        assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "1 | 2" });
+        assertFalse(
+                grid.getRow(0).hasClassName("v-treegrid-rowmode-row-focused"));
+        assertFalse(
+                grid.getRow(1).hasClassName("v-treegrid-rowmode-row-focused"));
+        assertTrue(
+                grid.getRow(2).hasClassName("v-treegrid-rowmode-row-focused"));
+
+        // Should select "1 | 1" without moving focus
+        new Actions(getDriver()).sendKeys(Keys.SPACE).perform();
+        assertTrue(grid.getRow(2).hasClassName("v-treegrid-row-selected"));
+
+        // Should move focus but not selection
+        new Actions(getDriver()).sendKeys(Keys.UP).perform();
+        assertTrue(
+                grid.getRow(1).hasClassName("v-treegrid-rowmode-row-focused"));
+        assertFalse(
+                grid.getRow(2).hasClassName("v-treegrid-rowmode-row-focused"));
+        assertFalse(grid.getRow(1).hasClassName("v-treegrid-row-selected"));
+        assertTrue(grid.getRow(2).hasClassName("v-treegrid-row-selected"));
+
+        // Should select "1 | 0" without moving focus
+        new Actions(getDriver()).sendKeys(Keys.SPACE).perform();
+        assertTrue(
+                grid.getRow(1).hasClassName("v-treegrid-rowmode-row-focused"));
+        assertFalse(
+                grid.getRow(2).hasClassName("v-treegrid-rowmode-row-focused"));
+        assertTrue(grid.getRow(1).hasClassName("v-treegrid-row-selected"));
+        assertFalse(grid.getRow(2).hasClassName("v-treegrid-row-selected"));
+
+        assertNoErrorNotifications();
+    }
+
+    @Test
     public void changing_hierarchy_column() {
         assertTrue(grid.getRow(0).getCell(0)
                 .isElementPresent(By.className("v-treegrid-expander")));


### PR DESCRIPTION
Refactors WidgetUtil.findWidget() to multiple variants, uses simpler variants and fixes
special event handler support for subclasses of Grid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9283)
<!-- Reviewable:end -->
