### PR TITLE
Remove scroll bar inherited borders and background for Tree (#9644)

### DIFF
--- a/themes/src/main/themes/VAADIN/themes/valo/components/_tree8.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_tree8.scss
@@ -61,4 +61,20 @@
     border-color: transparent;
     box-shadow: inset 0 0 0 1px valo-font-color($tree-sel-bg);
   }
+
+  // Scroll bar
+  .#{$primary-stylename}-scroller-vertical {
+    border: none;
+  }
+
+  .#{$primary-stylename}-scroller-horizontal {
+    border: none;
+  }
+
+  .#{$primary-stylename}-header-deco,
+  .#{$primary-stylename}-footer-deco,
+  .#{$primary-stylename}-horizontal-scrollbar-deco {
+    border: none;
+    background: transparent;
+  }
 }


### PR DESCRIPTION
Resolves #9644

Best to test with `TreeWideContent`

Mac Chrome:
<img width="223" alt="screen shot 2017-09-04 at 11 51 32" src="https://user-images.githubusercontent.com/15823229/30019127-227cfcf4-9168-11e7-9408-41d56b9396c2.png">

Windows Chrome:
<img width="232" alt="screen shot 2017-09-04 at 11 52 54" src="https://user-images.githubusercontent.com/15823229/30019157-36af0c44-9168-11e7-8922-d4f969be9eca.png">

Windows IE11:
<img width="230" alt="screen shot 2017-09-04 at 11 54 33" src="https://user-images.githubusercontent.com/15823229/30019162-3f68fdea-9168-11e7-838b-be8b3d38b8ef.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9924)
<!-- Reviewable:end -->
