### PR TITLE
Add View.beforeLeave to support delayed navigation

### DIFF
--- a/server/src/main/java/com/vaadin/navigator/View.java
+++ b/server/src/main/java/com/vaadin/navigator/View.java
@@ -34,9 +34,8 @@ import com.vaadin.ui.Component;
 public interface View extends Serializable {
 
     /**
-     * This view is navigated to.
-     *
-     * This method is always called before the view is shown on screen.
+     * Called before the view is shown on screen.
+     * <p>
      * {@link ViewChangeEvent#getParameters() event.getParameters()} may contain
      * extra parameters relevant to the view.
      *
@@ -47,6 +46,34 @@ public interface View extends Serializable {
      *
      */
     public void enter(ViewChangeEvent event);
+
+    /**
+     * Called when the user is requesting navigation away from the view.
+     * <p>
+     * This method allows the view to accept or prevent navigation away from the
+     * view or optionally delay navigation away until a later stage. For
+     * navigation to take place, the {@link ViewBeforeLeaveEvent#navigate()}
+     * method must be called either directly when handling this event or later
+     * to perform delayed navigation.
+     * <p>
+     * The default implementation calls {@link ViewBeforeLeaveEvent#navigate()}
+     * directly. If you override this and do nothing, the user will never be
+     * able to leave the view.
+     * <p>
+     * This method is triggered before any methods in any added
+     * {@link ViewChangeListener ViewChangeListeners}. Whenever you call
+     * {@link ViewBeforeLeaveEvent#navigate()}, any {@link ViewChangeListener}s
+     * will be triggered. They will be handled normally and might also prevent
+     * navigation.
+     *
+     * @param event
+     *            an event object providing information about the event and
+     *            containing the {@link ViewBeforeLeaveEvent#navigate()} method
+     *            needed to perform navigation
+     */
+    public default void beforeLeave(ViewBeforeLeaveEvent event) {
+        event.navigate();
+    }
 
     /**
      * Gets the component to show when navigating to the view.

--- a/server/src/main/java/com/vaadin/navigator/ViewBeforeLeaveEvent.java
+++ b/server/src/main/java/com/vaadin/navigator/ViewBeforeLeaveEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.navigator;
+
+import java.util.EventObject;
+
+/**
+ * Event sent to the View instance before navigating away from it.
+ * <p>
+ * Provides a {@link #navigate()} method which must be called for the navigation
+ * to take place.
+ *
+ * @since 8.1
+ */
+public class ViewBeforeLeaveEvent extends EventObject {
+
+    private ViewLeaveAction action;
+    private boolean navigateRun = false;
+
+    /**
+     * Creates a new event instance for the given navigator.
+     *
+     * @param navigator
+     *            the navigator instance
+     * @param action
+     *            the command to execute when calling {@link #navigate()}
+     */
+    public ViewBeforeLeaveEvent(Navigator navigator, ViewLeaveAction action) {
+        super(navigator);
+        this.action = action;
+    }
+
+    /**
+     * Performs the navigation which triggered the event in the first place.
+     */
+    public void navigate() {
+        if (navigateRun) {
+            throw new IllegalStateException(
+                    "navigate() can only be called once");
+        }
+        action.run();
+        navigateRun = true;
+    }
+
+    /**
+     * Checks if the navigate command has been executed.
+     *
+     * @return <code>true</code> if {@link #navigate()} has been called,
+     *         <code>false</code> otherwise
+     */
+    protected boolean isNavigateRun() {
+        return navigateRun;
+    }
+}

--- a/server/src/main/java/com/vaadin/navigator/ViewLeaveAction.java
+++ b/server/src/main/java/com/vaadin/navigator/ViewLeaveAction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.navigator;
+
+import java.io.Serializable;
+
+/**
+ * An action to execute when navigating away from a view.
+ *
+ * @since 8.1
+ */
+@FunctionalInterface
+public interface ViewLeaveAction extends Serializable {
+    /**
+     * Executes the action.
+     */
+    public void run();
+}

--- a/uitest/src/main/java/com/vaadin/tests/navigator/DelayedViewLeaveConfirmation.java
+++ b/uitest/src/main/java/com/vaadin/tests/navigator/DelayedViewLeaveConfirmation.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.navigator;
+
+import com.vaadin.navigator.Navigator;
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewBeforeLeaveEvent;
+import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
+import com.vaadin.navigator.ViewLeaveAction;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.TextField;
+import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.Window;
+
+public class DelayedViewLeaveConfirmation extends AbstractTestUI {
+
+    public static class OtherView extends VerticalLayout implements View {
+        public OtherView() {
+            addComponent(new Label("Just another view"));
+        }
+
+        @Override
+        public void enter(ViewChangeEvent event) {
+
+        }
+    }
+
+    public static class MainView extends VerticalLayout implements View {
+        private Label saved;
+        private TextField input;
+
+        public MainView() {
+            saved = new Label("Initial");
+            saved.setCaption("Saved value");
+            input = new TextField("Enter a value");
+            input.setId("input");
+            Button navigateAway = new Button("Navigate to the other view",
+                    e -> {
+                        getUI().getNavigator().navigateTo("other");
+                    });
+            Button logout = new Button("Simulate logout", e -> {
+                getUI().getNavigator().runAfterLeaveConfirmation(() -> {
+                    removeAllComponents();
+                    addComponent(new Label("You have been logged out"));
+                    getUI().getPage().setUriFragment("", false);
+                });
+            });
+            navigateAway.setId("navigateAway");
+            logout.setId("logout");
+            addComponents(saved, input, navigateAway, logout);
+        }
+
+        @Override
+        public void enter(ViewChangeEvent event) {
+            input.setValue(saved.getValue());
+        }
+
+        @Override
+        public void beforeLeave(ViewBeforeLeaveEvent event) {
+            boolean hasChanges = !(saved.getValue().equals(input.getValue()));
+            if (hasChanges) {
+                getUI().addWindow(new ConfirmationWindow(event::navigate));
+            } else {
+                event.navigate();
+            }
+        }
+
+    }
+
+    public static class ConfirmationWindow extends Window {
+        public ConfirmationWindow(ViewLeaveAction action) {
+            super();
+            VerticalLayout layout = new VerticalLayout();
+            layout.addComponent(new Label(
+                    "You have unsaved changes. Are you sure you want to leave?"));
+            Button leave = new Button("YES, LEAVE!", e -> {
+                close();
+                action.run();
+            });
+            leave.setId("leave");
+            Button stay = new Button("NO, STAY!", e -> {
+                close();
+            });
+            stay.setId("stay");
+            layout.addComponents(new HorizontalLayout(leave, stay));
+            setContent(layout);
+        }
+    }
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        setNavigator(new Navigator(this, this));
+        getNavigator().addView("main", MainView.class);
+        getNavigator().addView("other", OtherView.class);
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/navigator/DelayedViewLeaveConfirmationTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/navigator/DelayedViewLeaveConfirmationTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.navigator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.LabelElement;
+import com.vaadin.testbench.elements.TextFieldElement;
+import com.vaadin.testbench.elements.WindowElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class DelayedViewLeaveConfirmationTest extends SingleBrowserTest {
+
+    @Test
+    public void navigateAwayWithoutChanges() {
+        openMainView();
+        navigateToOtherView();
+        assertOnOtherView();
+    }
+
+    @Test
+    public void cancelNavigateAwayWithChanges() {
+        openMainView();
+        updateValue();
+        navigateToOtherView();
+        assertOnMainView();
+        chooseToStay();
+        assertOnMainView();
+    }
+
+    @Test
+    public void confirmNavigateAwayWithChanges() {
+        openMainView();
+        updateValue();
+        navigateToOtherView();
+        assertOnMainView();
+        chooseToLeave();
+        assertOnOtherView();
+    }
+
+    @Test
+    public void confirmLogoutWithChanges() {
+        openMainView();
+        updateValue();
+        logout();
+        assertOnMainView();
+        chooseToLeave();
+        assertLoggedOut();
+    }
+
+    @Test
+    public void cancelLogoutWithChanges() {
+        openMainView();
+        updateValue();
+        logout();
+        assertOnMainView();
+        chooseToStay();
+        assertOnMainView();
+    }
+
+    @Test
+    public void logoutWithoutChanges() {
+        openMainView();
+        getLogout().click();
+        assertLoggedOut();
+
+    }
+
+    private void openMainView() {
+        String url = getTestURL(DelayedViewLeaveConfirmation.class);
+        url += "#!main";
+
+        driver.get(url);
+    }
+
+    private void navigateToOtherView() {
+        getNavigateAway().click();
+    }
+
+    private void logout() {
+        getLogout().click();
+    }
+
+    private void assertOnOtherView() {
+        Assert.assertEquals("Just another view",
+                $(LabelElement.class).first().getText());
+    }
+
+    private void assertOnMainView() {
+        Assert.assertEquals("Saved value",
+                $(LabelElement.class).first().getCaption());
+    }
+
+    private void assertLoggedOut() {
+        Assert.assertEquals("You have been logged out",
+                $(LabelElement.class).first().getText());
+    }
+
+    private void chooseToStay() {
+        $(WindowElement.class).first().$(ButtonElement.class).id("stay")
+                .click();
+    }
+
+    private void chooseToLeave() {
+        $(WindowElement.class).first().$(ButtonElement.class).id("leave")
+                .click();
+    }
+
+    private void updateValue() {
+        TextFieldElement input = $(TextFieldElement.class).id("input");
+        input.setValue(input.getValue() + "-upd");
+    }
+
+    private ButtonElement getNavigateAway() {
+        return $(ButtonElement.class).id("navigateAway");
+    }
+
+    private ButtonElement getLogout() {
+        return $(ButtonElement.class).id("logout");
+    }
+}


### PR DESCRIPTION
Using View.beforeLeave you can delay navigation so that you can
e.g. show a confirmation popup to the user and only invoke the navigation
if the user confirms it in the popup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9539)
<!-- Reviewable:end -->
