### PR TITLE
Fix DataCommunicator parameter not used in Grid constructor (#10075)

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -2277,7 +2277,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
      * @since 8.0.7
      */
     protected Grid(Class<T> beanType, DataCommunicator<T> dataCommunicator) {
-        this(BeanPropertySet.get(beanType));
+        this(BeanPropertySet.get(beanType), dataCommunicator);
         this.beanType = beanType;
     }
 

--- a/server/src/test/java/com/vaadin/tests/server/component/grid/GridTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/grid/GridTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.data.provider.DataCommunicator;
 import org.easymock.Capture;
 import org.junit.Assert;
 import org.junit.Before;
@@ -68,6 +69,15 @@ public class GridTest {
         objectColumn = grid.addColumn(string -> new Object());
         randomColumn = grid.addColumn(ValueProvider.identity())
                 .setId("randomColumnId");
+    }
+
+    @Test
+    public void testCreateGridWithDataCommunicator() {
+        DataCommunicator specificDataCommunicator = new DataCommunicator<>();
+
+        TestGrid<String> grid = new TestGrid(String.class, specificDataCommunicator);
+
+        assertEquals(specificDataCommunicator, grid.getDataCommunicator());
     }
 
     @Test

--- a/server/src/test/java/com/vaadin/tests/server/component/grid/TestGrid.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/grid/TestGrid.java
@@ -1,0 +1,17 @@
+package com.vaadin.tests.server.component.grid;
+
+import com.vaadin.data.provider.DataCommunicator;
+import com.vaadin.ui.Grid;
+
+/**
+ * {@link Grid} class for testing purposes
+ * @param <T>
+ *            the grid bean type
+ */
+public class TestGrid<T> extends Grid<T> {
+
+    public TestGrid(Class<T> beanType, DataCommunicator<T> dataCommunicator) {
+        super(beanType, dataCommunicator);
+    }
+
+}


### PR DESCRIPTION
Fixes #9944

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10084)
<!-- Reviewable:end -->
