### PR TITLE
Make BaseThemeTest more stable on IE11

### DIFF
--- a/uitest/src/test/java/com/vaadin/tests/components/uitest/ThemeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/uitest/ThemeTest.java
@@ -129,7 +129,8 @@ public abstract class ThemeTest extends MultiBrowserTest {
     private void testNotification(int id, String identifier)
             throws IOException {
         $(ButtonElement.class).id("notifButt" + id).click();
-        waitForElementPresent(By.className("v-Notification"));
+        // For some reason, this seems to be more reliable on IE11
+        waitUntil(driver -> isElementPresent(NotificationElement.class), 10);
         compareScreen(identifier);
         $(NotificationElement.class).first().close();
     }


### PR DESCRIPTION
Try to make the test more stable by using a different way of
detecting the presence of a notification. This approach is used e.g.
in GridComponentsTest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9906)
<!-- Reviewable:end -->
