### PR TITLE
Add docker feature to demo build script

### DIFF
--- a/scripts/BuildDemos.py
+++ b/scripts/BuildDemos.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 		log_status("BuildDemos depends on gitpython. Install it with `pip install gitpython`")
 		dump_status(True)
 		sys.exit(1)
-	from BuildHelpers import updateRepositories, mavenValidate, copyWarFiles, getLogFile, removeDir, getArgs, mavenInstall, resultPath, readPomFile, parser
+	from BuildHelpers import updateRepositories, mavenValidate, copyWarFiles, getLogFile, removeDir, getArgs, mavenInstall, resultPath, readPomFile, parser, dockerWrap
 	from DeployHelpers import deployWar
 	# Add command line agrument for ignoring failing demos
 	parser.add_argument("--ignore", type=str, help="Ignored demos", default="")
@@ -82,12 +82,16 @@ if __name__ == "__main__":
 			pass
 		print("")
 
-	for war in wars:
-		try:
-			deployWar(war)
-		except Exception as e:
-			log_status("War %s failed to deploy: %s" % (war, e))
-			demosFailed = True
+	if args.deploy_mode:
+		for war in wars:
+			try:
+				deployWar(war)
+			except Exception as e:
+				log_status("War %s failed to deploy: %s" % (war, e))
+				demosFailed = True
+	else:
+		dockerWrap(args.version)
+
 
 	if demosFailed:
 		dump_status(True)

--- a/scripts/BuildHelpers.py
+++ b/scripts/BuildHelpers.py
@@ -10,7 +10,6 @@ from shutil import copy, rmtree
 from glob import glob
 
 # Directory where the resulting war files are stored
-# TODO: deploy results
 resultPath = join("result", "demos")
 
 if not exists(resultPath):
@@ -39,26 +38,27 @@ def parseArgs():
 		args = parser.parse_args()
 	return args
 
-# Function for determining the path for maven executable
-def getMavenCommand():
+# Function for determining the path for an executable
+def getCommand(command):
 	# This method uses .split("\n")[0] which basically chooses the first result where/which returns.
 	# Fixes the case with multiple maven installations available on PATH
 	if platform.system() == "Windows":
 		try:
-			return subprocess.check_output(["where", "mvn.cmd"], universal_newlines=True).split("\n")[0]
+			return subprocess.check_output(["where", "%s.cmd" % (command)], universal_newlines=True).split("\n")[0]
 		except:
 			try:
-				return subprocess.check_output(["where", "mvn.bat"], universal_newlines=True).split("\n")[0]
+				return subprocess.check_output(["where", "%s.bat" % (command)], universal_newlines=True).split("\n")[0]
 			except:
-				print("Unable to locate mvn with where. Is the maven executable in your PATH?")
+				print("Unable to locate command %s with where. Is it in your PATH?" % (command))
 	else:
 		try:
-			return subprocess.check_output(["which", "mvn"], universal_newlines=True).split("\n")[0]
+			return subprocess.check_output(["which", command], universal_newlines=True).split("\n")[0]
 		except:
-			print("Unable to locate maven executable with which. Is the maven executable in your PATH?")
+			print("Unable to locate command %s with which. Is it in your PATH?" % (command))
 	return None
 
-mavenCmd = getMavenCommand()
+mavenCmd = getCommand("mvn")
+dockerCmd = getCommand("docker")
 
 # Get command line arguments. Parses arguments if needed.
 def getArgs():
@@ -176,3 +176,53 @@ def mavenInstall(pomFile, jarFile = None, mvnCmd = mavenCmd, logFile = sys.stdou
 	cmd.append("-DpomFile=%s" % (pomFile))
 	print("executing: %s" % (" ".join(cmd)))
 	subprocess.check_call(cmd, stdout=logFile)	
+
+def dockerWrap(imageVersion, imageName = "demo-validation"):
+	dockerFileContent = """FROM jetty:jre8-alpine
+MAINTAINER FrameworkTeam
+
+RUN apk add --update sed
+
+#Autodeploy folder:
+#/var/lib/jetty/webapps/
+
+COPY ./*.war /var/lib/jetty/webapps/
+COPY ./index-generate.sh /opt/
+RUN chmod +x /opt/index-generate.sh
+
+RUN /opt/index-generate.sh
+
+RUN mkdir -p /var/lib/jetty/webapps/root && \
+    cp /opt/index.html /var/lib/jetty/webapps/root && \
+    chmod 644 /var/lib/jetty/webapps/root/index.html
+
+EXPOSE 8080
+"""
+	indexGenerateScript = """#!/bin/ash
+
+wars="/var/lib/jetty/webapps"
+OUTPUT="/opt/index.html"
+
+echo "<UL>" > $OUTPUT
+cd $wars
+for war in `ls -1 *.war`; do
+  nowar=`echo "$war" | sed -e 's/\(^.*\)\(.war$\)/\\1/'`
+  echo "<LI><a href=\"/$nowar/\">$nowar</a></LI>" >> $OUTPUT
+done
+echo "</UL>" >> $OUTPUT
+"""
+	with open(join(resultPath, "Dockerfile"), "w") as dockerFile:
+		dockerFile.write(dockerFileContent)
+	with open(join(resultPath, "index-generate.sh"), "w") as indexScript:
+		indexScript.write(indexGenerateScript)
+	# build image
+	cmd = [dockerCmd, "build", "-t", "%s:%s" % (imageName, imageVersion), resultPath]
+	subprocess.check_call(cmd)
+	# save to tgz
+	cmd = [dockerCmd, "save", imageName]
+	dockerSave = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+	subprocess.check_call(["gzip"], stdin=dockerSave.stdout, stdout=open(join(resultPath, "%s-%s.tgz" % (imageName, imageVersion)), "w"))
+	dockerSave.wait()
+	# delete from docker
+	cmd = [dockerCmd, "rmi", "%s:%s" % (imageName, imageVersion)]
+	subprocess.check_call(cmd)

--- a/scripts/DeployHelpers.py
+++ b/scripts/DeployHelpers.py
@@ -14,9 +14,13 @@ from os.path import join, expanduser, basename
 from BuildHelpers import parser, getArgs
 from time import sleep
 
-parser.add_argument("--deployUrl", help="Wildfly management URL")
-parser.add_argument("--deployUser", help="Deployment user", default=None)
-parser.add_argument("--deployPass", help="Deployment password", default=None)
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument("--deploy", dest="deploy_mode", help="Deploy to a remote Wildfly instance", action="store_true")
+group.add_argument("--docker", dest="deploy_mode", help="Wrap results into a Docker image", action="store_false")
+
+parser.add_argument("--deployUrl", help="Wildfly management URL to use with --deploy")
+parser.add_argument("--deployUser", help="Deployment user to use with --deploy", default=None)
+parser.add_argument("--deployPass", help="Deployment password to use with --deploy", default=None)
 
 serverUp = None
 
@@ -120,4 +124,4 @@ def getAuth():
 # Read the deploy url file and return the url
 def getUrl():
 	return getArgs().deployUrl
-	
+


### PR DESCRIPTION
This patch allows the demo build script to wrap the resulting war files into docker image. The image contains a jetty with the provided war files deployed on start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9826)
<!-- Reviewable:end -->
