### PR TITLE
Fix TreeGrid.getHierarchyColumn to use correct id

### DIFF
--- a/server/src/main/java/com/vaadin/ui/TreeGrid.java
+++ b/server/src/main/java/com/vaadin/ui/TreeGrid.java
@@ -248,7 +248,7 @@ public class TreeGrid<T> extends Grid<T>
      *         has been explicitly set
      */
     public Column<T, ?> getHierarchyColumn() {
-        return getColumn(getState(false).hierarchyColumnId);
+        return getColumnByInternalId(getState(false).hierarchyColumnId);
     }
 
     /**

--- a/server/src/test/java/com/vaadin/tests/components/treegrid/TreeGridTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/treegrid/TreeGridTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import com.vaadin.data.TreeData;
 import com.vaadin.data.provider.TreeDataProvider;
+import com.vaadin.ui.Grid.Column;
 import com.vaadin.ui.TreeGrid;
 import com.vaadin.ui.renderers.TextRenderer;
 
@@ -14,6 +15,7 @@ public class TreeGridTest {
     private boolean expandEventFired = false;
     private boolean collapseEventFired = false;
 
+    @Test
     public void testChangeRendererOfHierarchyColumn() {
         treeGrid.addColumn(Object::toString).setId("foo");
         treeGrid.setHierarchyColumn("foo");
@@ -44,4 +46,14 @@ public class TreeGridTest {
         Assert.assertFalse("Item not collapsed", treeGrid.isExpanded("Foo"));
         Assert.assertTrue("Collapse event not fired", collapseEventFired);
     }
+
+    @Test
+    public void testSetAndGetHierarchyColumn() {
+        Column<String, String> column = treeGrid.addColumn(Object::toString)
+                .setId("foo");
+        treeGrid.setHierarchyColumn("foo");
+        Assert.assertEquals("Hierarchy column was not correctly returned",
+                column, treeGrid.getHierarchyColumn());
+    }
+
 }


### PR DESCRIPTION
Fixes #9661

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9690)
<!-- Reviewable:end -->
