### PR TITLE
Tidy up the Vaadin OSGi whiteboard component

### DIFF
--- a/osgi-integration/pom.xml
+++ b/osgi-integration/pom.xml
@@ -56,7 +56,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The Vaadin OSGi integration component uses Declarative Services, but it does some odd things:
 * It uses the whiteboard service's own bundle context to get hold of the service instance
 * It has an asymmetric get/release for the whiteboard service, which could leak instances over time
 * It releases service instances that it is still actively using

This change tidies up the service lifecycle by delegating the get/release to the Service Component Runtime managing the container (specifically by injecting the service instance). Using this injection also ensures that the Vaadin whiteboard service is obtained using this component's bundle context.

This change also simplifies the code a little by using the reference as the key to track the registrations. Different references for the same service are required to be equal so there is no issue with doing this.

This change does not alter the fact that the whiteboard service's bundle context is used to register the Http Whiteboard servlet, as this may be the intended behaviour. As a result the component should be prepared for an IllegalStateException when unregistering the service whiteboard service, which may already have been unregistered by the OSGi framework if the target bundle is stopping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9648)
<!-- Reviewable:end -->
