### PR TITLE
Required fields arn't marked when button with binder.isValid() is triggered

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1621,15 +1621,8 @@ public class Binder<BEAN> implements Serializable {
                     + "bean level validators have been configured "
                     + "but no bean is currently set");
         }
-        if (validateBindings().stream().filter(BindingValidationStatus::isError)
-                .findAny().isPresent()) {
-            return false;
-        }
-        if (getBean() != null && validateBean(getBean()).stream()
-                .filter(ValidationResult::isError).findAny().isPresent()) {
-            return false;
-        }
-        return true;
+        BinderValidationStatus<BEAN> validate = validate();
+        return validate.isOk();
     }
 
     /**


### PR DESCRIPTION
When someone presses a Button that relies on `binder.isValid()` prior to entering all required values, the action is blocked as expected.

However the fields which haven't been touched aren't marked red.

Current work around is to trigger `binder.validate()` in the button action, this marks all empty required fields as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9874)
<!-- Reviewable:end -->
