### PR TITLE
Make component iterators unmodifiable

### DIFF
--- a/server/src/main/java/com/vaadin/ui/AbsoluteLayout.java
+++ b/server/src/main/java/com/vaadin/ui/AbsoluteLayout.java
@@ -16,6 +16,7 @@
 package com.vaadin.ui;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -85,7 +86,9 @@ public class AbsoluteLayout extends AbstractLayout
      */
     @Override
     public Iterator<Component> iterator() {
-        return componentToCoordinates.keySet().iterator();
+        return Collections
+                .unmodifiableCollection(componentToCoordinates.keySet())
+                .iterator();
     }
 
     /**

--- a/server/src/main/java/com/vaadin/ui/AbstractOrderedLayout.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractOrderedLayout.java
@@ -17,6 +17,7 @@
 package com.vaadin.ui;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.logging.Logger;
@@ -184,7 +185,7 @@ public abstract class AbstractOrderedLayout extends AbstractLayout
      */
     @Override
     public Iterator<Component> iterator() {
-        return components.iterator();
+        return Collections.unmodifiableCollection(components).iterator();
     }
 
     /**

--- a/server/src/main/java/com/vaadin/ui/AbstractSplitPanel.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractSplitPanel.java
@@ -226,12 +226,13 @@ public abstract class AbstractSplitPanel extends AbstractComponentContainer {
         }
     }
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Gets an iterator to the collection of contained components. Using this
+     * iterator it is possible to step through all components contained in this
+     * container and remove components from it.
      *
-     * @see com.vaadin.ui.ComponentContainer#getComponentIterator()
+     * @return the component iterator.
      */
-
     @Override
     public Iterator<Component> iterator() {
         return new ComponentIterator();

--- a/server/src/main/java/com/vaadin/ui/CssLayout.java
+++ b/server/src/main/java/com/vaadin/ui/CssLayout.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.ui;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 
@@ -194,7 +195,7 @@ public class CssLayout extends AbstractLayout implements LayoutClickNotifier {
      */
     @Override
     public Iterator<Component> iterator() {
-        return components.iterator();
+        return Collections.unmodifiableCollection(components).iterator();
     }
 
     /**

--- a/server/src/main/java/com/vaadin/ui/CustomLayout.java
+++ b/server/src/main/java/com/vaadin/ui/CustomLayout.java
@@ -20,6 +20,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -205,7 +206,7 @@ public class CustomLayout extends AbstractLayout implements LegacyComponent {
      */
     @Override
     public Iterator<Component> iterator() {
-        return slots.values().iterator();
+        return Collections.unmodifiableCollection(slots.values()).iterator();
     }
 
     /**

--- a/server/src/main/java/com/vaadin/ui/HasComponents.java
+++ b/server/src/main/java/com/vaadin/ui/HasComponents.java
@@ -35,6 +35,9 @@ public interface HasComponents extends Component, Iterable<Component> {
      * Gets an iterator to the collection of contained components. Using this
      * iterator it is possible to step through all components contained in this
      * container.
+     * <p>
+     * The iterator is typically unmodifiable, and calls to
+     * {@link Iterator#remove()} throw an exception.
      *
      * @return the component iterator.
      */

--- a/server/src/main/java/com/vaadin/ui/UI.java
+++ b/server/src/main/java/com/vaadin/ui/UI.java
@@ -467,7 +467,7 @@ public abstract class UI extends AbstractSingleComponentContainer
 
         components.addAll(windows);
 
-        return components.iterator();
+        return Collections.unmodifiableCollection(components).iterator();
     }
 
     /*


### PR DESCRIPTION
Document that component iterators are typically unmodifiable, and make
iterator.remove() throw an exception.

Document the exception of AbstractSplitPanel that actually supports
removing components through the iterator.

Fixes #9404

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9443)
<!-- Reviewable:end -->
