### PR TITLE
Upgrade maven-dependency and -source plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>3.0.1</version>
                     <configuration>
                         <outputDirectory>${dependency.unpack.directory}</outputDirectory>
                         <overWriteReleases>false</overWriteReleases>
@@ -438,7 +438,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>com.vaadin</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -137,7 +137,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>copy-font-icons</id>

--- a/testbench-api/pom.xml
+++ b/testbench-api/pom.xml
@@ -50,7 +50,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/themes/pom.xml
+++ b/themes/pom.xml
@@ -70,7 +70,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>copy-font-icons</id>


### PR DESCRIPTION
1. Upgrade `maven-dependency-plugin` to `3.0.1`, it was `2.10`, and referenced as `3.0.0`
2. Upgrade `maven-source-plugin` to `3.0.1`, it was `3.0.0`
3. Unify `javax.servlet-api` to `3.1.0`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9986)
<!-- Reviewable:end -->
