### PR TITLE
Mark valo $v-textfield-background-color--readonly as default #7765

### DIFF
--- a/themes/src/main/themes/VAADIN/themes/valo/components/_textfield.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_textfield.scss
@@ -8,7 +8,7 @@ $v-textfield-background-color: if(is-dark-color($v-app-background-color), darken
  * The background color for read-only text fields.
  * @group textfield
  */
-$v-textfield-background-color--readonly: darkest-color($v-app-background-color, darken($v-textfield-background-color, 2%));
+$v-textfield-background-color--readonly: darkest-color($v-app-background-color, darken($v-textfield-background-color, 2%)) !default;
 
 /**
  * The bevel style for text fields. See the documentation for $v-bevel.


### PR DESCRIPTION
Obvious fix for #7765

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9458)
<!-- Reviewable:end -->
