### PR TITLE
Store Vaadin session after each update

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinSession.java
+++ b/server/src/main/java/com/vaadin/server/VaadinSession.java
@@ -1035,6 +1035,10 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
                                         + ui.getUIId(),
                                 e);
                     }
+                    // Store session after modifications have been done so that
+                    // Spring Session and possibly other implementations realize
+                    // that something has changed inside the session attribute
+                    service.storeSession(this, session);
                 }
             }
         } finally {


### PR DESCRIPTION
This helps clustering solutions know when the session attribute needs
to be replicated instead of having to always aggressively replicate
all attributes.

Resolves #7535

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10093)
<!-- Reviewable:end -->
