### PR TITLE
Provide current request/response through VaadinRequest/VaadinResponse

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinRequest.java
+++ b/server/src/main/java/com/vaadin/server/VaadinRequest.java
@@ -497,6 +497,7 @@ public interface VaadinRequest extends Serializable {
      *
      * @return the current Vaadin request instance if available, otherwise
      *         <code>null</code>
+     * @since 8.1
      */
     public static VaadinRequest getCurrent() {
         return CurrentInstance.get(VaadinRequest.class);

--- a/server/src/main/java/com/vaadin/server/VaadinRequest.java
+++ b/server/src/main/java/com/vaadin/server/VaadinRequest.java
@@ -32,6 +32,8 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
+import com.vaadin.util.CurrentInstance;
+
 /**
  * A generic request to the server, wrapping a more specific request type, e.g.
  * HttpServletReqest or PortletRequest.
@@ -487,4 +489,16 @@ public interface VaadinRequest extends Serializable {
      */
     public Enumeration<String> getHeaders(String name);
 
+    /**
+     * Gets the currently processed Vaadin request. The current request is
+     * automatically defined when the request is started. The current request
+     * can not be used in e.g. background threads because of the way server
+     * implementations reuse request instances.
+     *
+     * @return the current Vaadin request instance if available, otherwise
+     *         <code>null</code>
+     */
+    public static VaadinRequest getCurrent() {
+        return CurrentInstance.get(VaadinRequest.class);
+    }
 }

--- a/server/src/main/java/com/vaadin/server/VaadinResponse.java
+++ b/server/src/main/java/com/vaadin/server/VaadinResponse.java
@@ -28,6 +28,8 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
+import com.vaadin.util.CurrentInstance;
+
 /**
  * A generic response from the server, wrapping a more specific response type,
  * e.g. HttpServletResponse or PortletResponse.
@@ -182,4 +184,17 @@ public interface VaadinResponse extends Serializable {
      * @since 7.3.8
      */
     public void setContentLength(int len);
+
+    /**
+     * Gets the currently processed Vaadin response. The current response is
+     * automatically defined when the request is started. The current response
+     * can not be used in e.g. background threads because of the way server
+     * implementations reuse response instances.
+     *
+     * @return the current Vaadin response instance if available, otherwise
+     *         <code>null</code>
+     */
+    public static VaadinResponse getCurrent() {
+        return CurrentInstance.get(VaadinResponse.class);
+    }
 }

--- a/server/src/main/java/com/vaadin/server/VaadinResponse.java
+++ b/server/src/main/java/com/vaadin/server/VaadinResponse.java
@@ -193,6 +193,7 @@ public interface VaadinResponse extends Serializable {
      *
      * @return the current Vaadin response instance if available, otherwise
      *         <code>null</code>
+     * @since 8.1
      */
     public static VaadinResponse getCurrent() {
         return CurrentInstance.get(VaadinResponse.class);

--- a/server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinService.java
@@ -1010,7 +1010,7 @@ public abstract class VaadinService implements Serializable {
      * @see #setCurrentInstances(VaadinRequest, VaadinResponse)
      */
     public static VaadinRequest getCurrentRequest() {
-        return CurrentInstance.get(VaadinRequest.class);
+        return VaadinRequest.getCurrent();
     }
 
     /**
@@ -1025,7 +1025,7 @@ public abstract class VaadinService implements Serializable {
      * @see #setCurrentInstances(VaadinRequest, VaadinResponse)
      */
     public static VaadinResponse getCurrentResponse() {
-        return CurrentInstance.get(VaadinResponse.class);
+        return VaadinResponse.getCurrent();
     }
 
     /**
@@ -1320,7 +1320,8 @@ public abstract class VaadinService implements Serializable {
      */
     private int getUidlRequestTimeout(VaadinSession session) {
         return getDeploymentConfiguration().isCloseIdleSessions()
-                ? session.getSession().getMaxInactiveInterval() : -1;
+                ? session.getSession().getMaxInactiveInterval()
+                : -1;
     }
 
     /**
@@ -1353,9 +1354,10 @@ public abstract class VaadinService implements Serializable {
     /**
      * Returns whether the given session is active or whether it can be closed.
      * <p>
-     * A session is active if and only if its {@link VaadinSession#getState()} returns {@link State#OPEN}
-     * and {@link #getUidlRequestTimeout(VaadinSession) getUidlRequestTimeout}
-     * is negative or has not yet expired.
+     * A session is active if and only if its {@link VaadinSession#getState()}
+     * returns {@link State#OPEN} and
+     * {@link #getUidlRequestTimeout(VaadinSession) getUidlRequestTimeout} is
+     * negative or has not yet expired.
      *
      * @param session
      *            The session whose status to check
@@ -1458,8 +1460,8 @@ public abstract class VaadinService implements Serializable {
      * <p>
      * The framework collects filters from the {@link SessionInitEvent} where
      * session init listeners can add them. This method is called with the
-     * combined list to optionally modify it, and the result is then stored
-     * by the caller as the final list to use.
+     * combined list to optionally modify it, and the result is then stored by
+     * the caller as the final list to use.
      * <p>
      * The filters are called in the order the session init listeners are
      * called, which is undefined. If you need a specific order, you can

--- a/server/src/main/java/com/vaadin/server/VaadinServletRequest.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServletRequest.java
@@ -76,4 +76,24 @@ public class VaadinServletRequest extends HttpServletRequestWrapper
     public VaadinServletService getService() {
         return vaadinService;
     }
+
+    /**
+     * Gets the currently processed Vaadin servlet request. The current request
+     * is automatically defined when the request is started. The current request
+     * can not be used in e.g. background threads because of the way server
+     * implementations reuse request instances.
+     *
+     *
+     * @return the current Vaadin servlet request instance if available,
+     *         otherwise <code>null</code>
+     */
+    public static VaadinServletRequest getCurrent() {
+        VaadinRequest currentRequest = VaadinRequest.getCurrent();
+        if (currentRequest instanceof VaadinServletRequest) {
+            return (VaadinServletRequest) currentRequest;
+        } else {
+            return null;
+        }
+    }
+
 }

--- a/server/src/main/java/com/vaadin/server/VaadinServletRequest.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServletRequest.java
@@ -86,6 +86,7 @@ public class VaadinServletRequest extends HttpServletRequestWrapper
      *
      * @return the current Vaadin servlet request instance if available,
      *         otherwise <code>null</code>
+     * @since 8.1
      */
     public static VaadinServletRequest getCurrent() {
         VaadinRequest currentRequest = VaadinRequest.getCurrent();

--- a/server/src/main/java/com/vaadin/server/VaadinServletResponse.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServletResponse.java
@@ -90,6 +90,7 @@ public class VaadinServletResponse extends HttpServletResponseWrapper
      *
      * @return the current Vaadin servlet response instance if available,
      *         otherwise <code>null</code>
+     * @since 8.1
      */
     public static VaadinServletResponse getCurrent() {
         VaadinResponse currentResponse = VaadinResponse.getCurrent();

--- a/server/src/main/java/com/vaadin/server/VaadinServletResponse.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServletResponse.java
@@ -81,4 +81,23 @@ public class VaadinServletResponse extends HttpServletResponseWrapper
     public VaadinServletService getService() {
         return vaadinService;
     }
+
+    /**
+     * Gets the currently processed Vaadin servlet response. The current
+     * response is automatically defined when the request is started. The
+     * current response can not be used in e.g. background threads because of
+     * the way server implementations reuse response instances.
+     *
+     * @return the current Vaadin servlet response instance if available,
+     *         otherwise <code>null</code>
+     */
+    public static VaadinServletResponse getCurrent() {
+        VaadinResponse currentResponse = VaadinResponse.getCurrent();
+        if (currentResponse instanceof VaadinServletResponse) {
+            return (VaadinServletResponse) currentResponse;
+        } else {
+            return null;
+        }
+    }
+
 }

--- a/server/src/main/java/com/vaadin/server/VaadinServletService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServletService.java
@@ -209,16 +209,11 @@ public class VaadinServletService extends VaadinService {
     }
 
     public static HttpServletRequest getCurrentServletRequest() {
-        VaadinRequest currentRequest = VaadinService.getCurrentRequest();
-        if (currentRequest instanceof VaadinServletRequest) {
-            return (VaadinServletRequest) currentRequest;
-        } else {
-            return null;
-        }
+        return VaadinServletRequest.getCurrent();
     }
 
     public static VaadinServletResponse getCurrentResponse() {
-        return (VaadinServletResponse) VaadinService.getCurrentResponse();
+        return VaadinServletResponse.getCurrent();
     }
 
     @Override


### PR DESCRIPTION
This greatly improves discoverability of the feature and was made possible
by dropping Java 7 support

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9642)
<!-- Reviewable:end -->
