### PR TITLE
Make input prompt test stable by excluding IE11

### DIFF
--- a/uitest/src/test/java/com/vaadin/tests/components/textfield/InputPromptAndCursorPositionTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/textfield/InputPromptAndCursorPositionTest.java
@@ -2,7 +2,10 @@ package com.vaadin.tests.components.textfield;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.List;
+
 import org.junit.Test;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.vaadin.testbench.elements.ButtonElement;
 import com.vaadin.testbench.elements.LabelElement;
@@ -10,6 +13,13 @@ import com.vaadin.testbench.elements.TextFieldElement;
 import com.vaadin.tests.tb3.MultiBrowserTest;
 
 public class InputPromptAndCursorPositionTest extends MultiBrowserTest {
+
+    @Override
+    public List<DesiredCapabilities> getBrowsersToTest() {
+        // IE11 has a known bug with placeholders:
+        // https://connect.microsoft.com/IE/feedback/details/811408
+        return getBrowsersExcludingIE();
+    }
 
     @Test
     public void verifyDatePattern() {


### PR DESCRIPTION
IE10-11 have a related bug
https://connect.microsoft.com/IE/feedback/details/811408
that is only fixed in Edge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9780)
<!-- Reviewable:end -->
