### PR TITLE
Fix generics type

### DIFF
--- a/uitest/src/main/java/com/vaadin/tests/components/table/Tables.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/Tables.java
@@ -855,7 +855,7 @@ public class Tables<T extends Table> extends AbstractSelectTestCase<T>
                 "Multi - ctrl/shift", new Command<T, SelectMode>() {
 
                     @Override
-                    public void execute(Table t, SelectMode value,
+                    public void execute(T t, SelectMode value,
                             Object data) {
                         switch (value) {
                         case NONE:


### PR DESCRIPTION
This fixes a compilation error with eclipse Oxygen:

> The method execute(Table, Tables.SelectMode, Object) of type new AbstractComponentTestCase.Command<T,Tables.SelectMode>(){} must override or implement a supertype method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9977)
<!-- Reviewable:end -->
