### PR TITLE
Remove element explicitly when reordering tree grid rows

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -3898,8 +3898,12 @@ public class Escalator extends Widget
                 if (tr == focusedRow) {
                     insertFirst = true;
                 } else if (insertFirst) {
+                    // remove row explicitly to work around an IE11 bug (#9850)
+                    root.removeChild(tr);
                     root.insertFirst(tr);
                 } else {
+                    // remove row explicitly to work around an IE11 bug (#9850)
+                    root.removeChild(tr);
                     root.insertAfter(tr, focusedRow);
                 }
             }

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -3899,11 +3899,12 @@ public class Escalator extends Widget
                     insertFirst = true;
                 } else if (insertFirst) {
                     // remove row explicitly to work around an IE11 bug (#9850)
-                    root.removeChild(tr);
+                    if (BrowserInfo.get().isIE11() && tr
+                            .equals(root.getFirstChildElement())) {
+                        root.removeChild(tr);
+                    }
                     root.insertFirst(tr);
                 } else {
-                    // remove row explicitly to work around an IE11 bug (#9850)
-                    root.removeChild(tr);
                     root.insertAfter(tr, focusedRow);
                 }
             }

--- a/uitest/src/main/java/com/vaadin/tests/components/treegrid/TreeGridInWindow.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/treegrid/TreeGridInWindow.java
@@ -1,0 +1,35 @@
+package com.vaadin.tests.components.treegrid;
+
+import com.vaadin.data.TreeData;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.TreeGrid;
+import com.vaadin.ui.UI;
+import com.vaadin.ui.Window;
+
+public class TreeGridInWindow extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        TreeGrid<String> treeGrid = new TreeGrid<>();
+        treeGrid.addColumn(Object::toString).setCaption("Column");
+
+        TreeData<String> data = treeGrid.getTreeData();
+
+        data.addRootItems("parent");
+        data.addItems("parent", "child1", "child2");
+        data.addItems("child1", "grandchild1", "grandchild2");
+        data.addItems("child2", "grandchild3", "grandchild4");
+
+        treeGrid.expand("parent", "child1", "child2");
+
+        Window window = new Window("Window", treeGrid);
+
+        Button openWindow = new Button("Open window", event -> {
+            UI.getCurrent().addWindow(window);
+        });
+
+        getLayout().addComponent(openWindow);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridInWindowTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridInWindowTest.java
@@ -1,0 +1,33 @@
+package com.vaadin.tests.components.treegrid;
+
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.TreeGridElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class TreeGridInWindowTest extends MultiBrowserTest {
+
+    @Test
+    public void collapse_and_expand_first_child_multiple_times() {
+        setDebug(true);
+        openTestURL();
+
+        ButtonElement openWindowButton = $(ButtonElement.class).first();
+        openWindowButton.click();
+
+        TreeGridElement grid = $(TreeGridElement.class).first();
+
+        for (int i = 0; i < 10; i++) {
+            // Collapse first child node
+            grid.getExpandElement(1, 0).click();
+            waitUntil(webDriver -> grid.getRowCount() == 5);
+
+            // Expand first child node
+            grid.getExpandElement(1, 0).click();
+            waitUntil(webDriver -> grid.getRowCount() == 7);
+        }
+
+        assertNoErrorNotifications();
+    }
+}


### PR DESCRIPTION
Fixes #9850 

Under certain circumstances IE 11 (11.0.45 / 11.0.9600.18762) produces an exception when collapsing/expanding rows (particularly the first child after the very first element) in a `TreeGrid` within a `Window`.

This workaround removes the row explicitly before inserting, instead of letting JS handle it.

Can be tested with the example in #9850

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9952)
<!-- Reviewable:end -->
