### PR TITLE
ListDataProvider#size now uses the offset and limit provided by the query

### DIFF
--- a/server/src/main/java/com/vaadin/data/provider/ListDataProvider.java
+++ b/server/src/main/java/com/vaadin/data/provider/ListDataProvider.java
@@ -84,7 +84,7 @@ public class ListDataProvider<T>
 
     @Override
     public int size(Query<T, SerializablePredicate<T>> query) {
-        return (int) getFilteredStream(query).count();
+        return (int) getFilteredStream(query).skip(query.getOffset()).limit(query.getLimit()).count();
     }
 
     private Stream<T> getFilteredStream(


### PR DESCRIPTION
It is my understanding that dp.size(someQueryWithOffsetOrLimit) should be equal to dp.fetch(theSameQueryAsBefore).count(). Currently that is not true.
I am willing to create a test, but I'm not sure where I should add it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9433)
<!-- Reviewable:end -->
