### PR TITLE
Re(set) calendar time after calculating rollAmount

### DIFF
--- a/uitest/src/main/java/com/vaadin/tests/themes/valo/CalendarTest.java
+++ b/uitest/src/main/java/com/vaadin/tests/themes/valo/CalendarTest.java
@@ -580,6 +580,7 @@ public class CalendarTest extends GridLayout implements View {
         int rollAmount = calendar.get(GregorianCalendar.DAY_OF_MONTH) - 1;
         calendar.add(GregorianCalendar.DAY_OF_MONTH, -rollAmount);
         currentMonthsFirstDate = calendar.getTime();
+        calendar.setTime(today);
 
         updateCaptionLabel();
 


### PR DESCRIPTION
by calling calendar.setTime(today);
after rollAmount has been initialized and given a value, we can reset the calendar's internal time back to the correct date. As it is currently implemented; calling calendar.getTime() will result in a wrong date, it returns the first of the month with the correct time.
the function addInitialEvents() is called AFTER the calendar's time has been subtracted from (by calculating the rollAmount), as such this results in an incorrect internal time and the 'Day' button does not switch to the correct day. Instead it shows the first of the month here too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9479)
<!-- Reviewable:end -->
