### PR TITLE
Update Binder to display updated validation status

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1462,9 +1462,11 @@ public class Binder<BEAN> implements Serializable {
         // If no validation errors then update bean
         if (bindingStatuses.stream().filter(BindingValidationStatus::isError)
                 .findAny().isPresent()) {
-            fireStatusChangeEvent(true);
-            return new BinderValidationStatus<>(this, bindingStatuses,
+            BinderValidationStatus<BEAN> validationStatus = new BinderValidationStatus<>(this, bindingStatuses,
                     Collections.emptyList());
+            fireStatusChangeEvent(true);
+            getValidationStatusHandler().statusChange(validationStatus);
+            return validationStatus;
         }
 
         // Store old bean values so we can restore them if validators fail


### PR DESCRIPTION
Hello,

I have a strange behaviour. I use the binder with readbean and writeBeanIfValid.
doWriteIfValid doesn't show updated field status.
For example, an empty required field is not filled by default then the status is ok.
writeBeanIfValid return false but the field status is not updated on the screen (not in error).

Is it a correct behaviour ? (field statuses are not refreshed after writebeanIfValid) 

[MyUI.java.zip](https://github.com/vaadin/framework/files/1288352/MyUI.java.zip)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9953)
<!-- Reviewable:end -->
