### PR TITLE
Fix Grid drag image offset for mobile

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/ui/UIConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/ui/UIConnector.java
@@ -1231,9 +1231,11 @@ public class UIConnector extends AbstractSingleComponentContainerConnector
         }
     }
 
-    // TODO add configuration to use custom drag start decider
     private static native void initializeMobileDndPolyfill()
     /*-{
-        $wnd.DragDropPolyfill.Initialize();
+         var conf = new Object();
+         // this is needed or the drag image will offset to weird place in for grid rows
+         conf['dragImageCenterOnTouch'] = true;
+         $wnd.DragDropPolyfill.Initialize(conf);
     }-*/;
 }

--- a/uitest/src/main/java/com/vaadin/tests/dnd/DragImage.java
+++ b/uitest/src/main/java/com/vaadin/tests/dnd/DragImage.java
@@ -24,6 +24,8 @@ public class DragImage extends AbstractTestUIWithLog {
 
     @Override
     protected void setup(VaadinRequest request) {
+        setMobileHtml5DndEnabled(true);
+
         HorizontalLayout layout1 = new HorizontalLayout();
         layout1.setCaption("No custom drag image");
         Styles styles = Page.getCurrent().getStyles();


### PR DESCRIPTION
Asks the polyfill to always center the drag image based on the touch coordinates.
Also temporarily removes the transform offset for the row. This causes small flickering in iOS10 Safari but is better than having drag image in the totally wrong place.
Also moves the row count badge to the right edge of the row drag image, so it is not hidden behind the dragging finger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9336)
<!-- Reviewable:end -->
