### PR TITLE
Rename OSGi classes for Java naming conventions

### DIFF
--- a/client-compiled/src/main/java/com/vaadin/osgi/widgetset/DefaultWidgetsetContribution.java
+++ b/client-compiled/src/main/java/com/vaadin/osgi/widgetset/DefaultWidgetsetContribution.java
@@ -21,7 +21,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.http.HttpService;
 
-import com.vaadin.osgi.resources.OSGiVaadinResources;
+import com.vaadin.osgi.resources.OsgiVaadinResources;
 import com.vaadin.osgi.resources.VaadinResourceService;
 
 @Component(immediate = true)
@@ -32,7 +32,7 @@ public class DefaultWidgetsetContribution {
 
     @Activate
     void startup(ComponentContext context) throws Exception {
-        VaadinResourceService service = OSGiVaadinResources.getService();
+        VaadinResourceService service = OsgiVaadinResources.getService();
         service.publishWidgetset(WIDGETSET_NAME, httpService);
     }
 

--- a/compatibility-client-compiled/src/main/java/com/vaadin/osgi/compatibility/widgetset/CompatibilityWidgetsetContribution.java
+++ b/compatibility-client-compiled/src/main/java/com/vaadin/osgi/compatibility/widgetset/CompatibilityWidgetsetContribution.java
@@ -21,7 +21,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.http.HttpService;
 
-import com.vaadin.osgi.resources.OSGiVaadinResources;
+import com.vaadin.osgi.resources.OsgiVaadinResources;
 import com.vaadin.osgi.resources.VaadinResourceService;
 
 @Component(immediate = true)
@@ -32,7 +32,7 @@ public class CompatibilityWidgetsetContribution {
 
     @Activate
     void startup(ComponentContext context) throws Exception {
-        VaadinResourceService service = OSGiVaadinResources.getService();
+        VaadinResourceService service = OsgiVaadinResources.getService();
         service.publishWidgetset(WIDGETSET_NAME, httpService);
     }
 

--- a/compatibility-themes/src/main/java/com/vaadin/osgi/compatibility/themes/LegacyThemeContributions.java
+++ b/compatibility-themes/src/main/java/com/vaadin/osgi/compatibility/themes/LegacyThemeContributions.java
@@ -20,7 +20,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.http.HttpService;
 
-import com.vaadin.osgi.resources.OSGiVaadinResources;
+import com.vaadin.osgi.resources.OsgiVaadinResources;
 import com.vaadin.osgi.resources.VaadinResourceService;
 
 @Component(immediate = true)
@@ -32,7 +32,7 @@ public class LegacyThemeContributions {
 
     @Activate
     void startup() throws Exception {
-        VaadinResourceService service = OSGiVaadinResources.getService();
+        VaadinResourceService service = OsgiVaadinResources.getService();
         for (String themeName : LEGACY_THEMES) {
             service.publishTheme(themeName, httpService);
         }

--- a/documentation/advanced/advanced-osgi.asciidoc
+++ b/documentation/advanced/advanced-osgi.asciidoc
@@ -41,12 +41,12 @@ public static class MyUIServlet extends VaadinServlet {
 
 Vaadin Framework 8.1 and later versions provide two supported ways of publishing static resources for OSGi: by making OSGi services implementing an interface or by explicit calls to a service.
 
-The easiest way to publish a theme or a widgetset is to create a class implementing the interface [interfacename]#OSGiVaadinTheme# or [interfacename]#OSGiVaadinWidgetset# and annotating it with [interfacename]#@Component# to make it an OSGi service. This automatically publishes the theme or the widget set from the bundle at a path that contains the Vaadin Framework version used by the application.
+The easiest way to publish a theme or a widgetset is to create a class implementing the interface [interfacename]#OsgiVaadinTheme# or [interfacename]#OsgiVaadinWidgetset# and annotating it with [interfacename]#@Component# to make it an OSGi service. This automatically publishes the theme or the widget set from the bundle at a path that contains the Vaadin Framework version used by the application.
 
 [source, java]
 ----
 @Component
-public class MyTheme extends ValoTheme implements OSGiVaadinTheme {
+public class MyTheme extends ValoTheme implements OsgiVaadinTheme {
     public static final String THEME_NAME = "mytheme";
 
     @Override
@@ -57,11 +57,11 @@ public class MyTheme extends ValoTheme implements OSGiVaadinTheme {
 }
 ----
 
-Alternatively, an OSGi bundle activator or an SCR Component [interfacename]#@Activate# method can obtain an instance of [classname]#VaadinResourceService# from [classname]#OSGiVaadinResources# and explicitly call its methods to publish a theme, a widget set or an individual file in the bundle as a static resource at the correct path.
+Alternatively, an OSGi bundle activator or an SCR Component [interfacename]#@Activate# method can obtain an instance of [classname]#VaadinResourceService# from [classname]#OsgiVaadinResources# and explicitly call its methods to publish a theme, a widget set or an individual file in the bundle as a static resource at the correct path.
 
 [source, java]
 ----
-  VaadinResourceService service = OSGiVaadinResources.getService();
+  VaadinResourceService service = OsgiVaadinResources.getService();
   service.publishTheme("mytheme", httpService);
 ----
 

--- a/liferay-integration/src/main/java/com/vaadin/osgi/liferay/OsgiUIProvider.java
+++ b/liferay-integration/src/main/java/com/vaadin/osgi/liferay/OsgiUIProvider.java
@@ -32,11 +32,11 @@ import com.vaadin.ui.UI;
  * @since 8.1
  */
 @SuppressWarnings("serial")
-public class OSGiUIProvider extends UIProvider {
+public class OsgiUIProvider extends UIProvider {
     private Class<UI> uiClass;
 
     @SuppressWarnings("unchecked")
-    public OSGiUIProvider(ServiceObjects<UI> serviceObjects) {
+    public OsgiUIProvider(ServiceObjects<UI> serviceObjects) {
         super();
         UI ui = serviceObjects.getService();
         uiClass = (Class<UI>) ui.getClass();

--- a/liferay-integration/src/main/java/com/vaadin/osgi/liferay/OsgiVaadinPortlet.java
+++ b/liferay-integration/src/main/java/com/vaadin/osgi/liferay/OsgiVaadinPortlet.java
@@ -19,14 +19,11 @@ import com.vaadin.server.DeploymentConfiguration;
 import com.vaadin.server.ServiceException;
 import com.vaadin.server.VaadinPortlet;
 import com.vaadin.server.VaadinPortletService;
-import com.vaadin.server.VaadinPortletSession;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinSession;
 import com.vaadin.ui.UI;
 
 /**
- * {@link VaadinPortletService} class that uses the {@link OSGiUIProvider} to
- * configure the {@link UI} class for a {@link VaadinPortlet}.
+ * {@link VaadinPortlet} that uses an {@link OsgiUIProvider} to configure its
+ * {@link UI}.
  * <p>
  * This only applies to Liferay Portal 7+ with OSGi support.
  *
@@ -35,25 +32,19 @@ import com.vaadin.ui.UI;
  * @since 8.1
  */
 @SuppressWarnings("serial")
-public class OSGiVaadinPortletService extends VaadinPortletService {
-    private OSGiUIProvider osgiUIProvider;
+public class OsgiVaadinPortlet extends VaadinPortlet {
+    private OsgiUIProvider uiProvider;
 
-    public OSGiVaadinPortletService(VaadinPortlet portlet,
-            DeploymentConfiguration deploymentConfiguration,
-            OSGiUIProvider osgiUIProvider) throws ServiceException {
-
-        super(portlet, deploymentConfiguration);
-        this.osgiUIProvider = osgiUIProvider;
+    public OsgiVaadinPortlet(OsgiUIProvider uiProvider) {
+        this.uiProvider = uiProvider;
     }
 
     @Override
-    protected VaadinSession createVaadinSession(VaadinRequest request)
-            throws ServiceException {
-
-        VaadinSession vaadinSession = new VaadinPortletSession(this);
-        vaadinSession.addUIProvider(osgiUIProvider);
-
-        return vaadinSession;
+    protected VaadinPortletService createPortletService(
+            DeploymentConfiguration configuration) throws ServiceException {
+        OsgiVaadinPortletService osgiVaadinPortletService = new OsgiVaadinPortletService(
+                this, configuration, uiProvider);
+        osgiVaadinPortletService.init();
+        return osgiVaadinPortletService;
     }
-
 }

--- a/liferay-integration/src/main/java/com/vaadin/osgi/liferay/OsgiVaadinPortletService.java
+++ b/liferay-integration/src/main/java/com/vaadin/osgi/liferay/OsgiVaadinPortletService.java
@@ -19,11 +19,14 @@ import com.vaadin.server.DeploymentConfiguration;
 import com.vaadin.server.ServiceException;
 import com.vaadin.server.VaadinPortlet;
 import com.vaadin.server.VaadinPortletService;
+import com.vaadin.server.VaadinPortletSession;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.server.VaadinSession;
 import com.vaadin.ui.UI;
 
 /**
- * {@link VaadinPortlet} that uses an {@link OSGiUIProvider} to configure its
- * {@link UI}.
+ * {@link VaadinPortletService} class that uses the {@link OsgiUIProvider} to
+ * configure the {@link UI} class for a {@link VaadinPortlet}.
  * <p>
  * This only applies to Liferay Portal 7+ with OSGi support.
  *
@@ -32,19 +35,25 @@ import com.vaadin.ui.UI;
  * @since 8.1
  */
 @SuppressWarnings("serial")
-public class VaadinOSGiPortlet extends VaadinPortlet {
-    private OSGiUIProvider uiProvider;
+public class OsgiVaadinPortletService extends VaadinPortletService {
+    private OsgiUIProvider osgiUIProvider;
 
-    public VaadinOSGiPortlet(OSGiUIProvider uiProvider) {
-        this.uiProvider = uiProvider;
+    public OsgiVaadinPortletService(VaadinPortlet portlet,
+            DeploymentConfiguration deploymentConfiguration,
+            OsgiUIProvider osgiUIProvider) throws ServiceException {
+
+        super(portlet, deploymentConfiguration);
+        this.osgiUIProvider = osgiUIProvider;
     }
 
     @Override
-    protected VaadinPortletService createPortletService(
-            DeploymentConfiguration configuration) throws ServiceException {
-        OSGiVaadinPortletService osgiVaadinPortletService = new OSGiVaadinPortletService(
-                this, configuration, uiProvider);
-        osgiVaadinPortletService.init();
-        return osgiVaadinPortletService;
+    protected VaadinSession createVaadinSession(VaadinRequest request)
+            throws ServiceException {
+
+        VaadinSession vaadinSession = new VaadinPortletSession(this);
+        vaadinSession.addUIProvider(osgiUIProvider);
+
+        return vaadinSession;
     }
+
 }

--- a/liferay-integration/src/main/java/com/vaadin/osgi/liferay/PortletUIServiceTrackerCustomizer.java
+++ b/liferay-integration/src/main/java/com/vaadin/osgi/liferay/PortletUIServiceTrackerCustomizer.java
@@ -102,7 +102,7 @@ class PortletUIServiceTrackerCustomizer
         ServiceObjects<UI> serviceObjects = bundleContext
                 .getServiceObjects(reference);
 
-        OSGiUIProvider uiProvider = new OSGiUIProvider(serviceObjects);
+        OsgiUIProvider uiProvider = new OsgiUIProvider(serviceObjects);
 
         Dictionary<String, Object> properties = null;
         if (configuration != null) {
@@ -112,7 +112,7 @@ class PortletUIServiceTrackerCustomizer
             properties = createPortletProperties(reference);
         }
 
-        VaadinOSGiPortlet portlet = new VaadinOSGiPortlet(uiProvider);
+        OsgiVaadinPortlet portlet = new OsgiVaadinPortlet(uiProvider);
 
         ServiceRegistration<Portlet> serviceRegistration = bundleContext
                 .registerService(Portlet.class, portlet, properties);
@@ -123,7 +123,7 @@ class PortletUIServiceTrackerCustomizer
     }
 
     private Dictionary<String, Object> createPortletProperties(
-            OSGiUIProvider uiProvider, ServiceReference<UI> reference,
+            OsgiUIProvider uiProvider, ServiceReference<UI> reference,
             VaadinLiferayPortletConfiguration configuration) {
 
         Hashtable<String, Object> properties = new Hashtable<String, Object>();

--- a/liferay-integration/src/main/java/com/vaadin/osgi/liferay/VaadinPortletProvider.java
+++ b/liferay-integration/src/main/java/com/vaadin/osgi/liferay/VaadinPortletProvider.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.util.tracker.ServiceTracker;
 
-import com.vaadin.osgi.resources.OSGiVaadinResources;
+import com.vaadin.osgi.resources.OsgiVaadinResources;
 import com.vaadin.osgi.resources.VaadinResourceService;
 import com.vaadin.ui.UI;
 
@@ -46,7 +46,7 @@ public class VaadinPortletProvider {
     @Activate
     void activate(ComponentContext componentContext) throws Exception {
         BundleContext bundleContext = componentContext.getBundleContext();
-        VaadinResourceService service = OSGiVaadinResources.getService();
+        VaadinResourceService service = OsgiVaadinResources.getService();
 
         portletUIServiceTrackerCustomizer = new PortletUIServiceTrackerCustomizer(
                 service);

--- a/osgi-integration/src/main/java/com/vaadin/osgi/servlet/VaadinServletRegistration.java
+++ b/osgi-integration/src/main/java/com/vaadin/osgi/servlet/VaadinServletRegistration.java
@@ -33,8 +33,8 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 import org.osgi.service.log.LogService;
 
-import com.vaadin.osgi.resources.OSGiVaadinResources;
-import com.vaadin.osgi.resources.OSGiVaadinResources.ResourceBundleInactiveException;
+import com.vaadin.osgi.resources.OsgiVaadinResources;
+import com.vaadin.osgi.resources.OsgiVaadinResources.ResourceBundleInactiveException;
 import com.vaadin.osgi.resources.VaadinResourceService;
 import com.vaadin.server.Constants;
 import com.vaadin.server.VaadinServlet;
@@ -118,7 +118,7 @@ public class VaadinServletRegistration {
     }
 
     private String getResourcePath() throws ResourceBundleInactiveException {
-        VaadinResourceService service = OSGiVaadinResources.getService();
+        VaadinResourceService service = OsgiVaadinResources.getService();
         return String.format("/%s", service.getResourcePathPrefix());
     }
 

--- a/push/src/main/java/com/vaadin/osgi/push/PushResourcesContribution.java
+++ b/push/src/main/java/com/vaadin/osgi/push/PushResourcesContribution.java
@@ -21,7 +21,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.http.HttpService;
 
-import com.vaadin.osgi.resources.OSGiVaadinResources;
+import com.vaadin.osgi.resources.OsgiVaadinResources;
 import com.vaadin.osgi.resources.VaadinResourceService;
 
 @Component(immediate = true)
@@ -34,7 +34,7 @@ public class PushResourcesContribution {
 
     @Activate
     void startup(ComponentContext context) throws Exception {
-        VaadinResourceService service = OSGiVaadinResources.getService();
+        VaadinResourceService service = OsgiVaadinResources.getService();
         for (String resourceName : RESOURCES) {
             service.publishResource(resourceName, httpService);
         }

--- a/server/src/main/java/com/vaadin/server/osgi/BootstrapContribution.java
+++ b/server/src/main/java/com/vaadin/server/osgi/BootstrapContribution.java
@@ -21,8 +21,8 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 
-import com.vaadin.osgi.resources.OSGiVaadinResources;
-import com.vaadin.osgi.resources.OSGiVaadinResources.ResourceBundleInactiveException;
+import com.vaadin.osgi.resources.OsgiVaadinResources;
+import com.vaadin.osgi.resources.OsgiVaadinResources.ResourceBundleInactiveException;
 import com.vaadin.osgi.resources.VaadinResourceService;
 
 /**
@@ -40,7 +40,7 @@ public class BootstrapContribution {
 
     @Activate
     void startup() throws NamespaceException, ResourceBundleInactiveException {
-        VaadinResourceService service = OSGiVaadinResources.getService();
+        VaadinResourceService service = OsgiVaadinResources.getService();
         for (String resourceName : RESOURCES) {
             service.publishResource(resourceName, httpService);
         }

--- a/shared/bnd.bnd
+++ b/shared/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName: ${project.groupId}.shared
-Bundle-Activator: com.vaadin.osgi.resources.OSGiVaadinResources
+Bundle-Activator: com.vaadin.osgi.resources.OsgiVaadinResources
 Bundle-Name: Vaadin Shared
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-License: http://www.apache.org/licenses/LICENSE-2.0

--- a/shared/src/main/java/com/vaadin/osgi/resources/OsgiVaadinResources.java
+++ b/shared/src/main/java/com/vaadin/osgi/resources/OsgiVaadinResources.java
@@ -30,7 +30,7 @@ import com.vaadin.osgi.resources.impl.VaadinResourceServiceImpl;
  * 
  * @since 8.1
  */
-public class OSGiVaadinResources implements BundleActivator {
+public class OsgiVaadinResources implements BundleActivator {
 
     /**
      * Thrown if a method is called when the Resource bundle is not active.
@@ -46,7 +46,7 @@ public class OSGiVaadinResources implements BundleActivator {
         }
     }
 
-    private static OSGiVaadinResources instance;
+    private static OsgiVaadinResources instance;
 
     private VaadinResourceServiceImpl service;
     private Version version;

--- a/shared/src/main/java/com/vaadin/osgi/resources/OsgiVaadinTheme.java
+++ b/shared/src/main/java/com/vaadin/osgi/resources/OsgiVaadinTheme.java
@@ -19,7 +19,7 @@ package com.vaadin.osgi.resources;
  * Used to declare a Vaadin Theme for use in OSGi. The theme is expected to be
  * in the same OSGi bundle as the class implementing this interface, under the
  * path "/VAADIN/themes/{themeName}" where {themeName} is what is returned by
- * {@link OSGiVaadinTheme#getName()}.
+ * {@link OsgiVaadinTheme#getName()}.
  * <p>
  * To publish a theme, an implementation of this interface needs to be
  * registered as an OSGi service, which makes
@@ -30,6 +30,11 @@ package com.vaadin.osgi.resources;
  *
  * @since 8.1
  */
-public interface OSGiVaadinTheme {
+public interface OsgiVaadinTheme {
+    /**
+     * Return the theme name to publish for OSGi.
+     *
+     * @return theme name, not null
+     */
     public String getName();
 }

--- a/shared/src/main/java/com/vaadin/osgi/resources/OsgiVaadinWidgetset.java
+++ b/shared/src/main/java/com/vaadin/osgi/resources/OsgiVaadinWidgetset.java
@@ -19,7 +19,7 @@ package com.vaadin.osgi.resources;
  * Used to declare a Vaadin Widgetset for use in OSGi. The widgetset is expected
  * to be in the same OSGi bundle as the class implementing this interface, under
  * the path "/VAADIN/widgetsets/{widgetsetName}" where {widgetsetName} is what
- * is returned by {@link OSGiVaadinWidgetset#getName()}.
+ * is returned by {@link OsgiVaadinWidgetset#getName()}.
  * <p>
  * To publish a widgetset, an implementation of this interface needs to be
  * registered as an OSGi service, which makes
@@ -30,6 +30,11 @@ package com.vaadin.osgi.resources;
  *
  * @since 8.1
  */
-public interface OSGiVaadinWidgetset {
+public interface OsgiVaadinWidgetset {
+    /**
+     * Return the widgetset name to publish for OSGi.
+     *
+     * @return widgetset name, not null
+     */
     public String getName();
 }

--- a/shared/src/main/java/com/vaadin/osgi/resources/impl/VaadinResourceTrackerComponent.java
+++ b/shared/src/main/java/com/vaadin/osgi/resources/impl/VaadinResourceTrackerComponent.java
@@ -36,14 +36,14 @@ import org.osgi.service.http.HttpContext;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 
-import com.vaadin.osgi.resources.OSGiVaadinResources;
-import com.vaadin.osgi.resources.OSGiVaadinResources.ResourceBundleInactiveException;
-import com.vaadin.osgi.resources.OSGiVaadinTheme;
-import com.vaadin.osgi.resources.OSGiVaadinWidgetset;
+import com.vaadin.osgi.resources.OsgiVaadinResources;
+import com.vaadin.osgi.resources.OsgiVaadinResources.ResourceBundleInactiveException;
+import com.vaadin.osgi.resources.OsgiVaadinTheme;
+import com.vaadin.osgi.resources.OsgiVaadinWidgetset;
 import com.vaadin.osgi.resources.VaadinResourceService;
 
 /**
- * Tracks {@link OSGiVaadinWidgetset} and {@link OSGiVaadinTheme} registration
+ * Tracks {@link OsgiVaadinWidgetset} and {@link OsgiVaadinTheme} registration
  * and uses {@link HttpService} to register them.
  * 
  * @author Vaadin Ltd.
@@ -59,18 +59,18 @@ public class VaadinResourceTrackerComponent {
     private Map<Long, String> widgetsetToAlias = Collections
             .synchronizedMap(new LinkedHashMap<>());
 
-    @Reference(cardinality = ReferenceCardinality.MULTIPLE, service = OSGiVaadinTheme.class, policy = ReferencePolicy.DYNAMIC)
-    void bindTheme(ServiceReference<OSGiVaadinTheme> themeRef)
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, service = OsgiVaadinTheme.class, policy = ReferencePolicy.DYNAMIC)
+    void bindTheme(ServiceReference<OsgiVaadinTheme> themeRef)
             throws ResourceBundleInactiveException, NamespaceException {
 
         Bundle bundle = themeRef.getBundle();
         BundleContext context = bundle.getBundleContext();
 
-        OSGiVaadinTheme theme = context.getService(themeRef);
+        OsgiVaadinTheme theme = context.getService(themeRef);
         if (theme == null)
             return;
 
-        VaadinResourceService resourceService = OSGiVaadinResources
+        VaadinResourceService resourceService = OsgiVaadinResources
                 .getService();
 
         try {
@@ -90,7 +90,7 @@ public class VaadinResourceTrackerComponent {
         }
     }
 
-    void unbindTheme(ServiceReference<OSGiVaadinTheme> themeRef) {
+    void unbindTheme(ServiceReference<OsgiVaadinTheme> themeRef) {
         Long serviceId = (Long) themeRef.getProperty(Constants.SERVICE_ID);
         String themeAlias = themeToAlias.remove(serviceId);
         if (themeAlias != null && httpService != null) {
@@ -98,17 +98,17 @@ public class VaadinResourceTrackerComponent {
         }
     }
 
-    @Reference(cardinality = ReferenceCardinality.MULTIPLE, service = OSGiVaadinWidgetset.class, policy = ReferencePolicy.DYNAMIC)
-    void bindWidgetset(ServiceReference<OSGiVaadinWidgetset> widgetsetRef)
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, service = OsgiVaadinWidgetset.class, policy = ReferencePolicy.DYNAMIC)
+    void bindWidgetset(ServiceReference<OsgiVaadinWidgetset> widgetsetRef)
             throws ResourceBundleInactiveException, NamespaceException {
         Bundle bundle = widgetsetRef.getBundle();
         BundleContext context = bundle.getBundleContext();
 
-        OSGiVaadinWidgetset widgetset = context.getService(widgetsetRef);
+        OsgiVaadinWidgetset widgetset = context.getService(widgetsetRef);
         if (widgetset == null)
             return;
 
-        VaadinResourceService service = OSGiVaadinResources.getService();
+        VaadinResourceService service = OsgiVaadinResources.getService();
         try {
             String pathPrefix = service.getResourcePathPrefix();
 
@@ -129,7 +129,7 @@ public class VaadinResourceTrackerComponent {
 
     }
 
-    void unbindWidgetset(ServiceReference<OSGiVaadinWidgetset> widgetsetRef) {
+    void unbindWidgetset(ServiceReference<OsgiVaadinWidgetset> widgetsetRef) {
         Long serviceId = (Long) widgetsetRef.getProperty(Constants.SERVICE_ID);
         String widgetsetAlias = widgetsetToAlias.remove(serviceId);
         if (widgetsetAlias != null && httpService != null) {

--- a/themes/src/main/java/com/vaadin/osgi/themes/ValoThemeContribution.java
+++ b/themes/src/main/java/com/vaadin/osgi/themes/ValoThemeContribution.java
@@ -20,7 +20,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.http.HttpService;
 
-import com.vaadin.osgi.resources.OSGiVaadinResources;
+import com.vaadin.osgi.resources.OsgiVaadinResources;
 import com.vaadin.osgi.resources.VaadinResourceService;
 
 @Component(immediate = true)
@@ -30,7 +30,7 @@ public class ValoThemeContribution {
 
     @Activate
     void startup() throws Exception {
-        VaadinResourceService service = OSGiVaadinResources.getService();
+        VaadinResourceService service = OsgiVaadinResources.getService();
         service.publishTheme("valo", httpService);
     }
 


### PR DESCRIPTION
- Rename OSGi to Osgi in class names.
- Rename VaadinOSGiPortlet to OSGiVaadinPortlet for consistency with
Spring, CDI etc. add-ons
- Add missing javadoc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9320)
<!-- Reviewable:end -->
