### PR TITLE
Store Vaadin session after each update

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinSession.java
+++ b/server/src/main/java/com/vaadin/server/VaadinSession.java
@@ -1035,6 +1035,10 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
                                         + ui.getUIId(),
                                 e);
                     }
+                    // Store session after modifications have been done so that
+                    // Spring Session and possibly other implementations realize
+                    // that something has changed inside the session attribute
+                    service.storeSession(this, session);
                 }
             }
         } finally {

--- a/server/src/main/java/com/vaadin/server/VaadinSession.java
+++ b/server/src/main/java/com/vaadin/server/VaadinSession.java
@@ -42,7 +42,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.portlet.PortletSession;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionBindingEvent;
 import javax.servlet.http.HttpSessionBindingListener;
@@ -56,8 +55,9 @@ import com.vaadin.util.ReflectTools;
 
 /**
  * Contains everything that Vaadin needs to store for a specific user. This is
- * typically stored in a {@link HttpSession} or {@link PortletSession}, but
- * others storage mechanisms might also be used.
+ * typically stored in a javax.servlet.http.HttpSession or
+ * javax.portlet.PortletSession, but others storage mechanisms might also be
+ * used.
  * <p>
  * Everything inside a {@link VaadinSession} should be serializable to ensure
  * compatibility with schemes using serialization for persisting the session


### PR DESCRIPTION
This helps clustering solutions know when the session attribute needs
to be replicated instead of having to always aggressively replicate
all attributes.

Resolves #7535

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9851)
<!-- Reviewable:end -->
