### PR TITLE
Omit duplicate caption for a Panel in a Composite

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/composite/CompositeConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/composite/CompositeConnector.java
@@ -116,4 +116,13 @@ public class CompositeConnector extends AbstractHasComponentsConnector
             ((DirectionalManagedLayout) childConnector).layoutVertically();
         }
     }
+
+    @Override
+    public boolean delegateCaptionHandling() {
+        if (!hasChildConnector()) {
+            return true;
+        } else {
+            return getChildConnector().delegateCaptionHandling();
+        }
+    }
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/composite/CompositePanelCaptionUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/composite/CompositePanelCaptionUI.java
@@ -1,0 +1,46 @@
+package com.vaadin.tests.components.composite;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Composite;
+import com.vaadin.ui.CustomComponent;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.Panel;
+import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.themes.ValoTheme;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class CompositePanelCaptionUI extends AbstractTestUI {
+    @Override
+    public void setup(VaadinRequest request) {
+        Panel regularPanel = new Panel("Regular ol' panel",
+                createPanelContent());
+        CustomComponentPanel customComponentPanel = new CustomComponentPanel();
+        CompositePanel compositePanel = new CompositePanel();
+
+        addComponents(regularPanel, customComponentPanel, compositePanel);
+    }
+
+    private VerticalLayout createPanelContent() {
+        Label helloWorld = new Label("Hello world!");
+        helloWorld.addStyleName(ValoTheme.LABEL_HUGE);
+
+        return new VerticalLayout(helloWorld);
+    }
+
+    private class CustomComponentPanel extends CustomComponent {
+        public CustomComponentPanel() {
+            Panel panel = new Panel("CustomComponentPanel",
+                    createPanelContent());
+            setCompositionRoot(panel);
+        }
+    }
+
+    private class CompositePanel extends Composite {
+        public CompositePanel() {
+            Panel panel = new Panel("CompositePanel", createPanelContent());
+            setCompositionRoot(panel);
+        }
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/composite/CompositePanelCaptionUITest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/composite/CompositePanelCaptionUITest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.components.composite;
+
+import org.junit.Test;
+
+import com.vaadin.testbench.By;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class CompositePanelCaptionUITest extends SingleBrowserTest {
+
+    @Test
+    public void compositeDoesNotDuplicateCaption() {
+        openTestURL();
+        assertElementNotPresent(By.className("v-caption"));
+    }
+}


### PR DESCRIPTION
Correctly render components that handle their own captions inside
a Composite.

Fixes #9848

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9890)
<!-- Reviewable:end -->
