### PR TITLE
Update application-errors.asciidoc

### DIFF
--- a/documentation/application/application-errors.asciidoc
+++ b/documentation/application/application-errors.asciidoc
@@ -70,8 +70,6 @@ the server.
 internalError:: A serious internal problem, possibly indicating a bug in Vaadin Client-Side
 Engine or in some custom client-side code.
 
-outOfSync:: The client-side state is invalid with respect to server-side state.
-
 cookiesDisabled:: Informs the user that cookies are disabled in the browser and the application
 does not work without them.
 


### PR DESCRIPTION
Update application-errors.asciidoc removing reference to outOfSync error
According to the latest version of that file the out-of-sync error is no longer contained:
https://github.com/vaadin/framework/blob/0924a9153c4c89366a4ad41b27e50ddfe1f68c22/server/src/main/java/com/vaadin/server/CustomizedSystemMessages.java

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9971)
<!-- Reviewable:end -->
