### PR TITLE
Add option to support null intermediate properties in NestedMethodProperty, for method setValue()

### DIFF
--- a/server/src/main/java/com/vaadin/data/util/NestedMethodProperty.java
+++ b/server/src/main/java/com/vaadin/data/util/NestedMethodProperty.java
@@ -245,6 +245,9 @@ public class NestedMethodProperty<T> extends AbstractProperty<T> {
             Object object = instance;
             for (int i = 0; i < getMethods.size() - 1; i++) {
                 object = getMethods.get(i).invoke(object);
+                if (object == null) {
+                    return;
+                }
             }
             setMethod.invoke(object, new Object[] { value });
         } catch (final InvocationTargetException e) {

--- a/server/src/test/java/com/vaadin/data/util/NestedMethodPropertyTest.java
+++ b/server/src/test/java/com/vaadin/data/util/NestedMethodPropertyTest.java
@@ -307,6 +307,12 @@ public class NestedMethodPropertyTest {
         Address address2 = new Address("Other street", 12345);
         addressProperty.setValue(address2);
         Assert.assertEquals("Other street", streetProperty.getValue());
+
+        Address address3 = null;
+        addressProperty.setValue(address3);
+        Assert.assertEquals(null, addressProperty.getValue());
+        streetProperty.setValue("Ruukinkatu");
+        Assert.assertEquals(null, streetProperty.getValue());
     }
 
     @Test


### PR DESCRIPTION
Currently, NestedMethodProperty.setValue() throws an exception if any intermediate property is null. In certain cases, it would be convenient to have an option to silently ignore request and do nothing in these cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10085)
<!-- Reviewable:end -->
