### PR TITLE
Implement hashCode() when implementing equals()

### DIFF
--- a/client/src/main/java/com/vaadin/client/WidgetUtil.java
+++ b/client/src/main/java/com/vaadin/client/WidgetUtil.java
@@ -1565,6 +1565,15 @@ public class WidgetUtil {
             return false;
         }
 
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + (int) value;
+            result = prime * result + ((unit == null) ? 0 : unit.hashCode());
+            return result;
+        }
+
         /**
          * Check whether the two sizes are equals.
          *

--- a/client/src/main/java/com/vaadin/client/ui/VComboBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VComboBox.java
@@ -229,6 +229,18 @@ public class VComboBox extends Composite implements Field, KeyDownHandler,
             }
             return true;
         }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + VComboBox.this.hashCode();
+            result = prime * result + ((key == null) ? 0 : key.hashCode());
+            result = prime * result + ((caption == null) ? 0 : caption.hashCode());
+            result = prime * result + ((untranslatedIconUri == null) ? 0 : untranslatedIconUri.hashCode());
+            result = prime * result + ((style == null) ? 0 : style.hashCode());
+            return result;
+        }
     }
 
     /** An inner class that handles all logic related to mouse wheel. */

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VFilterSelect.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VFilterSelect.java
@@ -227,6 +227,18 @@ public class VFilterSelect extends Composite
             }
             return true;
         }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + VFilterSelect.this.hashCode();
+            result = prime * result + ((key == null) ? 0 : key.hashCode());
+            result = prime * result + ((caption == null) ? 0 : caption.hashCode());
+            result = prime * result + ((untranslatedIconUri == null) ? 0 : untranslatedIconUri.hashCode());
+            result = prime * result + ((style == null) ? 0 : style.hashCode());
+            return result;
+        }
     }
 
     /** An inner class that handles all logic related to mouse wheel. */

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
@@ -7504,10 +7504,15 @@ public class VScrollTable extends FlowPanel
             return false;
         }
 
-        //
-        // public int hashCode() {
-        // return overkey;
-        // }
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((dropLocation == null) ? 0 : dropLocation.hashCode());
+            result = prime * result + overkey;
+            result = prime * result + ((colkey == null) ? 0 : colkey.hashCode());
+            return result;
+        }
     }
 
     public class VScrollTableDropHandler extends VAbstractDropHandler {

--- a/shared/src/main/java/com/vaadin/shared/communication/MethodInvocation.java
+++ b/shared/src/main/java/com/vaadin/shared/communication/MethodInvocation.java
@@ -108,8 +108,17 @@ public class MethodInvocation implements Serializable {
         if (!SharedUtil.equals(getParameters(), other.getParameters())) {
             return false;
         }
-
         return true;
+    }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((connectorId == null) ? 0 : connectorId.hashCode());
+        result = prime * result + ((interfaceName == null) ? 0 : interfaceName.hashCode());
+        result = prime * result + ((methodName == null) ? 0 : methodName.hashCode());
+        result = prime * result + Arrays.hashCode(parameters);
+        return result;
     }
 }


### PR DESCRIPTION
Whenever `.equals()` is overridden, `.hashCode()` should also be.

The implementation was generated by eclipse.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/9995)
<!-- Reviewable:end -->
