### PR TITLE
Prevent edit on non editable column

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -1557,6 +1557,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 throw new IllegalStateException(
                         "Cannot edit row: editor is not enabled");
             }
+            
+            // if column is not editable just return
+            Column<?, T> column = grid.getVisibleColumn(columnIndexDOM);
+            if(column != null && !column.isEditable()) {
+                return;
+            }
 
             if (isWorkPending()) {
                 // Request pending a response, don't move try to start another


### PR DESCRIPTION
Currently if user tries to edit a cell that is not editable (the corresponding column is not editable), the edit overlay is shown even if is not possible to edit that cell. This behavior is not desired so is better to prevent edit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9844)
<!-- Reviewable:end -->
