### PR TITLE
Mark session as dirty on UI/session access

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinSession.java
+++ b/server/src/main/java/com/vaadin/server/VaadinSession.java
@@ -493,6 +493,15 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
     }
 
     /**
+     * Stores this VaadinSession in the HTTP or portlet session.
+     *
+     * @since
+     */
+    public void storeInSession() {
+        service.storeSession(this, session);
+    }
+
+    /**
      * Updates the transient session lock from VaadinService.
      */
     private void refreshLock() {
@@ -1361,9 +1370,14 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
             old = CurrentInstance.setCurrent(this);
             runnable.run();
         } finally {
-            unlock();
-            if (old != null) {
-                CurrentInstance.restoreInstances(old);
+            try {
+                // mark the session as dirty for clustering etc.
+                getService().storeSession(this, getSession());
+            } finally {
+                unlock();
+                if (old != null) {
+                    CurrentInstance.restoreInstances(old);
+                }
             }
         }
 

--- a/server/src/main/java/com/vaadin/ui/UI.java
+++ b/server/src/main/java/com/vaadin/ui/UI.java
@@ -1432,9 +1432,14 @@ public abstract class UI extends AbstractSingleComponentContainer
             old = CurrentInstance.setCurrent(this);
             runnable.run();
         } finally {
-            session.unlock();
-            if (old != null) {
-                CurrentInstance.restoreInstances(old);
+            try {
+                // mark the session as dirty for clustering etc.
+                session.storeInSession();
+            } finally {
+                session.unlock();
+                if (old != null) {
+                    CurrentInstance.restoreInstances(old);
+                }
             }
         }
 


### PR DESCRIPTION
This helps clustering solutions know when the session attribute needs
to be replicated instead of having to always aggressively replicate
all attributes.

Resolves #7535

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9818)
<!-- Reviewable:end -->
