### PR TITLE
Add dependency filters through the service init event

### DIFF
--- a/server/src/main/java/com/vaadin/server/DependencyFilter.java
+++ b/server/src/main/java/com/vaadin/server/DependencyFilter.java
@@ -27,6 +27,8 @@ import com.vaadin.ui.Dependency;
  * Filter for dependencies loaded using {@link StyleSheet @StyleSheet},
  * {@link JavaScript @JavaScript} and {@link HtmlImport @HtmlImport}.
  *
+ * @see ServiceInitEvent#addDependencyFilter(DependencyFilter)
+ *
  * @since 8.1
  */
 @FunctionalInterface

--- a/server/src/main/java/com/vaadin/server/ServiceInitEvent.java
+++ b/server/src/main/java/com/vaadin/server/ServiceInitEvent.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 public class ServiceInitEvent extends EventObject {
 
     private List<RequestHandler> addedRequestHandlers = new ArrayList<>();
+    private List<DependencyFilter> addedDependencyFilters = new ArrayList<>();
 
     /**
      * Creates a new service init event for a given {@link VaadinService} and
@@ -69,6 +70,33 @@ public class ServiceInitEvent extends EventObject {
      */
     public List<RequestHandler> getAddedRequestHandlers() {
         return Collections.unmodifiableList(addedRequestHandlers);
+    }
+
+    /**
+     * Adds a new dependency filter that will be used by this service.
+     *
+     * @param dependencyFilter
+     *            the dependency filter to add, not <code>null</code>
+     *
+     * @since 8.1
+     */
+    public void addDependencyFilter(DependencyFilter dependencyFilter) {
+        Objects.requireNonNull(dependencyFilter,
+                "Dependency filter cannot be null");
+
+        addedDependencyFilters.add(dependencyFilter);
+    }
+
+    /**
+     * Gets an unmodifiable list of all dependency filters that have been added
+     * for the service.
+     *
+     * @return the current list of added dependency filters.
+     *
+     * @since 8.1
+     */
+    public List<DependencyFilter> getAddedDependencyFilters() {
+        return Collections.unmodifiableList(addedDependencyFilters);
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinService.java
@@ -207,8 +207,8 @@ public abstract class VaadinService implements Serializable {
 
         requestHandlers = Collections.unmodifiableCollection(handlers);
 
-        dependencyFilters = Collections
-                .unmodifiableCollection(createDependencyFilters());
+        dependencyFilters = Collections.unmodifiableCollection(
+                initDependencyFilters(event.getAddedDependencyFilters()));
         initialized = true;
     }
 
@@ -1444,34 +1444,34 @@ public abstract class VaadinService implements Serializable {
     }
 
     /**
-     * Constructs the list of resource dependency filters to use for the
+     * Determines the list of resource dependency filters to use for the
      * application.
      * <p>
      * The filters can freely update the dependencies in any way they see fit
      * (bundle, rewrite, merge).
      * <p>
-     * By default all filters found using the service loader are added to the
-     * list.
+     * By default all filters collected from the {@link SessionInitEvent} are
+     * used.
      * <p>
-     * The filters are called in the order the service loader returns the
-     * filters, which is undefined. If you need a specific order, you can
+     * The filters are called in the order the session init listeners are
+     * called, which is undefined. If you need a specific order, you can
      * override this method and alter the order.
      *
      * @since 8.1
+     * @param sessionInitFilters
+     *            a list of dependency filters collected from the session init
+     *            event
      * @return the list of dependency filters to use for filtering resources,
      *         not null
      * @throws ServiceException
      *             if something went wrong while determining the filters
      *
      */
-    protected List<DependencyFilter> createDependencyFilters()
-            throws ServiceException {
-        ArrayList<DependencyFilter> filters = new ArrayList<>();
-        ServiceLoader<DependencyFilter> loader = ServiceLoader
-                .load(DependencyFilter.class, getClassLoader());
-        loader.iterator().forEachRemaining(filters::add);
+    protected List<DependencyFilter> initDependencyFilters(
+            List<DependencyFilter> sessionInitFilters) throws ServiceException {
+        assert sessionInitFilters != null;
 
-        return filters;
+        return sessionInitFilters;
     }
 
     /**

--- a/server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinService.java
@@ -1444,14 +1444,16 @@ public abstract class VaadinService implements Serializable {
     }
 
     /**
-     * Determines the list of resource dependency filters to use for the
+     * Updates the list of resource dependency filters to use for the
      * application.
      * <p>
      * The filters can freely update the dependencies in any way they see fit
      * (bundle, rewrite, merge).
      * <p>
-     * By default all filters collected from the {@link SessionInitEvent} are
-     * used.
+     * The framework collects filters from the {@link SessionInitEvent} where
+     * session init listeners can add them. This method is called with the
+     * combined list to optionally modify it, and the result is then stored
+     * by the caller as the final list to use.
      * <p>
      * The filters are called in the order the session init listeners are
      * called, which is undefined. If you need a specific order, you can
@@ -1478,7 +1480,7 @@ public abstract class VaadinService implements Serializable {
      * Gets the filters which all resource dependencies are passed through
      * before being sent to the client for loading.
      *
-     * @see #createDependencyFilters()
+     * @see #initDependencyFilters()
      *
      * @since 8.1
      * @return the dependency filters to pass resources dependencies through


### PR DESCRIPTION
We shouldn't create new service loader interfaces since each new such
interface has implications for custom integrations. Instead, the
VaadinServiceInitListener mechanism should be enhanced to allow such
listeners to introduce their own dependency filter implementations
similarly to how VaadinServiceInitListener can already be used to
contribute new request handlers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9368)
<!-- Reviewable:end -->
