### PR TITLE
Fix issue #1892: Uploading a large (artifical) file with Vaadin upload (com.vaadin.ui.upload)

### DIFF
--- a/server/src/main/java/com/vaadin/server/communication/FileUploadHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/FileUploadHandler.java
@@ -315,7 +315,7 @@ public class FileUploadHandler implements RequestHandler {
             readByte = stream.read();
         }
         byte[] bytes = bout.toByteArray();
-        return new String(bytes, 0, bytes.length - 1, UTF8);
+        return new String(bytes, UTF8);
     }
 
     /**


### PR DESCRIPTION
Fixes issue #1892:

https://docs.oracle.com/javase/7/docs/api/java/lang/String.html

Use this constructor:
String(byte[] bytes, Charset charset)
Constructs a new String by decoding the specified array of bytes using the specified charset.

Instead of this one:
String(byte[] bytes, int offset, int length, String charsetName)
Constructs a new String by decoding the specified subarray of bytes using the specified charset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9914)
<!-- Reviewable:end -->
