### PR TITLE
Fixed incorrect resource name generation.

### DIFF
--- a/server/src/test/java/com/vaadin/server/AbstractClientConnectorTest.java
+++ b/server/src/test/java/com/vaadin/server/AbstractClientConnectorTest.java
@@ -162,7 +162,7 @@ public class AbstractClientConnectorTest {
             if (!name.startsWith("com.vaadin.")) {
                 return super.loadClass(name);
             }
-            String path = name.replaceAll("\\.", File.separator)
+            String path = name.replace('.', '/')
                     .concat(".class");
             URL resource = Thread.currentThread().getContextClassLoader()
                     .getResource(path);


### PR DESCRIPTION
@ahie @hesara The test introduced in https://github.com/vaadin/framework/commit/4ee3db95434518eb326da4f15670f7aa4dfe6687 fails on windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9957)
<!-- Reviewable:end -->
