### PR TITLE
Fix caption width rounding in Chrome

### DIFF
--- a/client/src/main/java/com/vaadin/client/VCaption.java
+++ b/client/src/main/java/com/vaadin/client/VCaption.java
@@ -541,10 +541,10 @@ public class VCaption extends HTML {
         }
         if (captionText != null) {
             int textWidth = captionText.getScrollWidth();
-            if (BrowserInfo.get().isFirefox()) {
+            if (BrowserInfo.get().isFirefox() || BrowserInfo.get().isChrome()) {
                 /*
-                 * In Firefox3 the caption might require more space than the
-                 * scrollWidth returns as scrollWidth is rounded down.
+                 * The caption might require more space than the scrollWidth
+                 * returns as scrollWidth is rounded down.
                  */
                 int requiredWidth = WidgetUtil.getRequiredWidth(captionText);
                 if (requiredWidth > textWidth) {


### PR DESCRIPTION
Otherwise, TabSheet close button may break the small theme
in ReindeerThemeTest when the caption width is rounded down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9785)
<!-- Reviewable:end -->
