### PR TITLE
Validator severity

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -263,7 +263,36 @@ public class Binder<BEAN> implements Serializable {
         public default BindingBuilder<BEAN, TARGET> withValidator(
                 SerializablePredicate<? super TARGET> predicate,
                 String message) {
-            return withValidator(Validator.from(predicate, message));
+            return withValidator(Validator.from(predicate, message, Severity.ERROR));
+        }
+        
+        /**
+         * A convenience method to add a validator to this binding using the
+         * {@link Validator#from(SerializablePredicate, String)} factory method.
+         * <p>
+         * Validators are applied, in registration order, when the field value
+         * is written to the backing property. If any validator returns a
+         * failure, the property value is not updated.
+         *
+         * @see #withValidator(Validator)
+         * @see #withValidator(SerializablePredicate, ErrorMessageProvider)
+         * @see Validator#from(SerializablePredicate, String)
+         *
+         * @param predicate
+         *            the predicate performing validation, not null
+         * @param message
+         *            the error message to report in case validation failure
+         * @param severity
+         *            the severity of the validation failure
+         * @return this binding, for chaining
+         * @throws IllegalStateException
+         *             if {@code bind} has already been called
+         * @since 8.2
+         */
+        public default BindingBuilder<BEAN, TARGET> withValidator(
+                SerializablePredicate<? super TARGET> predicate,
+                String message, Severity severity) {
+            return withValidator(Validator.from(predicate, message, severity));
         }
 
         /**
@@ -291,7 +320,38 @@ public class Binder<BEAN> implements Serializable {
                 SerializablePredicate<? super TARGET> predicate,
                 ErrorMessageProvider errorMessageProvider) {
             return withValidator(
-                    Validator.from(predicate, errorMessageProvider));
+                    Validator.from(predicate, errorMessageProvider, Severity.ERROR));
+        }
+        
+        /**
+         * A convenience method to add a validator to this binding using the
+         * {@link Validator#from(SerializablePredicate, ErrorMessageProvider)}
+         * factory method.
+         * <p>
+         * Validators are applied, in registration order, when the field value
+         * is written to the backing property. If any validator returns a
+         * failure, the property value is not updated.
+         *
+         * @see #withValidator(Validator)
+         * @see #withValidator(SerializablePredicate, String)
+         * @see Validator#from(SerializablePredicate, ErrorMessageProvider)
+         *
+         * @param predicate
+         *            the predicate performing validation, not null
+         * @param errorMessageProvider
+         *            the provider to generate error messages, not null
+         * @param severity
+         *            the severity of the validation failure
+         * @return this binding, for chaining
+         * @throws IllegalStateException
+         *             if {@code bind} has already been called
+         * @since 8.2
+         */
+        public default BindingBuilder<BEAN, TARGET> withValidator(
+                SerializablePredicate<? super TARGET> predicate,
+                ErrorMessageProvider errorMessageProvider, Severity severity) {
+            return withValidator(
+                    Validator.from(predicate, errorMessageProvider, severity));
         }
 
         /**
@@ -848,8 +908,8 @@ public class Binder<BEAN> implements Serializable {
         private BindingValidationStatus<TARGET> toValidationStatus(
                 Result<TARGET> result) {
             return new BindingValidationStatus<>(this,
-                    result.isError()
-                            ? ValidationResult.error(result.getMessage().get())
+                    result.hasMessage()
+                            ? ValidationResult.result(result.getMessage().get(), result.getSeverity())
                             : ValidationResult.ok());
         }
 
@@ -1538,6 +1598,32 @@ public class Binder<BEAN> implements Serializable {
 
     /**
      * A convenience method to add a validator to this binder using the
+     * {@link Validator#from(SerializablePredicate, String)} factory method.
+     * <p>
+     * Bean level validators are applied on the bean instance after the bean is
+     * updated. If the validators fail, the bean instance is reverted to its
+     * previous state.
+     *
+     * @see #writeBean(Object)
+     * @see #writeBeanIfValid(Object)
+     * @see #withValidator(Validator)
+     * @see #withValidator(SerializablePredicate, ErrorMessageProvider)
+     *
+     * @param predicate
+     *            the predicate performing validation, not null
+     * @param message
+     *            the error message to report in case validation failure
+     * @param severity 
+     *            the severity of the validation
+     * @return this binder, for chaining
+     */
+    public Binder<BEAN> withValidator(SerializablePredicate<BEAN> predicate,
+            String message, Severity severity) {
+        return withValidator(Validator.from(predicate, message, severity));
+    }
+
+    /**
+     * A convenience method to add a validator to this binder using the
      * {@link Validator#from(SerializablePredicate, ErrorMessageProvider)}
      * factory method.
      * <p>
@@ -1559,6 +1645,33 @@ public class Binder<BEAN> implements Serializable {
     public Binder<BEAN> withValidator(SerializablePredicate<BEAN> predicate,
             ErrorMessageProvider errorMessageProvider) {
         return withValidator(Validator.from(predicate, errorMessageProvider));
+    }
+    
+    /**
+     * A convenience method to add a validator to this binder using the
+     * {@link Validator#from(SerializablePredicate, ErrorMessageProvider)}
+     * factory method.
+     * <p>
+     * Bean level validators are applied on the bean instance after the bean is
+     * updated. If the validators fail, the bean instance is reverted to its
+     * previous state.
+     *
+     * @see #writeBean(Object)
+     * @see #writeBeanIfValid(Object)
+     * @see #withValidator(Validator)
+     * @see #withValidator(SerializablePredicate, String)
+     *
+     * @param predicate
+     *            the predicate performing validation, not null
+     * @param errorMessageProvider
+     *            the provider to generate error messages, not null
+     * @param severity
+     *            the severity of the validation 
+     * @return this binder, for chaining
+     */
+    public Binder<BEAN> withValidator(SerializablePredicate<BEAN> predicate,
+            ErrorMessageProvider errorMessageProvider, Severity severity) {
+        return withValidator(Validator.from(predicate, errorMessageProvider, severity));
     }
 
     /**
@@ -1604,6 +1717,63 @@ public class Binder<BEAN> implements Serializable {
         return validationStatus;
     }
 
+    /**
+     * Runs all currently configured field level validators, as well as all bean
+     * level validators if a bean is currently set with
+     * {@link #setBean(Object)}, and returns whether any of the validators
+     * produced informations.
+     *
+     * @return whether this binder validations produced infos.
+     * @throws IllegalStateException
+     *             if bean level validators have been configured and no bean is
+     *             currently set
+     * @since 8.2
+     */
+    public boolean hasInfos() {
+        if (getBean() == null && !validators.isEmpty()) {
+            throw new IllegalStateException("Cannot validate binder: "
+                    + "bean level validators have been configured "
+                    + "but no bean is currently set");
+        }
+        if (validateBindings().stream().filter(BindingValidationStatus::isInfo)
+                .findAny().isPresent()) {
+            return false;
+        }
+        if (getBean() != null && validateBean(getBean()).stream()
+                .filter(ValidationResult::isInfo).findAny().isPresent()) {
+            return false;
+        }
+        return true;
+    }
+    /**
+     * Runs all currently configured field level validators, as well as all bean
+     * level validators if a bean is currently set with
+     * {@link #setBean(Object)}, and returns whether any of the validators
+     * produced warnings.
+     *
+     * @return whether this binder validations produced warnings.
+     * @throws IllegalStateException
+     *             if bean level validators have been configured and no bean is
+     *             currently set
+     * @since 8.2
+     */
+    public boolean hasWarnings() {
+        if (getBean() == null && !validators.isEmpty()) {
+            throw new IllegalStateException("Cannot validate binder: "
+                    + "bean level validators have been configured "
+                    + "but no bean is currently set");
+        }
+        if (validateBindings().stream().filter(BindingValidationStatus::isWarn)
+                .findAny().isPresent()) {
+            return false;
+        }
+        if (getBean() != null && validateBean(getBean()).stream()
+                .filter(ValidationResult::isWarn).findAny().isPresent()) {
+            return false;
+        }
+        return true;
+    }
+    
     /**
      * Runs all currently configured field level validators, as well as all bean
      * level validators if a bean is currently set with
@@ -1870,11 +2040,10 @@ public class Binder<BEAN> implements Serializable {
      * @param error
      *            the error message to set
      */
-    protected void handleError(HasValue<?> field, String error) {
+    protected void handleError(HasValue<?> field, String error, BindingValidationStatus.Status status) {
         if (field instanceof AbstractComponent) {
-            ((AbstractComponent) field).setComponentError(new UserError(error));
+            ((AbstractComponent) field).setComponentError(new UserError(error, status.getErrorLevel()));
         }
-
     }
 
     /**
@@ -1887,9 +2056,11 @@ public class Binder<BEAN> implements Serializable {
     protected void handleValidationStatus(BindingValidationStatus<?> status) {
         HasValue<?> source = status.getField();
         clearError(source);
-        if (status.isError()) {
-            handleError(source, status.getMessage().get());
-        }
+        //TODO clear INFO
+        //TODO clear WARNINGS
+        if (status.hasMessage()) {
+            handleError(source, status.getMessage().get(), status.getStatus());
+        } 
     }
 
     /**

--- a/server/src/main/java/com/vaadin/data/Result.java
+++ b/server/src/main/java/com/vaadin/data/Result.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.data;
 
 import java.io.Serializable;
@@ -25,17 +24,13 @@ import com.vaadin.server.SerializableFunction;
 import com.vaadin.server.SerializableSupplier;
 
 /**
- * Represents the result of an operation that might fail, such as type
- * conversion. A result may contain either a value, signifying a successful
- * operation, or an error message in case of a failure.
+ * Represents the result of an operation that might fail, such as type conversion. A result may contain either a value, signifying a successful operation, or an error message in case of a failure.
  * <p>
- * Result instances are created using the factory methods {@link #ok(R)} and
- * {@link #error(String)}, denoting success and failure respectively.
+ * Result instances are created using the factory methods {@link #ok(R)} and {@link #error(String)}, denoting success and failure respectively.
  * <p>
  * Unless otherwise specified, {@code Result} method arguments cannot be null.
  *
- * @param <R>
- *            the result value type
+ * @param <R> the result value type
  *
  * @since 8.0
  */
@@ -44,10 +39,8 @@ public interface Result<R> extends Serializable {
     /**
      * Returns a successful result wrapping the given value.
      *
-     * @param <R>
-     *            the result value type
-     * @param value
-     *            the result value, can be null
+     * @param <R> the result value type
+     * @param value the result value, can be null
      * @return a successful result
      */
     public static <R> Result<R> ok(R value) {
@@ -57,29 +50,34 @@ public interface Result<R> extends Serializable {
     /**
      * Returns a failure result wrapping the given error message.
      *
-     * @param <R>
-     *            the result value type
-     * @param message
-     *            the error message
+     * @param <R> the result value type
+     * @param message the error message
      * @return a failure result
      */
     public static <R> Result<R> error(String message) {
         Objects.requireNonNull(message, "message cannot be null");
-        return new SimpleResult<>(null, message);
+        return new SimpleResult<>(null, message, Severity.ERROR);
     }
 
     /**
-     * Returns a Result representing the result of invoking the given supplier.
-     * If the supplier returns a value, returns a {@code Result.ok} of the
-     * value; if an exception is thrown, returns the message in a
-     * {@code Result.error}.
+     * Returns a failure result wrapping the given error message.
      *
-     * @param <R>
-     *            the result value type
-     * @param supplier
-     *            the supplier to run
-     * @param onError
-     *            the function to provide the error message
+     * @param <R> the result value type
+     * @param message the error message
+     * @param severity the severity of the error
+     * @return a failure result
+     */
+    public static <R> Result<R> error(String message, Severity severity) {
+        Objects.requireNonNull(message, "message cannot be null");
+        return new SimpleResult<>(null, message, severity);
+    }
+
+    /**
+     * Returns a Result representing the result of invoking the given supplier. If the supplier returns a value, returns a {@code Result.ok} of the value; if an exception is thrown, returns the message in a {@code Result.error}.
+     *
+     * @param <R> the result value type
+     * @param supplier the supplier to run
+     * @param onError the function to provide the error message
      * @return the result of invoking the supplier
      */
     public static <R> Result<R> of(SerializableSupplier<R> supplier,
@@ -95,15 +93,10 @@ public interface Result<R> extends Serializable {
     }
 
     /**
-     * If this Result has a value, returns a Result of applying the given
-     * function to the value. Otherwise, returns a Result bearing the same error
-     * as this one. Note that any exceptions thrown by the mapping function are
-     * not wrapped but allowed to propagate.
+     * If this Result has a value, returns a Result of applying the given function to the value. Otherwise, returns a Result bearing the same error as this one. Note that any exceptions thrown by the mapping function are not wrapped but allowed to propagate.
      *
-     * @param <S>
-     *            the type of the mapped value
-     * @param mapper
-     *            the mapping function
+     * @param <S> the type of the mapped value
+     * @param mapper the mapping function
      * @return the mapped result
      */
     public default <S> Result<S> map(SerializableFunction<R, S> mapper) {
@@ -111,27 +104,19 @@ public interface Result<R> extends Serializable {
     }
 
     /**
-     * If this Result has a value, applies the given Result-returning function
-     * to the value. Otherwise, returns a Result bearing the same error as this
-     * one. Note that any exceptions thrown by the mapping function are not
-     * wrapped but allowed to propagate.
+     * If this Result has a value, applies the given Result-returning function to the value. Otherwise, returns a Result bearing the same error as this one. Note that any exceptions thrown by the mapping function are not wrapped but allowed to propagate.
      *
-     * @param <S>
-     *            the type of the mapped value
-     * @param mapper
-     *            the mapping function
+     * @param <S> the type of the mapped value
+     * @param mapper the mapping function
      * @return the mapped result
      */
     public <S> Result<S> flatMap(SerializableFunction<R, Result<S>> mapper);
 
     /**
-     * Invokes either the first callback or the second one, depending on whether
-     * this Result denotes a success or a failure, respectively.
+     * Invokes either the first callback or the second one, depending on whether this Result denotes a success or a failure, respectively.
      *
-     * @param ifOk
-     *            the function to call if success
-     * @param ifError
-     *            the function to call if failure
+     * @param ifOk the function to call if success
+     * @param ifError the function to call if failure
      */
     public void handle(SerializableConsumer<R> ifOk,
             SerializableConsumer<String> ifError);
@@ -139,8 +124,7 @@ public interface Result<R> extends Serializable {
     /**
      * Applies the {@code consumer} if result is not an error.
      *
-     * @param consumer
-     *            consumer to apply in case it's not an error
+     * @param consumer consumer to apply in case it's not an error
      */
     public default void ifOk(SerializableConsumer<R> consumer) {
         handle(consumer, error -> {
@@ -150,8 +134,7 @@ public interface Result<R> extends Serializable {
     /**
      * Applies the {@code consumer} if result is an error.
      *
-     * @param consumer
-     *            consumer to apply in case it's an error
+     * @param consumer consumer to apply in case it's an error
      */
     public default void ifError(SerializableConsumer<String> consumer) {
         handle(value -> {
@@ -159,10 +142,43 @@ public interface Result<R> extends Serializable {
     }
 
     /**
+     * Checks if the result denotes the presence of a info, warning or errror.
+     *
+     * @return <code>true</code> if the result denotes an warning, <code>false</code> otherwise
+     * @since 8.2
+     */
+    public default boolean hasMessage() {
+        return isError();
+    }
+
+    /**
+     * Checks if the result denotes a info.
+     *
+     * @return <code>true</code> if the result denotes an info, <code>false</code> otherwise
+     * @since 8.2
+     */
+    public default boolean isInfo() {
+        return false;
+    }
+
+    /**
+     * Checks if the result denotes a warning.
+     *
+     * @return <code>true</code> if the result denotes an warning, <code>false</code> otherwise
+     * @since 8.2
+     */
+    public default boolean isWarn() {
+        return false;
+    }
+    
+    public default Severity getSeverity() {
+        return isError() ? Severity.ERROR : Severity.OK;
+    }
+
+    /**
      * Checks if the result denotes an error.
      *
-     * @return <code>true</code> if the result denotes an error,
-     *         <code>false</code> otherwise
+     * @return <code>true</code> if the result denotes an error, <code>false</code> otherwise
      */
     public boolean isError();
 
@@ -174,17 +190,12 @@ public interface Result<R> extends Serializable {
     public Optional<String> getMessage();
 
     /**
-     * Return the value, if the result denotes success, otherwise throw an
-     * exception to be created by the provided supplier.
+     * Return the value, if the result denotes success, otherwise throw an exception to be created by the provided supplier.
      *
-     * @param <X>
-     *            Type of the exception to be thrown
-     * @param exceptionProvider
-     *            The provider which will return the exception to be thrown
-     *            based on the given error message
+     * @param <X> Type of the exception to be thrown
+     * @param exceptionProvider The provider which will return the exception to be thrown based on the given error message
      * @return the value
-     * @throws X
-     *             if this result denotes an error
+     * @throws X if this result denotes an error
      */
     public <X extends Throwable> R getOrThrow(
             SerializableFunction<String, ? extends X> exceptionProvider)

--- a/server/src/main/java/com/vaadin/data/Severity.java
+++ b/server/src/main/java/com/vaadin/data/Severity.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.data;
+
+/**
+ * Defines the possible Severity levels that can be applied to validators.
+ * 
+ * @see Binder
+ * @see Validator
+ * @see ValidationResult
+ * 
+ * @author Stephan Knitelius {@literal <stephan@knitelius.com>}
+ * @since 8.2
+ */
+public enum Severity {
+    /** Level is irrelevant*/
+    OK(BindingValidationStatus.Status.OK), 
+    /** Info level - not error state.*/
+    INFO(BindingValidationStatus.Status.INFO), 
+    /** Warning - not error state.*/
+    WARN(BindingValidationStatus.Status.WARN), 
+    /** Info error, results in invalid state.*/
+    ERROR(BindingValidationStatus.Status.ERROR);
+    
+    private final BindingValidationStatus.Status status;
+    
+    private Severity(BindingValidationStatus.Status status) {
+        this.status = status;
+    }
+
+    public BindingValidationStatus.Status getStatus() {
+        return status;
+    }
+}

--- a/server/src/main/java/com/vaadin/data/SimpleResult.java
+++ b/server/src/main/java/com/vaadin/data/SimpleResult.java
@@ -33,7 +33,8 @@ class SimpleResult<R> implements Result<R> {
 
     private final R value;
     private final String message;
-
+    private final Severity severity;
+    
     /**
      * Creates a new {@link Result} instance using {@code value} for a non error
      * {@link Result} and {@code message} for an error {@link Result}.
@@ -48,10 +49,30 @@ class SimpleResult<R> implements Result<R> {
      */
     SimpleResult(R value, String message) {
         // value != null => message == null
+        this(value, message, message == null ? Severity.OK :Severity.ERROR);
+    }
+
+    /**
+     * Creates a new {@link Result} instance using {@code value} for a non error
+     * {@link Result} and {@code message} for an error {@link Result}.
+     * <p>
+     * If {@code message} is null then {@code value} is ignored and result is an
+     * error.
+     *
+     * @param value
+     *            the value of the result, may be {@code null}
+     * @param message
+     *            the error message of the result, may be {@code null}
+     * @param severity
+     *            the severity of the error message of the result
+     */
+    SimpleResult(R value, String message, Severity severity) {
+        // value != null => message == null
         assert value == null
                 || message == null : "Message must be null if value is provided";
         this.value = value;
         this.message = message;
+        this.severity = severity;
     }
 
     @Override
@@ -83,10 +104,25 @@ class SimpleResult<R> implements Result<R> {
     public Optional<String> getMessage() {
         return Optional.ofNullable(message);
     }
+    
+    @Override
+    public boolean isInfo() {
+        return Severity.INFO.equals(severity);
+    }
+    
+    @Override
+    public boolean isWarn() {
+        return Severity.WARN.equals(severity);
+    }
 
     @Override
     public boolean isError() {
         return message != null;
+    }
+    
+    @Override
+    public Severity getSeverity() {
+        return severity;
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/data/ValidationResult.java
+++ b/server/src/main/java/com/vaadin/data/ValidationResult.java
@@ -34,9 +34,16 @@ public interface ValidationResult extends Serializable {
 
     class SimpleValidationResult implements ValidationResult {
 
+        private final Severity severity; 
         private final String error;
 
         SimpleValidationResult(String error) {
+            this.severity = Severity.ERROR;
+            this.error = error;
+        }
+        
+        SimpleValidationResult(String error, Severity severity) {
+            this.severity = severity;
             this.error = error;
         }
 
@@ -52,9 +59,50 @@ public interface ValidationResult extends Serializable {
 
         @Override
         public boolean isError() {
-            return error != null;
+            return error != null && Severity.ERROR.equals(severity);
         }
 
+        @Override
+        public boolean isInfo() {
+            return Severity.INFO.equals(severity);
+        }
+        
+        @Override
+        public boolean isWarn() {
+            return Severity.WARN.equals(severity);
+        }
+        
+        @Override
+        public Severity getSeverity() {
+            return severity;
+        }
+
+    }
+    
+    public default Severity getSeverity() {
+      return Severity.ERROR;
+    }
+    
+    /**
+     * Checks if the result denotes an info.
+     *
+     * @return <code>true</code> if the result denotes an info,
+     *         <code>false</code> otherwise
+     * @since 8.2
+     */
+    public default boolean isInfo() {
+      return false;
+    }
+
+    /**
+     * Checks if the result denotes a warning.
+     *
+     * @return <code>true</code> if the result denotes an warning,
+     *         <code>false</code> otherwise
+     * @since 8.2
+     */
+    public default boolean isWarn() {
+      return false;
     }
 
     /**
@@ -65,6 +113,7 @@ public interface ValidationResult extends Serializable {
      * @return the error message
      * @throws IllegalStateException
      *             if the result represents success
+     * @since 8.2
      */
     String getErrorMessage();
 
@@ -75,6 +124,7 @@ public interface ValidationResult extends Serializable {
      *         <code>false</code> otherwise
      */
     boolean isError();
+    
 
     /**
      * Returns a successful result.
@@ -83,6 +133,22 @@ public interface ValidationResult extends Serializable {
      */
     public static ValidationResult ok() {
         return new SimpleValidationResult(null);
+    }
+
+    /**
+     * Creates the validation result which represent an error with the given
+     * {@code errorMessage}.
+     *
+     * @param errorMessage
+     *            error message, not {@code null}
+     * @return validation result which represent an error with the given
+     *         {@code errorMessage}
+     * @throws NullPointerException
+     *             if {@code errorMessage} is null
+     */
+    public static ValidationResult result(String message, Severity severity) {
+        Objects.requireNonNull(message);
+        return new SimpleValidationResult(message, severity);
     }
 
     /**

--- a/server/src/main/java/com/vaadin/data/Validator.java
+++ b/server/src/main/java/com/vaadin/data/Validator.java
@@ -138,8 +138,22 @@ public interface Validator<T>
         Objects.requireNonNull(errorMessage, "errorMessage cannot be null");
         return from(guard, ctx -> errorMessage, severity);
     }
-    
-    public static <T> Validator<T> from(SerializablePredicate guard, 
+
+    /**
+     * Builds a validator out of a conditional function and an error message
+     * provider. If the function returns true, the validator returns
+     * {@code Result.ok()}; if it returns false or throws an exception,
+     * {@code Result.error()} is returned with the message from the provider.
+     *
+     * @param <T>
+     *            the value type
+     * @param guard
+     *            the function used to validate, not null
+     * @param errorMessageProvider
+     *            the provider to generate error messages, not null
+     * @return the new validator using the function
+     */    
+    public static <T> Validator<T> from(SerializablePredicate<T> guard, 
             ErrorMessageProvider errorMessageProvider) {
         return from(guard, errorMessageProvider, Severity.ERROR);
     }

--- a/server/src/main/java/com/vaadin/data/Validator.java
+++ b/server/src/main/java/com/vaadin/data/Validator.java
@@ -107,6 +107,44 @@ public interface Validator<T>
     }
 
     /**
+     * Builds a validator out of a conditional function and an error message. If
+     * the function returns true, the validator returns {@code Result.ok()}; if
+     * it returns false or throws an exception,
+     * {@link ValidationResult#error(String)} is returned with the given
+     * message.
+     * <p>
+     * For instance, the following validator checks if a number is between 0 and
+     * 10, inclusive:
+     *
+     * <pre>
+     * Validator&lt;Integer&gt; v = Validator.from(num -&gt; num &gt;= 0 && num &lt;= 10,
+     *         "number must be between 0 and 10");
+     * </pre>
+     *
+     * @param <T>
+     *            the value type
+     * @param guard
+     *            the function used to validate, not null
+     * @param errorMessage
+     *            the message returned if validation fails, not null
+     * @param severity
+     *            the severity of the failed validation.
+     * @return the new validator using the function
+     * @since 8.2
+     */
+    public static <T> Validator<T> from(SerializablePredicate<T> guard,
+            String errorMessage, Severity severity) {
+        Objects.requireNonNull(guard, "guard cannot be null");
+        Objects.requireNonNull(errorMessage, "errorMessage cannot be null");
+        return from(guard, ctx -> errorMessage, severity);
+    }
+    
+    public static <T> Validator<T> from(SerializablePredicate guard, 
+            ErrorMessageProvider errorMessageProvider) {
+        return from(guard, errorMessageProvider, Severity.ERROR);
+    }
+    
+    /**
      * Builds a validator out of a conditional function and an error message
      * provider. If the function returns true, the validator returns
      * {@code Result.ok()}; if it returns false or throws an exception,
@@ -118,10 +156,13 @@ public interface Validator<T>
      *            the function used to validate, not null
      * @param errorMessageProvider
      *            the provider to generate error messages, not null
+     * @param severity
+     *            the severity of the failed validation.
      * @return the new validator using the function
+     * @since 8.2
      */
     public static <T> Validator<T> from(SerializablePredicate<T> guard,
-            ErrorMessageProvider errorMessageProvider) {
+            ErrorMessageProvider errorMessageProvider, Severity severity) {
         Objects.requireNonNull(guard, "guard cannot be null");
         Objects.requireNonNull(errorMessageProvider,
                 "errorMessageProvider cannot be null");

--- a/server/src/main/java/com/vaadin/server/AbstractErrorMessage.java
+++ b/server/src/main/java/com/vaadin/server/AbstractErrorMessage.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 import java.io.PrintWriter;
@@ -24,8 +23,7 @@ import java.util.List;
 /**
  * Base class for component error messages.
  *
- * This class is used on the server side to construct the error messages to send
- * to the client.
+ * This class is used on the server side to construct the error messages to send to the client.
  *
  * @since 7.0
  */
@@ -40,7 +38,6 @@ public abstract class AbstractErrorMessage implements ErrorMessage {
          * Content mode, where the error contains preformatted text.
          */
         PREFORMATTED,
-
         /**
          * Content mode, where the error contains HTML.
          *
@@ -61,11 +58,16 @@ public abstract class AbstractErrorMessage implements ErrorMessage {
     /**
      * Error level.
      */
-    private ErrorLevel level = ErrorLevel.ERROR;
+    private ErrorMessage.ErrorLevel level = ErrorMessage.ErrorLevel.ERROR;
 
     private final List<ErrorMessage> causes = new ArrayList<>();
 
     protected AbstractErrorMessage(String message) {
+        this(message, ErrorMessage.ErrorLevel.ERROR);
+    }
+
+    protected AbstractErrorMessage(String message, ErrorMessage.ErrorLevel level) {
+        this.level = level;
         this.message = message;
     }
 
@@ -79,11 +81,11 @@ public abstract class AbstractErrorMessage implements ErrorMessage {
 
     /* Documented in interface */
     @Override
-    public ErrorLevel getErrorLevel() {
+    public ErrorMessage.ErrorLevel getErrorLevel() {
         return level;
     }
 
-    public void setErrorLevel(ErrorLevel level) {
+    public void setErrorLevel(ErrorMessage.ErrorLevel level) {
         this.level = level;
     }
 
@@ -107,16 +109,16 @@ public abstract class AbstractErrorMessage implements ErrorMessage {
     public String getFormattedHtmlMessage() {
         String result = null;
         switch (getMode()) {
-        case TEXT:
-            result = VaadinServlet.safeEscapeForHtml(getMessage());
-            break;
-        case PREFORMATTED:
-            result = "<pre>" + VaadinServlet.safeEscapeForHtml(getMessage())
-                    + "</pre>";
-            break;
-        case HTML:
-            result = getMessage();
-            break;
+            case TEXT:
+                result = VaadinServlet.safeEscapeForHtml(getMessage());
+                break;
+            case PREFORMATTED:
+                result = "<pre>" + VaadinServlet.safeEscapeForHtml(getMessage())
+                        + "</pre>";
+                break;
+            case HTML:
+                result = getMessage();
+                break;
         }
         // if no message, combine the messages of all children
         if (null == result && null != getCauses() && getCauses().size() > 0) {

--- a/server/src/main/java/com/vaadin/server/ErrorMessage.java
+++ b/server/src/main/java/com/vaadin/server/ErrorMessage.java
@@ -83,19 +83,19 @@ public interface ErrorMessage extends Serializable {
     }
 
     /**
-     * @deprecated As of 7.0, use {@link ErrorLevel#SYSTEMERROR} instead Â  Â 
+     * @deprecated As of 7.0, use {@link ErrorLevel#SYSTEMERROR} instead
      */
     @Deprecated
     public static final ErrorLevel SYSTEMERROR = ErrorLevel.SYSTEMERROR;
 
     /**
-     * @deprecated As of 7.0, use {@link ErrorLevel#CRITICAL} instead Â  Â 
+     * @deprecated As of 7.0, use {@link ErrorLevel#CRITICAL} instead
      */
     @Deprecated
     public static final ErrorLevel CRITICAL = ErrorLevel.CRITICAL;
 
     /**
-     * @deprecated As of 7.0, use {@link ErrorLevel#ERROR} instead Â  Â 
+     * @deprecated As of 7.0, use {@link ErrorLevel#ERROR} instead
      */
 
     @Deprecated

--- a/server/src/main/java/com/vaadin/server/ErrorMessage.java
+++ b/server/src/main/java/com/vaadin/server/ErrorMessage.java
@@ -83,32 +83,32 @@ public interface ErrorMessage extends Serializable {
     }
 
     /**
-     * @deprecated As of 7.0, use {@link ErrorLevel#SYSTEMERROR} instead    
+     * @deprecated As of 7.0, use {@link ErrorLevel#SYSTEMERROR} instead Â  Â 
      */
     @Deprecated
     public static final ErrorLevel SYSTEMERROR = ErrorLevel.SYSTEMERROR;
 
     /**
-     * @deprecated As of 7.0, use {@link ErrorLevel#CRITICAL} instead    
+     * @deprecated As of 7.0, use {@link ErrorLevel#CRITICAL} instead Â  Â 
      */
     @Deprecated
     public static final ErrorLevel CRITICAL = ErrorLevel.CRITICAL;
 
     /**
-     * @deprecated As of 7.0, use {@link ErrorLevel#ERROR} instead    
+     * @deprecated As of 7.0, use {@link ErrorLevel#ERROR} instead Â  Â 
      */
 
     @Deprecated
     public static final ErrorLevel ERROR = ErrorLevel.ERROR;
 
     /**
-     * @deprecated As of 7.0, use {@link ErrorLevel#WARNING} instead    
+     * @deprecated As of 7.0, use {@link ErrorLevel#WARNING} instead Â  Â 
      */
     @Deprecated
     public static final ErrorLevel WARNING = ErrorLevel.WARNING;
 
     /**
-     * @deprecated As of 7.0, use {@link ErrorLevel#INFORMATION} instead    
+     * @deprecated As of 7.0, use {@link ErrorLevel#INFORMATION} instead Â  Â 
      */
     @Deprecated
     public static final ErrorLevel INFORMATION = ErrorLevel.INFORMATION;

--- a/server/src/main/java/com/vaadin/server/UserError.java
+++ b/server/src/main/java/com/vaadin/server/UserError.java
@@ -13,12 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.server;
 
 /**
- * <code>UserError</code> is a controlled error occurred in application. User
- * errors are occur in normal usage of the application and guide the user.
+ * <code>UserError</code> is a controlled error occurred in application. User errors are occur in normal usage of the application and guide the user.
  *
  * @author Vaadin Ltd.
  * @since 3.0
@@ -27,51 +25,57 @@ package com.vaadin.server;
 public class UserError extends AbstractErrorMessage {
 
     /**
-     * @deprecated As of 7.0, use {@link ContentMode#TEXT} instead    
+     * @deprecated As of 7.0, use {@link ContentMode#TEXT} instead Â  Â 
      */
     @Deprecated
-    public static final ContentMode CONTENT_TEXT = ContentMode.TEXT;
+    public static final AbstractErrorMessage.ContentMode CONTENT_TEXT = AbstractErrorMessage.ContentMode.TEXT;
 
     /**
-     * @deprecated As of 7.0, use {@link ContentMode#PREFORMATTED} instead    
+     * @deprecated As of 7.0, use {@link ContentMode#PREFORMATTED} instead Â  Â 
      */
     @Deprecated
-    public static final ContentMode CONTENT_PREFORMATTED = ContentMode.PREFORMATTED;
+    public static final AbstractErrorMessage.ContentMode CONTENT_PREFORMATTED = AbstractErrorMessage.ContentMode.PREFORMATTED;
 
     /**
-     * @deprecated As of 7.0, use {@link ContentMode#HTML} instead    
+     * @deprecated As of 7.0, use {@link ContentMode#HTML} instead Â  Â 
      */
     @Deprecated
-    public static final ContentMode CONTENT_XHTML = ContentMode.HTML;
+    public static final AbstractErrorMessage.ContentMode CONTENT_XHTML = AbstractErrorMessage.ContentMode.HTML;
 
     /**
      * Creates a textual error message of level ERROR.
      *
-     * @param textErrorMessage
-     *            the text of the error message.
+     * @param textErrorMessage the text of the error message.
      */
     public UserError(String textErrorMessage) {
         super(textErrorMessage);
     }
 
     /**
+     * Creates an error message with level.
+     *
+     * @param message the error message.
+     * @param errorLevel the level of error.
+     */
+    public UserError(String message, ErrorMessage.ErrorLevel errorLevel) {
+        this(message, null, errorLevel);
+    }
+
+    /**
      * Creates an error message with level and content mode.
      *
-     * @param message
-     *            the error message.
-     * @param contentMode
-     *            the content Mode.
-     * @param errorLevel
-     *            the level of error.
+     * @param message the error message.
+     * @param contentMode the content Mode.
+     * @param errorLevel the level of error.
      */
-    public UserError(String message, ContentMode contentMode,
-            ErrorLevel errorLevel) {
+    public UserError(String message, AbstractErrorMessage.ContentMode contentMode,
+            ErrorMessage.ErrorLevel errorLevel) {
         super(message);
         if (contentMode == null) {
-            contentMode = ContentMode.TEXT;
+            contentMode = AbstractErrorMessage.ContentMode.TEXT;
         }
         if (errorLevel == null) {
-            errorLevel = ErrorLevel.ERROR;
+            errorLevel = ErrorMessage.ErrorLevel.ERROR;
         }
         setMode(contentMode);
         setErrorLevel(errorLevel);


### PR DESCRIPTION
Allow the specification of Validator Severity level.

Example:

binder.forField(...).withValidator(o -> ..., "My Info message", Severity.INFO);

Info and Warn levels are not considered to cause an invalid state,  so that binder.isValid() will return true even when there are Warnings or Info messages. 

Validation messages are mapped to the respective ErrorMessage.ErrorLevel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9872)
<!-- Reviewable:end -->
