### PR TITLE
Change sendMessage access modifier to protected.

### DIFF
--- a/server/src/main/java/com/vaadin/server/communication/AtmospherePushConnection.java
+++ b/server/src/main/java/com/vaadin/server/communication/AtmospherePushConnection.java
@@ -180,7 +180,7 @@ public class AtmospherePushConnection implements PushConnection {
      * @param message
      *            The message to send
      */
-    void sendMessage(String message) {
+    protected void sendMessage(String message) {
         assert (isConnected());
         // "Broadcast" the changes to the single client only
         outgoingMessage = getResource().getBroadcaster().broadcast(message,


### PR DESCRIPTION
This allows extending AtmospherePushConnection, and then doing overriding sendMessage. One use case is to correlate the IP address and the message in the logs.

    @Override
    protected void sendMessage(String message) {
        logger.info("sentMessage=" + message + ",destinationIp="+getUI().getPage.getLocation().getHost());
        super.sendMessage(message);
    }

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9622)
<!-- Reviewable:end -->
