### PR TITLE
Fix item description tests on IE for RadioButtonGroup and CheckBoxGroup

### DIFF
--- a/uitest/src/test/java/com/vaadin/tests/components/checkboxgroup/CheckBoxGroupTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/checkboxgroup/CheckBoxGroupTest.java
@@ -292,4 +292,9 @@ public class CheckBoxGroupTest extends MultiBrowserTest {
         }
     }
 
+    // needed to make tooltips work in IE tests
+    @Override
+    protected boolean requireWindowFocusForIE() {
+        return true;
+    }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupTest.java
@@ -246,4 +246,10 @@ public class RadioButtonGroupTest extends MultiBrowserTest {
         }
         assertEquals("Number of items", count, i);
     }
+
+    // needed to make tooltips work in IE tests
+    @Override
+    protected boolean requireWindowFocusForIE() {
+        return true;
+    }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9866)
<!-- Reviewable:end -->
