### PR TITLE
More user friendly fail message (was NullPointerException)

### DIFF
--- a/server/src/test/java/com/vaadin/tests/CompileTransitionPropertyTest.java
+++ b/server/src/test/java/com/vaadin/tests/CompileTransitionPropertyTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.tests;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -31,8 +32,12 @@ public class CompileTransitionPropertyTest {
 
     @Test
     public void testCompilation() throws Exception {
+        String file = getClass().getResource("styles.scss").getFile();
+        if (file.contains("%20")) {
+            fail("path contains spaces, please move the project");
+        }
         ScssStylesheet ss = ScssStylesheet
-                .get(getClass().getResource("styles.scss").getFile());
+                .get(file);
         ss.compile();
         // extract the style rules for .my-label
         String compiled = ss.printState();


### PR DESCRIPTION
Yes, I should never have created "D:\eclipse workspaces" in the first
place.
No, I am not replacing "%20" with spaces, or creating an URI instance.
"D:\eclipse%20workspaces" is a valid folder and I'm not willing to go
down the rabbit hole and see what that turns into.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9665)
<!-- Reviewable:end -->
