### PR TITLE
Fix menu item selection in tests

### DIFF
--- a/uitest/src/test/java/com/vaadin/tests/focusable/GridFocusableTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/focusable/GridFocusableTest.java
@@ -1,9 +1,5 @@
 package com.vaadin.tests.focusable;
 
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebElement;
-
-import com.vaadin.testbench.By;
 import com.vaadin.testbench.elements.GridElement;
 import com.vaadin.testbench.elements.GridElement.GridCellElement;
 import com.vaadin.tests.components.grid.basics.GridBasics;
@@ -28,11 +24,5 @@ public class GridFocusableTest extends AbstractFocusableComponentTest {
     @Override
     protected GridCellElement getFocusElement() {
         return $(GridElement.class).first().getCell(0, 0);
-    }
-
-    @Override
-    protected WebElement getMenuElement(String menuCaption)
-            throws NoSuchElementException {
-        return super.getMenuElement(menuCaption).findElement(By.xpath(".."));
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/tb3/AbstractTB3Test.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/AbstractTB3Test.java
@@ -1080,8 +1080,9 @@ public abstract class AbstractTB3Test extends ParallelTest {
      */
     protected WebElement getMenuElement(String menuCaption)
             throws NoSuchElementException {
+        // Need the parent span to obtain the correct size
         return getDriver().findElement(
-                By.xpath("//span[text() = '" + menuCaption + "']"));
+                By.xpath("//span[text() = '" + menuCaption + "']/.."));
     }
 
     /**


### PR DESCRIPTION
When the parent span was not used, the size of the wrong span was used
in the calculation of mouse locations for activating a menu item. This
occasionally leads to the wrong submenu being opened on IE as the
cursor passed over the corner of the next item.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9387)
<!-- Reviewable:end -->
