### PR TITLE
Remove unnecessary rowmode prefix from TreeGrid focus styles

### DIFF
--- a/client/src/main/java/com/vaadin/client/widget/treegrid/TreeGrid.java
+++ b/client/src/main/java/com/vaadin/client/widget/treegrid/TreeGrid.java
@@ -50,9 +50,4 @@ public class TreeGrid extends Grid<JsonObject> {
     public HandlerRegistration addBodyClickHandler(BodyClickHandler handler) {
         return addHandler(handler, TreeGridClickEvent.TYPE);
     }
-
-    @Override
-    protected String getFocusPrimaryStyleName() {
-        return getStylePrimaryName() + "-rowmode";
-    }
 }

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -6217,18 +6217,14 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         rowSelectedStyleName = rowStyle + "-selected";
         rowStripeStyleName = rowStyle + "-stripe";
 
-        cellFocusStyleName = getFocusPrimaryStyleName() + "-cell-focused";
-        rowFocusStyleName = getFocusPrimaryStyleName() + "-row-focused";
+        cellFocusStyleName = getStylePrimaryName() + "-cell-focused";
+        rowFocusStyleName = getStylePrimaryName() + "-row-focused";
 
         if (isAttached()) {
             refreshHeader();
             requestRefreshBody();
             refreshFooter();
         }
-    }
-
-    protected String getFocusPrimaryStyleName() {
-        return getStylePrimaryName();
     }
 
     /**

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_tree8.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_tree8.scss
@@ -28,10 +28,6 @@ $v-tree8-border-radius: 3px;
     border: none;
   }
 
-  .#{$primary-stylename}:focus .#{$primary-stylename}-rowmode-row-focused:before {
-    display: none;
-  }
-
   .#{$primary-stylename}-cell-content {
     border: $v-grid-cell-focused-border;
     border-color: transparent;
@@ -39,7 +35,11 @@ $v-tree8-border-radius: 3px;
     padding: $v-grid-cell-padding;
   }
 
-  .#{$primary-stylename}:focus .#{$primary-stylename}-rowmode-cell-focused
+  .#{$primary-stylename}:focus .#{$primary-stylename}-row-focused:before {
+    display: none;
+  }
+
+  .#{$primary-stylename}:focus .#{$primary-stylename}-cell-focused
     > .#{$primary-stylename}-node > .#{$primary-stylename}-cell-content {
     border: $v-grid-cell-focused-border;
   }

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_treegrid.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_treegrid.scss
@@ -67,7 +67,7 @@ $tg-expander-padding: 10px !default;
     display: inline-block;
   }
 
-  .#{$primary-stylename}-rowmode-row-focused {
+  .#{$primary-stylename}-row-focused {
 
     &:before {
       content: "";
@@ -82,14 +82,25 @@ $tg-expander-padding: 10px !default;
     }
   }
 
-  .#{$primary-stylename}:focus .#{$primary-stylename}-rowmode-row-focused:before {
+  .#{$primary-stylename}-cell-focused {
+    position: static;
+
+    &:before {
+      display: none;
+    }
+  }
+
+  .#{$primary-stylename}:focus .#{$primary-stylename}-row-focused:before {
     display: block;
   }
 
-  .#{$primary-stylename}.v-disabled:focus .#{$primary-stylename}-rowmode-row-focused:before {
-    // Disabled Grid should not show cell focus outline
+  .#{$primary-stylename}.v-disabled:focus .#{$primary-stylename}-row-focused:before {
+    // Disabled TreeGrid should not show row focus outline
     display: none;
   }
 
+  .#{$primary-stylename}:focus .#{$primary-stylename}-cell-focused:before {
+    display: none;
+  }
 }
 

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_treegrid.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_treegrid.scss
@@ -82,6 +82,7 @@ $tg-expander-padding: 10px !default;
     }
   }
 
+  // Needed for hiding the included style
   .#{$primary-stylename}-cell-focused {
     position: static;
 

--- a/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridBasicFeaturesTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridBasicFeaturesTest.java
@@ -137,20 +137,20 @@ public class TreeGridBasicFeaturesTest extends MultiBrowserTest {
         assertEquals(6, grid.getRowCount());
         assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "1 | 2" });
         assertTrue(
-                grid.getRow(0).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(0).hasClassName("v-treegrid-row-focused"));
         assertFalse(
-                grid.getRow(1).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(1).hasClassName("v-treegrid-row-focused"));
 
         // Should navigate 2 times down to "1 | 1"
         new Actions(getDriver()).sendKeys(Keys.DOWN, Keys.DOWN).perform();
         assertEquals(6, grid.getRowCount());
         assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "1 | 2" });
         assertFalse(
-                grid.getRow(0).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(0).hasClassName("v-treegrid-row-focused"));
         assertFalse(
-                grid.getRow(1).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(1).hasClassName("v-treegrid-row-focused"));
         assertTrue(
-                grid.getRow(2).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(2).hasClassName("v-treegrid-row-focused"));
 
         // Should expand "1 | 1" without moving focus
         new Actions(getDriver()).sendKeys(Keys.RIGHT).perform();
@@ -158,14 +158,14 @@ public class TreeGridBasicFeaturesTest extends MultiBrowserTest {
         assertCellTexts(2, 0,
                 new String[] { "1 | 1", "2 | 0", "2 | 1", "2 | 2", "1 | 2" });
         assertTrue(
-                grid.getRow(2).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(2).hasClassName("v-treegrid-row-focused"));
 
         // Should collapse "1 | 1"
         new Actions(getDriver()).sendKeys(Keys.LEFT).perform();
         assertEquals(6, grid.getRowCount());
         assertCellTexts(2, 0, new String[] { "1 | 1", "1 | 2", "0 | 1" });
         assertTrue(
-                grid.getRow(2).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(2).hasClassName("v-treegrid-row-focused"));
 
         // Should navigate to "0 | 0"
         new Actions(getDriver()).sendKeys(Keys.LEFT).perform();
@@ -173,21 +173,21 @@ public class TreeGridBasicFeaturesTest extends MultiBrowserTest {
         assertCellTexts(0, 0,
                 new String[] { "0 | 0", "1 | 0", "1 | 1", "1 | 2", "0 | 1" });
         assertTrue(
-                grid.getRow(0).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(0).hasClassName("v-treegrid-row-focused"));
 
         // Should collapse "0 | 0"
         new Actions(getDriver()).sendKeys(Keys.LEFT).perform();
         assertEquals(3, grid.getRowCount());
         assertCellTexts(0, 0, new String[] { "0 | 0", "0 | 1", "0 | 2" });
         assertTrue(
-                grid.getRow(0).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(0).hasClassName("v-treegrid-row-focused"));
 
         // Nothing should happen
         new Actions(getDriver()).sendKeys(Keys.LEFT).perform();
         assertEquals(3, grid.getRowCount());
         assertCellTexts(0, 0, new String[] { "0 | 0", "0 | 1", "0 | 2" });
         assertTrue(
-                grid.getRow(0).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(0).hasClassName("v-treegrid-row-focused"));
 
         assertNoErrorNotifications();
     }

--- a/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridBasicFeaturesTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridBasicFeaturesTest.java
@@ -206,11 +206,11 @@ public class TreeGridBasicFeaturesTest extends MultiBrowserTest {
         assertEquals(6, grid.getRowCount());
         assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "1 | 2" });
         assertFalse(
-                grid.getRow(0).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(0).hasClassName("v-treegrid-row-focused"));
         assertFalse(
-                grid.getRow(1).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(1).hasClassName("v-treegrid-row-focused"));
         assertTrue(
-                grid.getRow(2).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(2).hasClassName("v-treegrid-row-focused"));
 
         // Should select "1 | 1" without moving focus
         new Actions(getDriver()).sendKeys(Keys.SPACE).perform();
@@ -219,18 +219,18 @@ public class TreeGridBasicFeaturesTest extends MultiBrowserTest {
         // Should move focus but not selection
         new Actions(getDriver()).sendKeys(Keys.UP).perform();
         assertTrue(
-                grid.getRow(1).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(1).hasClassName("v-treegrid-row-focused"));
         assertFalse(
-                grid.getRow(2).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(2).hasClassName("v-treegrid-row-focused"));
         assertFalse(grid.getRow(1).hasClassName("v-treegrid-row-selected"));
         assertTrue(grid.getRow(2).hasClassName("v-treegrid-row-selected"));
 
         // Should select "1 | 0" without moving focus
         new Actions(getDriver()).sendKeys(Keys.SPACE).perform();
         assertTrue(
-                grid.getRow(1).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(1).hasClassName("v-treegrid-row-focused"));
         assertFalse(
-                grid.getRow(2).hasClassName("v-treegrid-rowmode-row-focused"));
+                grid.getRow(2).hasClassName("v-treegrid-row-focused"));
         assertTrue(grid.getRow(1).hasClassName("v-treegrid-row-selected"));
         assertFalse(grid.getRow(2).hasClassName("v-treegrid-row-selected"));
 

--- a/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridHugeTreeNavigationTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridHugeTreeNavigationTest.java
@@ -143,18 +143,18 @@ public class TreeGridHugeTreeNavigationTest extends MultiBrowserTest {
     }
 
     private WebElement findFocusedRow() {
-        return grid.findElement(By.className("v-treegrid-rowmode-row-focused"));
+        return grid.findElement(By.className("v-treegrid-row-focused"));
     }
 
     private void checkRowFocused(int index) {
         if (index > 0) {
             assertFalse(grid.getRow(index - 1)
-                .hasClassName("v-treegrid-rowmode-row-focused"));
+                    .hasClassName("v-treegrid-row-focused"));
     }
         assertTrue(grid.getRow(index)
-                .hasClassName("v-treegrid-rowmode-row-focused"));
+                .hasClassName("v-treegrid-row-focused"));
         assertFalse(grid.getRow(index + 1)
-                .hasClassName("v-treegrid-rowmode-row-focused"));
+                .hasClassName("v-treegrid-row-focused"));
     }
 
     private void assertCellTexts(int startRowIndex, int cellIndex,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9327)
<!-- Reviewable:end -->
