### PR TITLE
Throw exception if user modifies same binding step twice

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -711,6 +711,9 @@ public class Binder<BEAN> implements Serializable {
             checkUnbound();
             Objects.requireNonNull(converter, "converter cannot be null");
 
+            // Mark this step to be bound to prevent modifying multiple times.
+            bound = true;
+
             if (resetNullRepresentation) {
                 getBinder().initialConverters.get(field).setIdentity();
             }

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.data.Binder.BindingBuilder;
+import com.vaadin.data.converter.StringToDoubleConverter;
 import com.vaadin.data.converter.StringToIntegerConverter;
 import com.vaadin.data.validator.NotEmptyValidator;
 import com.vaadin.server.ErrorMessage;
@@ -669,5 +670,16 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
     private void assertStreamEquals(Stream<?> s1, Stream<?> s2) {
         Assert.assertArrayEquals(s1.toArray(), s2.toArray());
+    }
+
+    /**
+     * Access to old step in binding chain that already has a converter applied
+     * to it is expected to prevent modifications.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void multiple_calls_to_same_binder_throws() {
+        BindingBuilder<Person, String> forField = binder.forField(nameField);
+        forField.withConverter(new StringToDoubleConverter("Failed"));
+        forField.bind(Person::getFirstName, Person::setFirstName);
     }
 }


### PR DESCRIPTION
Adding a converter to a binding step does not mark it to be bound
allowing it to be later re-used leading into unexpected cast exceptions.

Fixes #9427

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9428)
<!-- Reviewable:end -->
