### PR TITLE
Content mode for MenuBar items

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VMenuBar.java
+++ b/client/src/main/java/com/vaadin/client/ui/VMenuBar.java
@@ -831,6 +831,7 @@ public class VMenuBar extends SimpleFocusablePanel
         protected boolean checked = false;
         protected boolean selected = false;
         protected String description = null;
+        protected ContentMode contentMode = null;
 
         private String styleName;
 
@@ -1080,15 +1081,22 @@ public class VMenuBar extends SimpleFocusablePanel
                         MenuBarConstants.ATTRIBUTE_ITEM_DESCRIPTION);
             }
 
+            if (uidl.hasAttribute(
+                    MenuBarConstants.ATTRIBUTE_ITEM_CONTENT_MODE)) {
+                String contentModeString = uidl.getStringAttribute(
+                        MenuBarConstants.ATTRIBUTE_ITEM_CONTENT_MODE);
+                contentMode = ContentMode.valueOf(contentModeString);
+            }
+
             updateStyleNames();
         }
 
         public TooltipInfo getTooltip() {
-            if (description == null) {
+            if (description == null || contentMode == null) {
                 return null;
             }
 
-            return new TooltipInfo(description, ContentMode.PREFORMATTED, null,
+            return new TooltipInfo(description, contentMode, null,
                     this);
         }
 

--- a/server/src/main/java/com/vaadin/ui/MenuBar.java
+++ b/server/src/main/java/com/vaadin/ui/MenuBar.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import com.vaadin.shared.ui.ContentMode;
 import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
@@ -143,6 +144,13 @@ public class MenuBar extends AbstractComponent
                 target.addAttribute(MenuBarConstants.ATTRIBUTE_ITEM_DESCRIPTION,
                         description);
             }
+
+            ContentMode contentMode = item.getContentMode();
+            if (description != null && description.length() > 0) {
+                target.addAttribute(MenuBarConstants.ATTRIBUTE_ITEM_CONTENT_MODE,
+                        contentMode.name());
+            }
+
             if (item.isCheckable()) {
                 // if the "checked" attribute is present (either true or false),
                 // the item is checkable
@@ -460,6 +468,7 @@ public class MenuBar extends AbstractComponent
         private boolean isSeparator = false;
         private String styleName;
         private String description;
+        private ContentMode contentMode;
         private boolean checkable = false;
         private boolean checked = false;
 
@@ -785,6 +794,8 @@ public class MenuBar extends AbstractComponent
         }
 
         /**
+         * Analogous method to {@link AbstractComponent#setDescription(String)}
+         *
          * Sets the items's description. See {@link #getDescription()} for more
          * information on what the description is.
          *
@@ -792,7 +803,31 @@ public class MenuBar extends AbstractComponent
          *            the new description string for the component.
          */
         public void setDescription(String description) {
+            setDescription(description, ContentMode.PREFORMATTED);
+        }
+
+        /**
+         *
+         * Analogous method to {@link AbstractComponent#setDescription(String, ContentMode)}
+         *
+         * Sets the component's description using given content {@code mode}. See
+         * {@link #getDescription()} for more information on what the description
+         * is.
+         * <p>
+         * If the content {@code mode} is {@literal ContentMode.HTML} the
+         * description is displayed as HTML in tooltips or directly in certain
+         * components so care should be taken to avoid creating the possibility for
+         * HTML injection and possibly XSS vulnerabilities.
+         *
+         * @param description
+         *            the new description string for the component.
+         * @param mode
+         *            the content mode for the description
+         * @since 8.0
+         */
+        public void setDescription(String description, ContentMode mode) {
             this.description = description;
+            this.contentMode = mode;
             markAsDirty();
         }
 
@@ -854,6 +889,10 @@ public class MenuBar extends AbstractComponent
          */
         public String getDescription() {
             return description;
+        }
+
+        private ContentMode getContentMode() {
+            return contentMode;
         }
 
         /**
@@ -984,6 +1023,9 @@ public class MenuBar extends AbstractComponent
                 def.isChecked(), boolean.class, context);
         DesignAttributeHandler.writeAttribute("description", attr,
                 item.getDescription(), def.getDescription(), String.class,
+                context);
+        DesignAttributeHandler.writeAttribute("contentmode", attr,
+                item.getContentMode(), def.getContentMode(), ContentMode.class,
                 context);
         DesignAttributeHandler.writeAttribute("style-name", attr,
                 item.getStyleName(), def.getStyleName(), String.class, context);

--- a/server/src/test/java/com/vaadin/tests/components/menubar/MenuBarDeclarativeTest.java
+++ b/server/src/test/java/com/vaadin/tests/components/menubar/MenuBarDeclarativeTest.java
@@ -40,7 +40,7 @@ public class MenuBarDeclarativeTest extends DeclarativeTestBase<MenuBar> {
     public void testReadWrite() throws IOException {
         String design = "<vaadin-menu-bar auto-open tabindex=5>"
                 + "<menu checkable>Save</menu>"
-                + "<menu description='Open a file'>Open</menu>"
+                + "<menu contentmode='preformatted' description='Open a file'>Open</menu>"
                 + "<menu disabled>Close</menu>"
                 + "<menu icon='http://foo.bar/ico.png'>Help</menu>"
                 + "<menu visible='false'>About</menu>"
@@ -74,7 +74,7 @@ public class MenuBarDeclarativeTest extends DeclarativeTestBase<MenuBar> {
                 + "<menu icon=\"theme://../runo/icons/16/folder.png\">Open</menu>"
                 + "<menu separator />" + "<menu disabled>Exit</menu>"
                 + "<menu visible='false'>Not for everybody</menu>" + "</menu>"
-                + "<menu description=\"This contains many items in sub menus\">Other"
+                + "<menu contentmode='preformatted' description=\"This contains many items in sub menus\">Other"
                 + "<menu style-name=\"fancy\">Sub"
                 + "<menu checkable checked>Option 1 - no <b>html</b></menu>"
                 + "<menu checkable>Option 2</menu>"

--- a/shared/src/main/java/com/vaadin/shared/ui/menubar/MenuBarConstants.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/menubar/MenuBarConstants.java
@@ -24,6 +24,8 @@ public class MenuBarConstants implements Serializable {
     @Deprecated
     public static final String ATTRIBUTE_ITEM_DESCRIPTION = "description";
     @Deprecated
+    public static final String ATTRIBUTE_ITEM_CONTENT_MODE = "contentmode";
+    @Deprecated
     public static final String ATTRIBUTE_ITEM_ICON = "icon";
     @Deprecated
     public static final String ATTRIBUTE_ITEM_DISABLED = "disabled";


### PR DESCRIPTION
Adds the ability to set the content mode for the description of a `MenuItem` that is part of a `MenuBar`.

This functionality was already available for every `AbstractComponent` but missing for the menu items of menu bars.
If no content mode is specified it defaults to `ContentMode.PREFORMATTED`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9982)
<!-- Reviewable:end -->
