### PR TITLE
Add API for forcing Grid column width calculation

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
@@ -241,6 +241,11 @@ public class GridConnector extends AbstractListingConnector
                     }
                 });
             }
+
+            @Override
+            public void recalculateColumnWidths() {
+                getWidget().recalculateColumnWidths();
+            }
         });
 
         getWidget().addSortHandler(this::handleSortEvent);

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -403,11 +403,12 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      *
      * <p>
      * Usage:
+     * 
      * <pre>
      * grid.addContextClickListener(event -&gt; Notification.show(
-     *       ((GridContextClickEvent&lt;Person&gt;)event).getItem() + " Clicked")
-     * );
+     *         ((GridContextClickEvent&lt;Person&gt;) event).getItem() + " Clicked"));
      * </pre>
+     * 
      * @param <T>
      *            the grid bean type
      */
@@ -2766,6 +2767,19 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
     }
 
     /**
+     * Requests that the column widths should be recalculated.
+     * <p>
+     * In most cases Grid will know when column widths need to be recalculated
+     * but this method can be used to force recalculation in situations when
+     * grid does not recalculate automatically.
+     *
+     * @since
+     */
+    public void recalculateColumnWidths() {
+        getRpcProxy(GridClientRpc.class).recalculateColumnWidths();
+    }
+
+    /**
      * Sets the details component generator.
      *
      * @param generator
@@ -3396,8 +3410,8 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      * happens.
      *
      * @param listener
-     *            the context click listener to add, not null
-     *            actual event provided to the listener is {@link GridContextClickEvent}
+     *            the context click listener to add, not null actual event
+     *            provided to the listener is {@link GridContextClickEvent}
      * @return a registration object for removing the listener
      *
      * @since 8.1
@@ -3405,7 +3419,8 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      * @see Registration
      */
     @Override
-    public Registration addContextClickListener(ContextClickEvent.ContextClickListener listener) {
+    public Registration addContextClickListener(
+            ContextClickEvent.ContextClickListener listener) {
         return super.addContextClickListener(listener);
     }
 

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -2773,7 +2773,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      * but this method can be used to force recalculation in situations when
      * grid does not recalculate automatically.
      *
-     * @since
+     * @since 8.1.1
      */
     public void recalculateColumnWidths() {
         getRpcProxy(GridClientRpc.class).recalculateColumnWidths();

--- a/shared/src/main/java/com/vaadin/shared/ui/grid/GridClientRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/grid/GridClientRpc.java
@@ -53,6 +53,8 @@ public interface GridClientRpc extends ClientRpc {
 
     /**
      * Command client Grid to recalculate column widths.
+     * 
+     * @since 8.1.1
      */
     public void recalculateColumnWidths();
 }

--- a/shared/src/main/java/com/vaadin/shared/ui/grid/GridClientRpc.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/grid/GridClientRpc.java
@@ -50,4 +50,9 @@ public interface GridClientRpc extends ClientRpc {
      * Command client Grid to scroll to the last row.
      */
     public void scrollToEnd();
+
+    /**
+     * Command client Grid to recalculate column widths.
+     */
+    public void recalculateColumnWidths();
 }


### PR DESCRIPTION
This feature was present in Vaadin 7 but missing from Vaadin 8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9756)
<!-- Reviewable:end -->
