### PR TITLE
Fixes #9594 : Use ZoneId rather than ZoneOffset for conversion between model (Date) and presentation of LocalDateTime

### DIFF
--- a/server/src/main/java/com/vaadin/data/converter/LocalDateTimeToDateConverter.java
+++ b/server/src/main/java/com/vaadin/data/converter/LocalDateTimeToDateConverter.java
@@ -15,17 +15,17 @@
  */
 package com.vaadin.data.converter;
 
-import com.vaadin.data.Converter;
-import com.vaadin.data.Result;
-import com.vaadin.data.ValueContext;
-import com.vaadin.ui.DateTimeField;
-import com.vaadin.ui.InlineDateTimeField;
-
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.Objects;
+
+import com.vaadin.data.Converter;
+import com.vaadin.data.Result;
+import com.vaadin.data.ValueContext;
+import com.vaadin.ui.DateTimeField;
+import com.vaadin.ui.InlineDateTimeField;
 
 /**
  * A converter that converts between <code>LocalDateTime</code> and
@@ -35,8 +35,7 @@ import java.util.Objects;
  * @author Vaadin Ltd
  * @since 8.0
  */
-public class LocalDateTimeToDateConverter
-    implements Converter<LocalDateTime, Date> {
+public class LocalDateTimeToDateConverter implements Converter<LocalDateTime, Date> {
 
     private ZoneId zoneId;
 
@@ -46,13 +45,11 @@ public class LocalDateTimeToDateConverter
      * @param zoneId the time zone to use, not <code>null</code>
      */
     public LocalDateTimeToDateConverter(ZoneId zoneId) {
-        this.zoneId = Objects.requireNonNull(zoneId,
-                                             "Zone identifier cannot be null");
+        this.zoneId = Objects.requireNonNull(zoneId, "Zone identifier cannot be null");
     }
 
     @Override
-    public Result<Date> convertToModel(LocalDateTime localDate,
-                                       ValueContext context) {
+    public Result<Date> convertToModel(LocalDateTime localDate, ValueContext context) {
         if (localDate == null) {
             return Result.ok(null);
         }
@@ -61,8 +58,7 @@ public class LocalDateTimeToDateConverter
     }
 
     @Override
-    public LocalDateTime convertToPresentation(Date date,
-                                               ValueContext context) {
+    public LocalDateTime convertToPresentation(Date date, ValueContext context) {
         if (date == null) {
             return null;
         }

--- a/server/src/main/java/com/vaadin/data/converter/LocalDateTimeToDateConverter.java
+++ b/server/src/main/java/com/vaadin/data/converter/LocalDateTimeToDateConverter.java
@@ -15,17 +15,17 @@
  */
 package com.vaadin.data.converter;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.Date;
-import java.util.Objects;
-
 import com.vaadin.data.Converter;
 import com.vaadin.data.Result;
 import com.vaadin.data.ValueContext;
 import com.vaadin.ui.DateTimeField;
 import com.vaadin.ui.InlineDateTimeField;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Objects;
 
 /**
  * A converter that converts between <code>LocalDateTime</code> and
@@ -36,40 +36,38 @@ import com.vaadin.ui.InlineDateTimeField;
  * @since 8.0
  */
 public class LocalDateTimeToDateConverter
-        implements Converter<LocalDateTime, Date> {
+    implements Converter<LocalDateTime, Date> {
 
-    private ZoneOffset zoneOffset;
+    private ZoneId zoneId;
 
     /**
      * Creates a new converter using the given time zone.
      *
-     * @param zoneOffset
-     *            the time zone offset to use, not <code>null</code>
+     * @param zoneId the time zone to use, not <code>null</code>
      */
-    public LocalDateTimeToDateConverter(ZoneOffset zoneOffset) {
-        this.zoneOffset = Objects.requireNonNull(zoneOffset,
-                "Zone offset cannot be null");
+    public LocalDateTimeToDateConverter(ZoneId zoneId) {
+        this.zoneId = Objects.requireNonNull(zoneId,
+                                             "Zone identifier cannot be null");
     }
 
     @Override
     public Result<Date> convertToModel(LocalDateTime localDate,
-            ValueContext context) {
+                                       ValueContext context) {
         if (localDate == null) {
             return Result.ok(null);
         }
 
-        return Result.ok(Date.from(localDate.toInstant(zoneOffset)));
+        return Result.ok(Date.from(localDate.atZone(zoneId).toInstant()));
     }
 
     @Override
     public LocalDateTime convertToPresentation(Date date,
-            ValueContext context) {
+                                               ValueContext context) {
         if (date == null) {
             return null;
         }
 
-        return Instant.ofEpochMilli(date.getTime()).atZone(zoneOffset)
-                .toLocalDateTime();
+        return Instant.ofEpochMilli(date.getTime()).atZone(zoneId).toLocalDateTime();
     }
 
 }


### PR DESCRIPTION
LocalDateToDateConverter (correctly) uses ZoneId, whereas LocalDateTimeToDateConverter (incorrectly) uses a ZoneOffset. This fix aligns the two Converter implementations and makes the latter one more robust.

A ZoneOffset is a fixed time difference, e.g., +07:00, whereas a time zone - represented by a ZoneId - is more dynamic, including features like Daylight-Savings Time.  A ZoneId returns one or more ZoneOffsets via its ZoneRules method. (ZoneOffsets have trivial ZoneRules that simply return the ZoneOffset.)

Since the date/time being displayed may be from any date on the calendar, the ZoneOffset imposes a negative limitation. Using ZoneId instead gets us past that limitation and allows a more robust set of conversion rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9620)
<!-- Reviewable:end -->
