### PR TITLE
Fix SplitPanel test for Chrome with a hack

### DIFF
--- a/uitest/src/main/java/com/vaadin/tests/components/splitpanel/SplitPanelWithMinimumAndMaximum.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/splitpanel/SplitPanelWithMinimumAndMaximum.java
@@ -1,5 +1,6 @@
 package com.vaadin.tests.components.splitpanel;
 
+import com.vaadin.server.Page;
 import com.vaadin.server.Sizeable;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.tests.components.AbstractReindeerTestUI;
@@ -135,6 +136,10 @@ public class SplitPanelWithMinimumAndMaximum extends AbstractReindeerTestUI {
                 percentagePositionWithPixelLimitsHorizontalResersed);
 
         verticalLayout.setSizeFull();
+        // a hack for a Chrome 55+ issue (extra scrollbars) that is only seen on
+        // the testing cluster
+        Page.getCurrent().getStyles().add(
+                ".v-tabsheet-tabsheetpanel .v-scrollable { overflow: hidden }");
         tabs.addComponent(verticalLayout);
 
         HorizontalLayout horizontalLayout = new HorizontalLayout();


### PR DESCRIPTION
Chrome 55 and later cause extra scrollbars on the testing cluster but
not in local tests, probably due to a rounding error in the browser.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9782)
<!-- Reviewable:end -->
