### PR TITLE
Add since tags for 8.1

### DIFF
--- a/server/src/main/java/com/vaadin/ui/ConnectorTracker.java
+++ b/server/src/main/java/com/vaadin/ui/ConnectorTracker.java
@@ -280,7 +280,7 @@ public class ConnectorTracker implements Serializable {
      * <p>
      * This should only be called by the framework.
      *
-     * @since
+     * @since 8.1
      */
     public void ensureCleanedAndConsistent() {
         // Do this expensive check only with assertions enabled
@@ -449,7 +449,7 @@ public class ConnectorTracker implements Serializable {
      *
      * @return <code>true</code> if the hierarchy is consistent,
      *         <code>false</code> otherwise
-     * @since
+     * @since 8.1
      */
     private boolean isHierarchyComplete() {
         boolean noErrors = true;

--- a/shared/src/main/java/com/vaadin/shared/ui/ui/PageClientRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/ui/PageClientRpc.java
@@ -33,6 +33,8 @@ public interface PageClientRpc extends ClientRpc {
 
     /**
      * Initialize Mobile HTML5 Drag and Drop Polyfill.
+     *
+     * @since 8.1
      */
     public void initializeMobileHtml5DndPolyfill();
 }

--- a/shared/src/main/java/com/vaadin/shared/ui/ui/UIState.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/ui/UIState.java
@@ -88,6 +88,8 @@ public class UIState extends AbstractSingleComponentContainerState {
 
     /**
      * Enable Mobile HTML5 DnD support.
+     *
+     * @since 8.1
      */
     public boolean enableMobileHTML5DnD = false;
 


### PR DESCRIPTION
Note that ConnectorTracker changes will probably be backported to 7.7
in #9331.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9343)
<!-- Reviewable:end -->
