### PR TITLE
Fix NPE when detaching DragSource & DropTarget on client side

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridDragSourceConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridDragSourceConnector.java
@@ -39,7 +39,6 @@ import com.vaadin.client.widget.escalator.RowContainer;
 import com.vaadin.client.widget.grid.selection.SelectionModel;
 import com.vaadin.client.widgets.Escalator;
 import com.vaadin.client.widgets.Grid;
-import com.vaadin.server.SerializableFunction;
 import com.vaadin.shared.Range;
 import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.ui.dnd.DragSourceState;
@@ -204,8 +203,8 @@ public class GridDragSourceConnector extends DragSourceExtensionConnector {
     @Override
     protected Map<String, String> createDataTransferData(
             NativeEvent dragStartEvent) {
-        Map<String, String> dataMap = super
-                .createDataTransferData(dragStartEvent);
+        Map<String, String> dataMap = super.createDataTransferData(
+                dragStartEvent);
 
         // Add data provided by the generator functions
         getDraggedRows(dragStartEvent).forEach(row -> {
@@ -331,9 +330,9 @@ public class GridDragSourceConnector extends DragSourceExtensionConnector {
      * Gets drag data provided by the generator functions.
      *
      * @param row
-     *         The row data.
+     *            The row data.
      * @return The generated drag data type mapped to the corresponding drag
-     * data. If there are no generator functions, returns an empty map.
+     *         data. If there are no generator functions, returns an empty map.
      */
     private Map<String, String> getRowDragData(JsonObject row) {
         // Collect a map of data types and data that is provided by the
@@ -351,8 +350,6 @@ public class GridDragSourceConnector extends DragSourceExtensionConnector {
 
     @Override
     public void onUnregister() {
-        super.onUnregister();
-
         // Remove draggable from all row elements in the escalator
         Range visibleRange = getEscalator().getVisibleRowRange();
         for (int i = visibleRange.getStart(); i < visibleRange.getEnd(); i++) {
@@ -370,6 +367,8 @@ public class GridDragSourceConnector extends DragSourceExtensionConnector {
                     .setDelayToCancelTouchScroll(-1);
             touchScrollDelayUsed = false;
         }
+
+        super.onUnregister();
     }
 
     private Grid<JsonObject> getGrid() {

--- a/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
@@ -137,6 +137,8 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
         // if parent is null, the whole component has been removed,
         // no need to do clean up then
         if (parent != null) {
+            parent.onDragSourceDetached();
+
             Element dragSource = getDraggableElement();
 
             removeDraggable(dragSource);

--- a/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
@@ -27,7 +27,6 @@ import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.client.BrowserInfo;
-import com.vaadin.client.ComponentConnector;
 import com.vaadin.client.ServerConnector;
 import com.vaadin.client.annotations.OnStateChange;
 import com.vaadin.client.ui.AbstractComponentConnector;
@@ -62,15 +61,11 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
     private final EventListener dragStartListener = this::onDragStart;
     private final EventListener dragEndListener = this::onDragEnd;
 
-    /**
-     * Widget of the drag source component.
-     */
     private Widget dragSourceWidget;
 
     @Override
     protected void extend(ServerConnector target) {
-        dragSourceWidget = ((ComponentConnector) target).getWidget();
-
+        dragSourceWidget = ((AbstractComponentConnector) target).getWidget();
         // HTML5 DnD is by default not enabled for mobile devices
         if (BrowserInfo.get().isTouchDevice() && !getConnection()
                 .getUIConnector().isMobileHTML5DndEnabled()) {
@@ -138,14 +133,19 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
 
     @Override
     public void onUnregister() {
+        AbstractComponentConnector parent = (AbstractComponentConnector) getParent();
+        // if parent is null, the whole component has been removed,
+        // no need to do clean up then
+        if (parent != null) {
+            Element dragSource = getDraggableElement();
+
+            removeDraggable(dragSource);
+            removeDragListeners(dragSource);
+
+            dragSourceWidget = null;
+        }
+
         super.onUnregister();
-
-        Element dragSource = getDraggableElement();
-
-        removeDraggable(dragSource);
-        removeDragListeners(dragSource);
-
-        ((AbstractComponentConnector) getParent()).onDragSourceDetached();
     }
 
     @OnStateChange("resources")
@@ -256,9 +256,9 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
      * Creates the data map to be set as the {@code DataTransfer} object's data.
      *
      * @param dragStartEvent
-     *         The drag start event
+     *            The drag start event
      * @return The map from type to data, or {@code null} for not setting any
-     * data. Returning {@code null} will cancel the drag start.
+     *         data. Returning {@code null} will cancel the drag start.
      */
     protected Map<String, String> createDataTransferData(
             NativeEvent dragStartEvent) {

--- a/uitest/src/main/java/com/vaadin/tests/dnd/DragSourcesInTabSheet.java
+++ b/uitest/src/main/java/com/vaadin/tests/dnd/DragSourcesInTabSheet.java
@@ -1,0 +1,83 @@
+package com.vaadin.tests.dnd;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.shared.ui.grid.DropMode;
+import com.vaadin.tests.components.AbstractTestUIWithLog;
+import com.vaadin.tests.data.bean.Person;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.TabSheet;
+import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.Window;
+import com.vaadin.ui.components.grid.GridDragSource;
+import com.vaadin.ui.components.grid.GridDropTarget;
+import com.vaadin.ui.dnd.DragSourceExtension;
+import com.vaadin.ui.dnd.DropTargetExtension;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class DragSourcesInTabSheet extends AbstractTestUIWithLog {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        TabSheet tabSheet = new TabSheet();
+        addComponent(tabSheet);
+
+        tabSheet.addTab(new VerticalLayout(createLabels()))
+                .setCaption("Labels");
+
+        Button dsButton = new Button("DragSource");
+        new DragSourceExtension<>(dsButton)
+                .addDragEndListener(event -> log("drag end button"));
+        Button dtButton = new Button("DropTarget");
+        new DropTargetExtension<>(dtButton).addDropListener(event -> log("drop "
+                + event.getDragSourceComponent().orElse(null) + " on button"));
+        tabSheet.addTab(new VerticalLayout(dsButton, dtButton))
+                .setCaption("Buttons");
+
+        tabSheet.addTab(new VerticalLayout(createGrids())).setCaption("Grids");
+
+        addComponent(new Button("Open window", event -> openWindow()));
+    }
+
+    private Label[] createLabels() {
+        Label dragSource = new Label("DragSource");
+        new DragSourceExtension<>(dragSource)
+                .addDragEndListener(event -> log("drag end label"));
+        Label dropTarget = new Label("DropTarget");
+        new DropTargetExtension<>(dropTarget).addDropListener(event -> log(
+                "drop " + event.getDragSourceComponent().orElse(null)
+                        + " on label"));
+        return new Label[] { dragSource, dropTarget };
+    }
+
+    private Grid[] createGrids() {
+        Grid<Person> dsGrid = new Grid<>(Person.class);
+        dsGrid.setItems(Person.createTestPerson1(), Person.createTestPerson2());
+        new GridDragSource<>(dsGrid).addGridDragEndListener(event -> log(
+                "drag end " + event.getDraggedItems().iterator().next()));
+        Grid<Person> dtGrid = new Grid<>(Person.class);
+        dtGrid.setItems(Person.createTestPerson1(), Person.createTestPerson2());
+        new GridDropTarget<>(dtGrid, DropMode.BETWEEN)
+                .addGridDropListener(event -> log("drop on grid row "
+                        + event.getDropTargetRow().orElse(null) + " "
+                        + event.getDragData().orElse(null)));
+        return new Grid[] { dsGrid, dtGrid };
+    }
+
+    private void openWindow() {
+        Window window = new Window("Window with drag sources");
+        VerticalLayout layout = new VerticalLayout();
+        layout.addComponents(createLabels());
+        layout.addComponents(createGrids());
+        window.setContent(layout);
+        addWindow(window);
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Verify that removing drag source and drop target components in a tabsheet/window works";
+    }
+
+}


### PR DESCRIPTION
Fixes case where a TabSheet has a drag source component, and tab is changed, causing DragSourceExtensionConnector.getParent() to return null for some reason.

Closes #9101 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9341)
<!-- Reviewable:end -->
