### PR TITLE
Remove warning for shortcuts on disabled connector (#9352)

### DIFF
--- a/server/src/main/java/com/vaadin/event/ConnectorActionManager.java
+++ b/server/src/main/java/com/vaadin/event/ConnectorActionManager.java
@@ -20,7 +20,6 @@ import java.util.logging.Logger;
 import com.vaadin.event.Action.Container;
 import com.vaadin.server.ClientConnector;
 import com.vaadin.server.VariableOwner;
-import com.vaadin.server.communication.ServerRpcHandler;
 import com.vaadin.ui.Component;
 
 /**
@@ -72,8 +71,6 @@ public class ConnectorActionManager extends ActionManager {
     @Override
     public void handleAction(Action action, Object sender, Object target) {
         if (!connector.isConnectorEnabled()) {
-            getLogger().warning(ServerRpcHandler
-                    .getIgnoredDisabledError("action", connector));
             return;
         }
 


### PR DESCRIPTION
Remove unnecessary warning on server log when using shortcut on disabled connector. Cherry-picked from master.

Fixes #6951

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9369)
<!-- Reviewable:end -->
