### PR TITLE
Fix varargs warnings

### DIFF
--- a/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/table/TableVisibleColumnsTest.java
+++ b/compatibility-server/src/test/java/com/vaadin/v7/tests/server/component/table/TableVisibleColumnsTest.java
@@ -41,8 +41,7 @@ public class TableVisibleColumnsTest {
         Table t = TableGeneratorTest.createTableWithDefaultContainer(3, 10);
 
         try {
-            t.setVisibleColumns(
-                    new Object[] { "a", "Property 2", "Property 3" });
+            t.setVisibleColumns("a", "Property 2", "Property 3");
             junit.framework.Assert.fail("IllegalArgumentException expected");
         } catch (IllegalArgumentException e) {
             // OK, expected
@@ -54,8 +53,8 @@ public class TableVisibleColumnsTest {
     public void duplicateVisibleColumnIds() {
         Table t = TableGeneratorTest.createTableWithDefaultContainer(3, 10);
         try {
-            t.setVisibleColumns(new Object[] { "Property 0", "Property 1",
-                    "Property 2", "Property 1" });
+            t.setVisibleColumns("Property 0", "Property 1",
+                    "Property 2", "Property 1");
         } catch (IllegalArgumentException e) {
             // OK, expected
         }
@@ -65,7 +64,7 @@ public class TableVisibleColumnsTest {
     @Test
     public void noVisibleColumns() {
         Table t = TableGeneratorTest.createTableWithDefaultContainer(3, 10);
-        t.setVisibleColumns(new Object[] {});
+        t.setVisibleColumns();
         assertArrayEquals(new Object[] {}, t.getVisibleColumns());
 
     }

--- a/uitest/src/main/java/com/vaadin/tests/components/table/ColumnWidthsAfterChangeTableColumnsCountOrOrder.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/ColumnWidthsAfterChangeTableColumnsCountOrOrder.java
@@ -40,8 +40,7 @@ public class ColumnWidthsAfterChangeTableColumnsCountOrOrder
                 new Button.ClickListener() {
                     @Override
                     public void buttonClick(Button.ClickEvent clickEvent) {
-                        table.setVisibleColumns(
-                                new Object[] { "name", "descr", "id" });
+                        table.setVisibleColumns("name", "descr", "id");
                         table.setColumnWidth("descr", NEW_COLUMN_WIDTH);
                     }
                 });

--- a/uitest/src/main/java/com/vaadin/tests/components/table/EditableTableLeak.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/EditableTableLeak.java
@@ -95,7 +95,7 @@ public class EditableTableLeak extends TestBase {
         table.setHeight("170px");
         table.setSelectable(true);
         table.setContainerDataSource(TestUtils.getISO3166Container());
-        table.setColumnHeaders(new String[] { "Country", "Code" });
+        table.setColumnHeaders("Country", "Code");
         table.setColumnAlignment(TestUtils.iso3166_PROPERTY_SHORT,
                 Table.ALIGN_CENTER);
         table.setColumnExpandRatio(TestUtils.iso3166_PROPERTY_NAME, 1);

--- a/uitest/src/main/java/com/vaadin/tests/components/table/EmptyRowsWhenScrolling.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/EmptyRowsWhenScrolling.java
@@ -90,8 +90,8 @@ public class EmptyRowsWhenScrolling extends UI {
             table.setContainerDataSource(container);
             table.setEditable(true);
             table.setColumnReorderingAllowed(true);
-            table.setVisibleColumns(new String[] { "image", "id", "col1",
-                    "col2", "col3", "col4" });
+            table.setVisibleColumns("image", "id", "col1",
+                    "col2", "col3", "col4");
             table.addGeneratedColumn("image", new ColumnGenerator() {
                 @Override
                 public Object generateCell(Table source, Object itemId,

--- a/uitest/src/main/java/com/vaadin/tests/components/table/ExpandingContainerVisibleRowRaceCondition.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/ExpandingContainerVisibleRowRaceCondition.java
@@ -51,7 +51,7 @@ public class ExpandingContainerVisibleRowRaceCondition extends UI {
         table.setId(TABLE);
         table.setCacheRate(0);
         table.setSizeFull();
-        table.setVisibleColumns(ExpandingContainer.PROPERTY_IDS
+        table.setVisibleColumns((Object[]) ExpandingContainer.PROPERTY_IDS
                 .toArray(new String[ExpandingContainer.PROPERTY_IDS.size()]));
 
         table.setCurrentPageFirstItemIndex(120);

--- a/uitest/src/main/java/com/vaadin/tests/components/table/HiddenColumnsExpandRatios.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/HiddenColumnsExpandRatios.java
@@ -46,7 +46,7 @@ public class HiddenColumnsExpandRatios extends TestBase {
             public void buttonClick(ClickEvent event) {
                 table.setWidth("100px");
                 table.setWidth("800px");
-                table.setVisibleColumns(new Object[] { "foo", "bar", "baz" });
+                table.setVisibleColumns("foo", "bar", "baz");
             }
         }));
     }

--- a/uitest/src/main/java/com/vaadin/tests/components/table/LargeSelectionCausesNPE.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/LargeSelectionCausesNPE.java
@@ -85,9 +85,8 @@ public class LargeSelectionCausesNPE extends TestBase {
             table.setColumnCollapsingAllowed(true);
 
             // set column headers
-            table.setVisibleColumns(new String[] { CODE, NAME, ID });
-            table.setColumnHeaders(
-                    new String[] { "DummyCode", "DummyName", "DummyId" });
+            table.setVisibleColumns(CODE, NAME, ID);
+            table.setColumnHeaders("DummyCode", "DummyName", "DummyId");
 
             // Column alignment
             table.setColumnAlignment(ID, Align.CENTER);

--- a/uitest/src/main/java/com/vaadin/tests/components/table/SetDataSourceWithPropertyIds.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/SetDataSourceWithPropertyIds.java
@@ -69,7 +69,7 @@ public class SetDataSourceWithPropertyIds extends AbstractReindeerTestUI {
         jobContainer.addAll(getBeanList());
         try {
             table.setContainerDataSource(jobContainer);
-            table.setVisibleColumns(new String[] { "jobId" });
+            table.setVisibleColumns("jobId");
             label.setValue("no Exception");
         } catch (CacheUpdateException e) {
             ArrayList<String> propertyIds = new ArrayList<>();

--- a/uitest/src/main/java/com/vaadin/tests/components/table/SetPageFirstItemLoadsNeededRowsOnly.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/SetPageFirstItemLoadsNeededRowsOnly.java
@@ -63,7 +63,7 @@ public class SetPageFirstItemLoadsNeededRowsOnly
         }
 
         final Table table = new Table("Beans", beans);
-        table.setVisibleColumns(new Object[] { "i" });
+        table.setVisibleColumns("i");
         layout.addComponent(table);
 
         table.setCurrentPageFirstItemIndex(table.size() - 1);

--- a/uitest/src/main/java/com/vaadin/tests/components/table/TableCacheMinimizingOnFetchRows.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/TableCacheMinimizingOnFetchRows.java
@@ -38,7 +38,7 @@ public class TableCacheMinimizingOnFetchRows extends AbstractTestUIWithLog {
 
         table.setContainerDataSource(beans);
         table.setPageLength(20);
-        table.setVisibleColumns(new Object[] { "name", "value" });
+        table.setVisibleColumns("name", "value");
         table.setWidth("800px");
 
         Button button = new Button("scroll down");

--- a/uitest/src/main/java/com/vaadin/tests/components/table/TableSorting.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/TableSorting.java
@@ -28,7 +28,7 @@ public class TableSorting extends TestBase {
         testTable.setImmediate(true);
         testTable.setSelectable(true);
         testTable.setMultiSelect(false);
-        testTable.setVisibleColumns(new Object[] { "testName" });
+        testTable.setVisibleColumns("testName");
 
         // Handle selection change.
         testTable.addListener(new Property.ValueChangeListener() {

--- a/uitest/src/main/java/com/vaadin/tests/components/table/TableToggleColumnVisibilityWidth.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/TableToggleColumnVisibilityWidth.java
@@ -56,10 +56,9 @@ public class TableToggleColumnVisibilityWidth extends AbstractReindeerTestUI {
             @Override
             public void buttonClick(ClickEvent event) {
                 if (detailed) {
-                    table.setVisibleColumns(new Object[] { "Name" });
+                    table.setVisibleColumns("Name");
                 } else {
-                    table.setVisibleColumns(
-                            new Object[] { "Name", "Last Name" });
+                    table.setVisibleColumns("Name", "Last Name");
                 }
                 detailed = !detailed;
             }

--- a/uitest/src/main/java/com/vaadin/tests/components/table/TableVisibleColumnsUpdate.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/TableVisibleColumnsUpdate.java
@@ -41,7 +41,7 @@ public class TableVisibleColumnsUpdate extends AbstractReindeerTestUI {
 
         addComponent(table);
 
-        table.setVisibleColumns(cols1);
+        table.setVisibleColumns((Object[]) cols1);
         // table.setColumnHeaders(headers1);
 
         Button updateButton = new Button("Change columns", new ClickListener() {

--- a/uitest/src/main/java/com/vaadin/tests/components/table/TableWithContainerRequiringEqualsForItemId.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/TableWithContainerRequiringEqualsForItemId.java
@@ -77,8 +77,7 @@ public class TableWithContainerRequiringEqualsForItemId
         }
 
         t.setContainerDataSource(container);
-        t.setVisibleColumns(
-                new Object[] { "id", "created", "name", "Actions" });
+        t.setVisibleColumns("id", "created", "name", "Actions");
 
         addComponent(t);
         addComponent(log);

--- a/uitest/src/main/java/com/vaadin/tests/components/treetable/TreeTableCacheOnPartialUpdates.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/treetable/TreeTableCacheOnPartialUpdates.java
@@ -123,9 +123,9 @@ public class TreeTableCacheOnPartialUpdates extends TestBase {
 
     private TreeTable treeTable;
     private BeanItemContainer<TestBean> testBeanContainer;
-    private static String[] columnHeaders = new String[] { "Col1", "Col2",
+    private static String[] columnHeaders = { "Col1", "Col2",
             "Col3", "Col4" };
-    private static Object[] visibleColumns = new Object[] { "col1", "col2",
+    private static Object[] visibleColumns = { "col1", "col2",
             "col3", "col4" };
 
     @Override

--- a/uitest/src/main/java/com/vaadin/tests/components/treetable/TreeTableExtraScrollbarWithChildren.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/treetable/TreeTableExtraScrollbarWithChildren.java
@@ -51,9 +51,9 @@ public class TreeTableExtraScrollbarWithChildren extends TestBase {
             table.addItem(child);
             table.setParent(child, parent);
         }
-        table.setVisibleColumns(new Object[] { "wordingTextId", "parameterId",
-                "parameterTypeId" });
-        table.setColumnHeaders(new String[] { "", "", "" });
+        table.setVisibleColumns("wordingTextId", "parameterId",
+                "parameterTypeId");
+        table.setColumnHeaders("", "", "");
         table.setHierarchyColumn("parameterId");
 
         layout.addComponent(table);

--- a/uitest/src/main/java/com/vaadin/tests/containers/filesystemcontainer/FileSystemContainerInTreeTable.java
+++ b/uitest/src/main/java/com/vaadin/tests/containers/filesystemcontainer/FileSystemContainerInTreeTable.java
@@ -47,7 +47,7 @@ public class FileSystemContainerInTreeTable extends TestBase {
             treeTable.setHeight("550px");
             treeTable.setContainerDataSource(fsc);
             treeTable.setItemIconPropertyId(FilesystemContainer.PROPERTY_ICON);
-            treeTable.setVisibleColumns(new String[] { "Name" });
+            treeTable.setVisibleColumns("Name");
             treeTable.setColumnWidth("Name", 400);
             treeTable.addListener(new ExpandListener() {
 

--- a/uitest/src/main/java/com/vaadin/tests/dd/TreeDragStart.java
+++ b/uitest/src/main/java/com/vaadin/tests/dd/TreeDragStart.java
@@ -139,7 +139,7 @@ public class TreeDragStart extends TestBase {
         final BeanItemContainer<InventoryObject> tableContainer = new BeanItemContainer<>(
                 collection);
         table.setContainerDataSource(tableContainer);
-        table.setVisibleColumns(new String[] { "name", "weight" });
+        table.setVisibleColumns("name", "weight");
         table.removeAllItems();
 
         // Allow the table to receive drops and handle them


### PR DESCRIPTION
Change callers to use varargs variant, and fix Eclipse warnings:

>Type String[] of the last argument to method setVisibleColumns(Object...) doesn't exactly match the vararg parameter type. Cast to Object[] to confirm the non-varargs invocation, or pass individual arguments of type Object for a varargs invocation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9980)
<!-- Reviewable:end -->
