### PR TITLE
Remove margin-left for FontAwesome icons in ComboBox

### DIFF
--- a/all/src/main/templates/release-notes.html
+++ b/all/src/main/templates/release-notes.html
@@ -115,6 +115,7 @@
         <li>The <tt>HasValue</tt> interface now has an additional method <tt>getDefaultValidator()</tt> with a default implementation.</li>
         <li><tt>TreeGrid.createColumn()</tt> has an additional parameter.</li>
         <li><tt>LocalDateTimeToDateConverter</tt> now uses <tt>ZoneId</tt> instead of <tt>ZoneOffset</tt>.</li>
+        <li><tt>FontAwesome</tt> icon alignment in <tt>ComboBox</tt> has changed in the theme.</li>
 
         <h2>For incompatible or behaviour-altering changes in 8.0, please see <a href="https://vaadin.com/download/release/8.0/8.0.0/release-notes.html#incompatible">8.0 release notes</a></h2>
         

--- a/themes/src/main/themes/VAADIN/themes/valo/components/_combobox.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_combobox.scss
@@ -18,6 +18,10 @@
       position: absolute;
       pointer-events: none;
     }
+
+    .v-icon.FontAwesome {
+        margin-left: 0px;
+      }
   }
 
   .#{$primary-stylename}-error {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9805)
<!-- Reviewable:end -->
