### PR TITLE
Remove drag and drop from Tree doc

### DIFF
--- a/documentation/components/components-tree.asciidoc
+++ b/documentation/components/components-tree.asciidoc
@@ -18,7 +18,6 @@ endif::web[]
 The [classname]#Tree# component allows a natural way to represent data that has hierarchical relationships.
 The user can drill down in the hierarchy by expanding items by clicking on the expand arrow, and likewise collapse items.
 [classname]#Tree# is a selection component that allows selecting items.
-It also supports drag and drop, so you can drag items to and from a tree, and drop them in the hierarchy.
 
 A typical use of the [classname]#Tree# component is for displaying a hierarchical menu, as illustrated in <<figure.components.tree>>, or for displaying file systems or hierarchical datasets.
 


### PR DESCRIPTION
Tree does not support drag and drop right now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9992)
<!-- Reviewable:end -->
