### PR TITLE
Cancelling selection when filtered now don’t leave suggestions to inv…

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VComboBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VComboBox.java
@@ -2319,7 +2319,6 @@ public class VComboBox extends Composite implements Field, KeyDownHandler,
                     .findAny().orElse(null);
         }
 
-        lastFilter = "";
         suggestionPopup.hide();
     }
 

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingTest.java
@@ -49,11 +49,6 @@ public class ComboBoxSelectingTest extends MultiBrowserTest {
         return comboBoxElement.getPopupSuggestions().size();
     }
 
-    private void showOptions() {
-        getDriver().findElement(By.cssSelector(".v-filterselect-button"))
-                .click();
-    }
-
     private void clickOnLabel() {
         getDriver().findElement(By.cssSelector(".v-label")).click();
     }

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingTest.java
@@ -3,14 +3,10 @@ package com.vaadin.tests.components.combobox;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 
 import com.vaadin.testbench.By;
@@ -34,29 +30,23 @@ public class ComboBoxSelectingTest extends MultiBrowserTest {
 
     @Test
     public void ensureOldFilterIsCleared() {
-        showOptions();
+        comboBoxElement.openPopup();
         int initialVisibleOptions = countVisibleOptions();
         clearInputAndType("b11");
         int visibleOptionsAfterFiltering = countVisibleOptions();
         Assert.assertEquals(1, visibleOptionsAfterFiltering);
         clickOnLabel();
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
+        sleep(1000);
         // no selection was made, clicking on arrow should show all options
         // again
-        showOptions();
+        comboBoxElement.openPopup();
 
         int visibleOptions = countVisibleOptions();
         Assert.assertEquals(initialVisibleOptions, visibleOptions);
     }
 
     private int countVisibleOptions() {
-        List<String> suggestionsOnScreen = getSuggestionsOnScreen();
-        return suggestionsOnScreen.size();
+        return comboBoxElement.getPopupSuggestions().size();
     }
 
     private void showOptions() {
@@ -66,18 +56,6 @@ public class ComboBoxSelectingTest extends MultiBrowserTest {
 
     private void clickOnLabel() {
         getDriver().findElement(By.cssSelector(".v-label")).click();
-    }
-
-    private List<String> getSuggestionsOnScreen() {
-        List<WebElement> suggestionElements = getDriver()
-                .findElements(By.cssSelector(
-                        ".v-filterselect-suggestpopup .gwt-MenuItem span"));
-
-        List<String> suggestions = new ArrayList<>();
-        for (WebElement suggestion : suggestionElements) {
-            suggestions.add(suggestion.getText());
-        }
-        return suggestions;
     }
 
     @Test

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingTest.java
@@ -3,9 +3,14 @@ package com.vaadin.tests.components.combobox;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 
 import com.vaadin.testbench.By;
@@ -25,6 +30,54 @@ public class ComboBoxSelectingTest extends MultiBrowserTest {
         openTestURL();
         waitForElementPresent(By.className("v-filterselect"));
         comboBoxElement = $(ComboBoxElement.class).first();
+    }
+
+    @Test
+    public void ensureOldFilterIsCleared() {
+        showOptions();
+        int initialVisibleOptions = countVisibleOptions();
+        clearInputAndType("b11");
+        int visibleOptionsAfterFiltering = countVisibleOptions();
+        Assert.assertEquals(1, visibleOptionsAfterFiltering);
+        clickOnLabel();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        // no selection was made, clicking on arrow should show all options
+        // again
+        showOptions();
+
+        int visibleOptions = countVisibleOptions();
+        Assert.assertEquals(initialVisibleOptions, visibleOptions);
+    }
+
+    private int countVisibleOptions() {
+        List<String> suggestionsOnScreen = getSuggestionsOnScreen();
+        return suggestionsOnScreen.size();
+    }
+
+    private void showOptions() {
+        getDriver().findElement(By.cssSelector(".v-filterselect-button"))
+                .click();
+    }
+
+    private void clickOnLabel() {
+        getDriver().findElement(By.cssSelector(".v-label")).click();
+    }
+
+    private List<String> getSuggestionsOnScreen() {
+        List<WebElement> suggestionElements = getDriver()
+                .findElements(By.cssSelector(
+                        ".v-filterselect-suggestpopup .gwt-MenuItem span"));
+
+        List<String> suggestions = new ArrayList<>();
+        for (WebElement suggestion : suggestionElements) {
+            suggestions.add(suggestion.getText());
+        }
+        return suggestions;
     }
 
     @Test


### PR DESCRIPTION
…alid state

Currently the reset method resets the lastFilter as well and then the logic thinks items
don’t need to be refreshed when popup is reopened.

closes #9027 and #7790 (works bit differently ATM, if I read the description right,
but I’d assume this gets fixed now as well)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9381)
<!-- Reviewable:end -->
