### PR TITLE
Remove mention of height limitation in Tree

### DIFF
--- a/all/src/main/templates/release-notes.html
+++ b/all/src/main/templates/release-notes.html
@@ -124,7 +124,6 @@
                 Internet Explorer (Windows Phone, Surface)
                 (<a href="https://github.com/vaadin/framework/issues/5170">#5170</a>)
             </li>
-            <li>The new <tt>Tree</tt> component does not support height settings other than "undefined" - for scrolling and other heights, wrap the tree in a <tt>Panel</tt>.</li>
             <li>Payload based drop criteria do not work on IE11 - use criteria scripts if IE11 support of drop validation is required</li>
             <li>Specifying layout sizes using <tt>em</tt> is currently discouraged, because it results in fractional
             components sizes in many cases, which might cause unwanted 1px gaps between components.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9689)
<!-- Reviewable:end -->
