### PR TITLE
checkstyle end-of-line to be system-specific

### DIFF
--- a/checkstyle/vaadin-checkstyle.xml
+++ b/checkstyle/vaadin-checkstyle.xml
@@ -64,8 +64,8 @@
     </module>
     <module name="RegexpMultiline">
         <property name="message"
-            value="File contains carriage return (Windows newlines)" />
-        <property name="format" value="\r" />
+            value="File contains carriage return" />
+        <property name="format" value="system" />
     </module>
 
 

--- a/checkstyle/vaadin-checkstyle.xml
+++ b/checkstyle/vaadin-checkstyle.xml
@@ -62,12 +62,6 @@
     <module name="NewlineAtEndOfFile">
         <property name="severity" value="warning" />
     </module>
-    <module name="NewlineAtEndOfFile">
-        <property name="message"
-            value="File contains carriage return" />
-        <property name="lineSeparator" value="system" />
-    </module>
-
 
     <!-- Checks that property files contain the same keys. -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->

--- a/checkstyle/vaadin-checkstyle.xml
+++ b/checkstyle/vaadin-checkstyle.xml
@@ -62,10 +62,10 @@
     <module name="NewlineAtEndOfFile">
         <property name="severity" value="warning" />
     </module>
-    <module name="RegexpMultiline">
+    <module name="NewlineAtEndOfFile">
         <property name="message"
             value="File contains carriage return" />
-        <property name="format" value="system" />
+        <property name="lineSeparator" value="system" />
     </module>
 
 


### PR DESCRIPTION
After the last change of the `.gitattribute`, we should allow Windows users have their system-specific end-of-line

Please note it seems now Git detects a new change in line endings, if this is the case, then please some committer to replace all EOL globally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10060)
<!-- Reviewable:end -->
