### PR TITLE
Add `gwt-elemental` as a provided scope to `vaadin-server`

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -21,12 +21,6 @@
         <!-- Project modules -->
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>vaadin-shared</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>vaadin-server</artifactId>
             <version>${project.version}</version>
             <exclusions>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -80,6 +80,19 @@
             <artifactId>vaadin-icons</artifactId>
         </dependency>
 
+        <!-- GWT Elemental -->
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-elemental</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.gwt</groupId>
+                    <artifactId>gwt-user</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Jsoup for BootstrapHandler -->
         <dependency>
             <groupId>org.jsoup</groupId>


### PR DESCRIPTION
This is needed, as shown by Eclipse that `server` project has compilation failures.

The reason is that `AbstractClientConnector` references `element.json.JsonObject`, but `gwt-elemental` is not a transitive dependency from `shared` project to `server` project, so `server` doesn't see `gwt-elemental`.

Another thing: since `client` depends on `server`, then there is  no need to directly reference `gwt-elemental` or `shared`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10057)
<!-- Reviewable:end -->
