### PR TITLE
Exclude Firefox from JavaScriptPreloadingTest

### DIFF
--- a/uitest/src/test/java/com/vaadin/tests/components/javascriptcomponent/JavaScriptPreloadingTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/javascriptcomponent/JavaScriptPreloadingTest.java
@@ -33,7 +33,9 @@ public class JavaScriptPreloadingTest extends MultiBrowserTest {
 
     @Override
     public List<DesiredCapabilities> getBrowsersToTest() {
-        return getBrowsersExcludingPhantomJS();
+        // the test works on Firefox under low load, but often fails under high
+        // load - seems to be a Firefox bug
+        return getBrowsersExcludingFirefox();
     }
 
     @Test

--- a/uitest/src/test/java/com/vaadin/tests/components/javascriptcomponent/JavaScriptPreloadingTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/javascriptcomponent/JavaScriptPreloadingTest.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import com.vaadin.testbench.parallel.Browser;
 import com.vaadin.tests.tb3.MultiBrowserTest;
 
 public class JavaScriptPreloadingTest extends MultiBrowserTest {
@@ -35,7 +36,7 @@ public class JavaScriptPreloadingTest extends MultiBrowserTest {
     public List<DesiredCapabilities> getBrowsersToTest() {
         // the test works on Firefox under low load, but often fails under high
         // load - seems to be a Firefox bug
-        return getBrowsersExcludingFirefox();
+        return getBrowserCapabilities(Browser.IE11, Browser.CHROME);
     }
 
     @Test


### PR DESCRIPTION
The test works on Firefox under low load, but not when
the browser VM is slow due to load, in which case Firefox
sometimes executes scripts out of order. This seems to be
due to a Firefox bug - the generated HTML looks correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9784)
<!-- Reviewable:end -->
