### PR TITLE
Show validation error selecting invalid date from DateField (#10011)

### DIFF
--- a/server/src/main/java/com/vaadin/ui/AbstractDateField.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractDateField.java
@@ -249,8 +249,8 @@ public abstract class AbstractDateField<T extends Temporal & TemporalAdjuster & 
                 if (newDateString == null || newDateString.isEmpty()) {
                     uiHasValidDateString = true;
                     currentParseErrorMessage = null;
-                    setValue(newDate, true);
                     setComponentError(null);
+                    setValue(newDate, true);
                 } else {
                     if (variables.get("lastInvalidDateString") != null) {
                         Result<T> parsedDate = handleUnparsableDateString(

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldValidationError.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldValidationError.java
@@ -1,6 +1,7 @@
 package com.vaadin.tests.components.datefield;
 
 import java.time.LocalDate;
+import java.util.Locale;
 
 import com.vaadin.annotations.Widgetset;
 import com.vaadin.data.Binder;
@@ -16,14 +17,15 @@ public class DateFieldValidationError extends AbstractTestUI {
     @Override
     protected void setup(VaadinRequest request) {
         DateField df = new DateField();
+        df.setLocale(Locale.US);
         Binder<Void> binder = new Binder<>();
         binder.forField(df)
             .withValidator(localDate -> localDate != null && localDate.isAfter(LocalDate.now()), "Invalid date")
             .bind(v -> LocalDate.now(), (v, t) -> {
-            /* NO-OP */ });
+            /* NO-OP */
+            });
         addComponent(df);
-        addComponent(new Button("Validate", e -> Notification
-                .show(binder.validate().isOk() ? "OK" : "Fail")));
+        addComponent(new Button("Validate", e -> Notification.show(binder.validate().isOk() ? "OK" : "Fail")));
     }
 
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldValidationError.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldValidationError.java
@@ -1,0 +1,29 @@
+package com.vaadin.tests.components.datefield;
+
+import java.time.LocalDate;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.data.Binder;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.DateField;
+import com.vaadin.ui.Notification;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class DateFieldValidationError extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        DateField df = new DateField();
+        Binder<Void> binder = new Binder<>();
+        binder.forField(df)
+            .withValidator(localDate -> localDate != null && localDate.isAfter(LocalDate.now()), "Invalid date")
+            .bind(v -> LocalDate.now(), (v, t) -> {
+            /* NO-OP */ });
+        addComponent(df);
+        addComponent(new Button("Validate", e -> Notification
+                .show(binder.validate().isOk() ? "OK" : "Fail")));
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldValidationErrorTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldValidationErrorTest.java
@@ -49,4 +49,9 @@ public class DateFieldValidationErrorTest extends MultiBrowserTest {
         waitUntil(driver -> "Invalid date".equals(getTooltipErrorElement().getText()));
     }
 
+    @Override
+    protected boolean requireWindowFocusForIE() {
+        return true;
+    }
+
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldValidationErrorTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldValidationErrorTest.java
@@ -1,0 +1,66 @@
+package com.vaadin.tests.components.datefield;
+
+import java.time.LocalDate;
+
+import com.gargoylesoftware.htmlunit.javascript.host.geo.Coordinates;
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.DateFieldElement;
+import com.vaadin.testbench.elements.NotificationElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.HasInputDevices;
+import org.openqa.selenium.interactions.Mouse;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+public class DateFieldValidationErrorTest extends MultiBrowserTest {
+
+    @Test
+    public void testComponentErrorShouldBeShownWhenEnteringInvalidDate() throws InterruptedException {
+        openTestURL();
+        DateFieldElement dateField = $(DateFieldElement.class).first();
+        dateField.getInputElement().sendKeys("01/01/01", Keys.TAB);
+
+        assertHasErrorMessage(dateField);
+    }
+
+    @Test
+    public void testComponentErrorShouldBeShownWhenSelectingInvalidDate() throws InterruptedException {
+        openTestURL();
+        DateFieldElement dateField = $(DateFieldElement.class).first();
+        dateField.setDate(LocalDate.now());
+        dateField.openPopup();
+        waitUntil(ExpectedConditions.visibilityOfElementLocated(By.className("v-datefield-popup")));
+
+        WebElement popup = findElement(com.vaadin.testbench.By.className("v-datefield-popup"));
+        // select day before today
+        WebElement popupBody = popup.findElement(By.className("v-datefield-calendarpanel"));
+        popupBody.sendKeys(Keys.ARROW_LEFT, Keys.ENTER);
+
+        // move focus away otherwise tooltip is not shown
+        dateField.getInputElement().sendKeys(Keys.TAB);
+
+        assertHasErrorMessage(dateField);
+    }
+
+    private void assertHasErrorMessage(DateFieldElement dateField) {
+        waitForElementPresent(By.className("v-errorindicator"));
+        dateField.showTooltip();
+
+        // Should wait some additional time otherwise sometimes
+        // in case of date selection tooltip does is not showns
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ignored) { }
+
+        WebElement errorMessage = findElement(By.cssSelector(".v-errormessage .gwt-HTML"));
+        Assert.assertEquals("Error message must be present", "Invalid date", errorMessage.getText());
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldValidationErrorTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldValidationErrorTest.java
@@ -2,21 +2,12 @@ package com.vaadin.tests.components.datefield;
 
 import java.time.LocalDate;
 
-import com.gargoylesoftware.htmlunit.javascript.host.geo.Coordinates;
-import com.vaadin.testbench.elements.ButtonElement;
 import com.vaadin.testbench.elements.DateFieldElement;
-import com.vaadin.testbench.elements.NotificationElement;
 import com.vaadin.tests.tb3.MultiBrowserTest;
-import com.vaadin.tests.tb3.SingleBrowserTest;
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.interactions.HasInputDevices;
-import org.openqa.selenium.interactions.Mouse;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class DateFieldValidationErrorTest extends MultiBrowserTest {
@@ -25,6 +16,7 @@ public class DateFieldValidationErrorTest extends MultiBrowserTest {
     public void testComponentErrorShouldBeShownWhenEnteringInvalidDate() throws InterruptedException {
         openTestURL();
         DateFieldElement dateField = $(DateFieldElement.class).first();
+        dateField.getInputElement().click();
         dateField.getInputElement().sendKeys("01/01/01", Keys.TAB);
 
         assertHasErrorMessage(dateField);
@@ -44,7 +36,9 @@ public class DateFieldValidationErrorTest extends MultiBrowserTest {
         popupBody.sendKeys(Keys.ARROW_LEFT, Keys.ENTER);
 
         // move focus away otherwise tooltip is not shown
-        dateField.getInputElement().sendKeys(Keys.TAB);
+        WebElement inputElement = dateField.getInputElement();
+        inputElement.click();
+        inputElement.sendKeys(Keys.TAB);
 
         assertHasErrorMessage(dateField);
     }
@@ -52,15 +46,7 @@ public class DateFieldValidationErrorTest extends MultiBrowserTest {
     private void assertHasErrorMessage(DateFieldElement dateField) {
         waitForElementPresent(By.className("v-errorindicator"));
         dateField.showTooltip();
-
-        // Should wait some additional time otherwise sometimes
-        // in case of date selection tooltip does is not showns
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException ignored) { }
-
-        WebElement errorMessage = findElement(By.cssSelector(".v-errormessage .gwt-HTML"));
-        Assert.assertEquals("Error message must be present", "Invalid date", errorMessage.getText());
+        waitUntil(driver -> "Invalid date".equals(getTooltipErrorElement().getText()));
     }
 
 }


### PR DESCRIPTION
Component error is cleared after selecting a date from
calendar popup, even if the date is invalid due to
validation errors or if user programmatically sets an UserError.

Actual code invokes setComponentError(null) after setValue() so
errors set by ValueChangeListeners get lost.
This change inverts the order of this two operation in order
to preserve errors set by ValueChangeListeners (ie Binder validators)

Change-Id: I7cf47d454e3a1d98cccb6253e60ce83bba95f40f

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10013)
<!-- Reviewable:end -->
