### PR TITLE
Add content disposition header to XHR file-upload using XHR2

### DIFF
--- a/client/src/main/java/com/vaadin/client/extensions/FileDropTargetConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/FileDropTargetConnector.java
@@ -198,8 +198,9 @@ public class FileDropTargetConnector extends DropTargetExtensionConnector {
         }
 
         public final native void postFile(File file) /*-{
-            this.setRequestHeader('Content-Type', 'multipart/form-data');
-            this.send(file);
+            var formData = new FormData();
+            formData.append("File", file);
+            this.send(formData);
         }-*/;
 
     }


### PR DESCRIPTION
- Some WAFs rely on the content disposition header in the upload
- Supported in most browsers http://caniuse.com/#search=XHR2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10016)
<!-- Reviewable:end -->
