### PR TITLE
Make CurrentTimeMillisTest more stable

### DIFF
--- a/uitest/src/test/java/com/vaadin/tests/CurrentTimeMillisTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/CurrentTimeMillisTest.java
@@ -51,13 +51,15 @@ public class CurrentTimeMillisTest extends MultiBrowserTest {
             time = time.substring(0, time.length() - 2);
         }
         if (highResTimeSupported) {
-            if (BrowserUtil.isChrome(getDesiredCapabilities())) {
+            if (BrowserUtil.isChrome(getDesiredCapabilities())
+                    || BrowserUtil.isFirefox(getDesiredCapabilities())) {
                 // Chrome (version 33 at least) sometimes doesn't use high res
-                // time if number of ms is less then 1
+                // time for very short times
                 Assert.assertTrue(
                         "High resolution time is not used in "
                                 + "JSON parsing mesurement. Time=" + time,
-                        time.equals("0") || time.indexOf('.') > 0);
+                        time.equals("0") || time.equals("1")
+                                || time.indexOf('.') > 0);
             } else {
                 Assert.assertTrue(
                         "High resolution time is not used in "

--- a/uitest/src/test/java/com/vaadin/tests/CurrentTimeMillisTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/CurrentTimeMillisTest.java
@@ -40,8 +40,9 @@ public class CurrentTimeMillisTest extends MultiBrowserTest {
         setDebug(true);
         openTestURL();
 
-        boolean highResTimeSupported = !BrowserUtil
-                .isPhantomJS(getDesiredCapabilities())
+        boolean phantomJs1 = BrowserUtil.isPhantomJS(getDesiredCapabilities())
+                && "1".equals(getDesiredCapabilities().getVersion());
+        boolean highResTimeSupported = !phantomJs1
                 && !BrowserUtil.isSafari(getDesiredCapabilities());
 
         String time = getJsonParsingTime();


### PR DESCRIPTION
Sometimes Chrome reports 1ms for very short times to thwart
timing attacks, and sometimes Firefox seems to report 0ms. Make
the test accept these special cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9812)
<!-- Reviewable:end -->
