### PR TITLE
Exclude PhantomJS from flaky GridComponentsTest

### DIFF
--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridComponentsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridComponentsTest.java
@@ -14,12 +14,17 @@ import com.vaadin.testbench.elements.GridElement.GridCellElement;
 import com.vaadin.testbench.elements.GridElement.GridRowElement;
 import com.vaadin.testbench.elements.LabelElement;
 import com.vaadin.testbench.elements.NotificationElement;
+import com.vaadin.testbench.parallel.BrowserUtil;
 import com.vaadin.tests.tb3.MultiBrowserTest;
 
 public class GridComponentsTest extends MultiBrowserTest {
 
     @Test
     public void testReuseTextFieldOnScroll() {
+        if (BrowserUtil.isPhantomJS(getDesiredCapabilities())) {
+            // skip test on PhantomJS as it often crashes the browser
+            return;
+        }
         openTestURL();
         GridElement grid = $(GridElement.class).first();
         editTextFieldInCell(grid, 0, 1);


### PR DESCRIPTION
The test testReuseTextFieldOnScroll() often crashes PhantomJS 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9843)
<!-- Reviewable:end -->
