### PR TITLE
Provide old value of position in SplitPositionChangeEvent of *SplitPanel

### DIFF
--- a/server/src/main/java/com/vaadin/ui/AbstractSplitPanel.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractSplitPanel.java
@@ -588,6 +588,8 @@ public abstract class AbstractSplitPanel extends AbstractComponentContainer {
         /**
          * Returns the new split position that triggered this change event.
          *
+         * @since 7.5.0
+         *
          * @return the new value of split position
          */
         public float getSplitPosition() {
@@ -597,6 +599,8 @@ public abstract class AbstractSplitPanel extends AbstractComponentContainer {
         /**
          * Returns the new split position unit that triggered this change event.
          *
+         * @since 7.5.0
+         *
          * @return the new value of split position
          */
         public Unit getSplitPositionUnit() {
@@ -605,6 +609,8 @@ public abstract class AbstractSplitPanel extends AbstractComponentContainer {
 
         /**
          * Returns the position of the split before this change event occurred.
+         *
+         * @since 8.1
          *
          * @return the split position previously set to the source of this event
          */
@@ -616,6 +622,8 @@ public abstract class AbstractSplitPanel extends AbstractComponentContainer {
          * Returns the position unit of the split before this change event
          * occurred.
          *
+         * @since 8.1
+         *
          * @return the split position unit previously set to the source of
          *         this event
          */
@@ -626,6 +634,8 @@ public abstract class AbstractSplitPanel extends AbstractComponentContainer {
         /**
          * Returns whether this event was triggered by user interaction, on the
          * client side, or programmatically, on the server side.
+         *
+         * @since 8.1
          *
          * @return {@code true} if this event originates from the client,
          *         {@code false} otherwise.

--- a/server/src/main/java/com/vaadin/ui/AbstractSplitPanel.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractSplitPanel.java
@@ -64,9 +64,12 @@ public abstract class AbstractSplitPanel extends AbstractComponentContainer {
 
         @Override
         public void setSplitterPosition(float position) {
+            float oldPosition = getSplitPosition();
+
             getSplitterState().position = position;
-            fireEvent(new SplitPositionChangeEvent(AbstractSplitPanel.this,
-                    position, getSplitPositionUnit()));
+
+            fireEvent(new SplitPositionChangeEvent(AbstractSplitPanel.this, true,
+                    oldPosition, getSplitPositionUnit(), position, getSplitPositionUnit()));
         }
     };
 
@@ -331,13 +334,16 @@ public abstract class AbstractSplitPanel extends AbstractComponentContainer {
         if (unit != Unit.PERCENTAGE) {
             pos = Math.round(pos);
         }
+        float oldPosition = getSplitPosition();
+        Unit oldUnit = getSplitPositionUnit();
+
         SplitterState splitterState = getSplitterState();
         splitterState.position = pos;
         splitterState.positionUnit = unit.getSymbol();
         splitterState.positionReversed = reverse;
         posUnit = unit;
-        fireEvent(new SplitPositionChangeEvent(AbstractSplitPanel.this, pos,
-                posUnit));
+        fireEvent(new SplitPositionChangeEvent(AbstractSplitPanel.this, false,
+                oldPosition, oldUnit, pos, posUnit));
     }
 
     /**
@@ -559,24 +565,74 @@ public abstract class AbstractSplitPanel extends AbstractComponentContainer {
      */
     public static class SplitPositionChangeEvent extends Component.Event {
 
+        private final float oldPosition;
+        private final Unit oldUnit;
+
         private final float position;
         private final Unit unit;
 
+        private final boolean userOriginated;
+
         public SplitPositionChangeEvent(final Component source,
-                final float position, final Unit unit) {
+                                        final boolean userOriginated,
+                                        final float oldPosition, final Unit oldUnit,
+                                        final float position, final Unit unit) {
             super(source);
+            this.userOriginated = userOriginated;
+            this.oldUnit = oldUnit;
+            this.oldPosition = oldPosition;
             this.position = position;
             this.unit = unit;
         }
 
+        /**
+         * Returns the new split position that triggered this change event.
+         *
+         * @return the new value of split position
+         */
         public float getSplitPosition() {
             return position;
         }
 
+        /**
+         * Returns the new split position unit that triggered this change event.
+         *
+         * @return the new value of split position
+         */
         public Unit getSplitPositionUnit() {
             return unit;
         }
 
+        /**
+         * Returns the position of the split before this change event occurred.
+         *
+         * @return the split position previously set to the source of this event
+         */
+        public float getOldSplitPosition() {
+            return oldPosition;
+        }
+
+        /**
+         * Returns the position unit of the split before this change event
+         * occurred.
+         *
+         * @return the split position unit previously set to the source of
+         *         this event
+         */
+        public Unit getOldSplitPositionUnit() {
+            return oldUnit;
+        }
+
+        /**
+         * Returns whether this event was triggered by user interaction, on the
+         * client side, or programmatically, on the server side.
+         *
+         * @return {@code true} if this event originates from the client,
+         *         {@code false} otherwise.
+         */
+        public boolean isUserOriginated() {
+            return userOriginated;
+        }
     }
 
     public Registration addSplitterClickListener(

--- a/server/src/test/java/com/vaadin/ui/SplitPositionChangeListenerTest.java
+++ b/server/src/test/java/com/vaadin/ui/SplitPositionChangeListenerTest.java
@@ -15,15 +15,19 @@
  */
 package com.vaadin.ui;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-import org.junit.Test;
-
 import com.vaadin.server.Sizeable.Unit;
 import com.vaadin.ui.AbstractSplitPanel.SplitPositionChangeEvent;
 import com.vaadin.ui.AbstractSplitPanel.SplitPositionChangeListener;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Test for {@link SplitPositionChangeListener}
@@ -41,5 +45,30 @@ public class SplitPositionChangeListenerTest {
         splitPanel.setSplitPosition(50, Unit.PERCENTAGE);
         verify(splitPositionChangeListener)
                 .onSplitPositionChanged(any(SplitPositionChangeEvent.class));
+    }
+
+    @Test
+    public void testSplitPositionListenerContainsOldValues() throws Exception {
+        final HorizontalSplitPanel splitPanel = new HorizontalSplitPanel();
+
+        float previousPosition = 50.0f;
+        float newPosition = 125.0f;
+
+        AtomicBoolean executed = new AtomicBoolean(false);
+
+        splitPanel.setSplitPosition(previousPosition, Unit.PERCENTAGE);
+        splitPanel.addSplitPositionChangeListener(event -> {
+            assertFalse(event.isUserOriginated());
+
+            assertTrue(previousPosition == event.getOldSplitPosition());
+            assertEquals(Unit.PERCENTAGE, event.getOldSplitPositionUnit());
+
+            assertTrue(newPosition == event.getSplitPosition());
+            assertEquals(Unit.PIXELS, event.getSplitPositionUnit());
+
+            executed.set(true);
+        });
+        splitPanel.setSplitPosition(newPosition, Unit.PIXELS);
+        assertTrue(executed.get());
     }
 }


### PR DESCRIPTION
New properties have been added to SplitPositionChangeEvent (#9472):
oldSplitPositionUnit, oldSplitPosition, userOriginated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9578)
<!-- Reviewable:end -->
