### PR TITLE
Rename findAndFilterDependencies to findDependencies

### DIFF
--- a/server/src/main/java/com/vaadin/server/BootstrapHandler.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapHandler.java
@@ -577,10 +577,10 @@ public abstract class BootstrapHandler extends SynchronizedRequestHandler {
                     .attr("href", themeUri + "/favicon.ico");
         }
 
-        Collection<? extends Dependency> deps = Dependency
-                .findAndFilterDependencies(Collections.singletonList(uiClass),
-                        context.getSession().getCommunicationManager(),
-                        new FilterContext(context.getSession()));
+        Collection<? extends Dependency> deps = Dependency.findDependencies(
+                Collections.singletonList(uiClass),
+                context.getSession().getCommunicationManager(),
+                new FilterContext(context.getSession()));
         for (Dependency dependency : deps) {
             Type type = dependency.getType();
             String url = context.getUriResolver()

--- a/server/src/main/java/com/vaadin/server/communication/UidlWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/UidlWriter.java
@@ -285,8 +285,8 @@ public class UidlWriter implements Serializable {
 
             List<Dependency> dependencies = new ArrayList<>();
             dependencies.addAll(ui.getPage().getPendingDependencies());
-            dependencies.addAll(Dependency.findAndFilterDependencies(
-                    newConnectorTypes, manager, new FilterContext(session)));
+            dependencies.addAll(Dependency.findDependencies(newConnectorTypes,
+                    manager, new FilterContext(session)));
 
             // Include dependencies in output if there are any
             if (!dependencies.isEmpty()) {

--- a/server/src/main/java/com/vaadin/ui/Dependency.java
+++ b/server/src/main/java/com/vaadin/ui/Dependency.java
@@ -158,7 +158,7 @@ public class Dependency implements Serializable {
      * @return the list of found dependencies
      */
     @SuppressWarnings("deprecation")
-    public static List<Dependency> findDependencies(
+    private static List<Dependency> findDependencies(
             List<Class<? extends ClientConnector>> connectorTypes,
             LegacyCommunicationManager manager) {
         List<Dependency> dependencies = new ArrayList<>();
@@ -191,7 +191,7 @@ public class Dependency implements Serializable {
      *            the context information for the filtering operation
      * @return the list of found and filtered dependencies
      */
-    public static List<Dependency> findAndFilterDependencies(
+    public static List<Dependency> findDependencies(
             List<Class<? extends ClientConnector>> connectorTypes,
             LegacyCommunicationManager manager, FilterContext context) {
         List<Dependency> dependencies = findDependencies(connectorTypes,


### PR DESCRIPTION
The old findDependencies method is made private since it's only an
implementation detail and should not be used from outside the class.

At the same time, the new findAndFilterDependencies method is renamed to
findDependencies since there's no longer necessary to have a name that
distinguishes it from the variant that doesn't do any filtering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9366)
<!-- Reviewable:end -->
