### PR TITLE
Don't use synthetic methods for listener classes (Fixes #9504).

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -423,9 +423,11 @@ public class Binder<BEAN> implements Serializable {
                 TARGET nullRepresentation) {
             return withConverter(
                     fieldValue -> Objects.equals(fieldValue, nullRepresentation)
-                            ? null : fieldValue,
+                            ? null
+                            : fieldValue,
                     modelValue -> Objects.isNull(modelValue)
-                            ? nullRepresentation : modelValue);
+                            ? nullRepresentation
+                            : modelValue);
         }
 
         /**
@@ -1900,7 +1902,7 @@ public class Binder<BEAN> implements Serializable {
      */
     public Registration addStatusChangeListener(StatusChangeListener listener) {
         return getEventRouter().addListener(StatusChangeEvent.class, listener,
-                StatusChangeListener.class.getDeclaredMethods()[0]);
+                ReflectTools.getMethod(StatusChangeListener.class));
     }
 
     /**
@@ -1923,7 +1925,7 @@ public class Binder<BEAN> implements Serializable {
     public Registration addValueChangeListener(
             ValueChangeListener<?> listener) {
         return getEventRouter().addListener(ValueChangeEvent.class, listener,
-                ValueChangeListener.class.getDeclaredMethods()[0]);
+                ReflectTools.getMethod(ValueChangeListener.class));
     }
 
     /**
@@ -2158,7 +2160,8 @@ public class Binder<BEAN> implements Serializable {
         Converter<FIELDVALUE, FIELDVALUE> nullRepresentationConverter = Converter
                 .from(fieldValue -> fieldValue,
                         modelValue -> Objects.isNull(modelValue)
-                                ? field.getEmptyValue() : modelValue,
+                                ? field.getEmptyValue()
+                                : modelValue,
                         exception -> exception.getMessage());
         ConverterDelegate<FIELDVALUE> converter = new ConverterDelegate<>(
                 nullRepresentationConverter);

--- a/server/src/main/java/com/vaadin/ui/components/grid/EditorImpl.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/EditorImpl.java
@@ -37,6 +37,7 @@ import com.vaadin.ui.Component;
 import com.vaadin.ui.Grid;
 import com.vaadin.ui.Grid.AbstractGridExtension;
 import com.vaadin.ui.Grid.Column;
+import com.vaadin.util.ReflectTools;
 
 import elemental.json.JsonObject;
 
@@ -338,19 +339,19 @@ public class EditorImpl<T> extends AbstractGridExtension<T>
     @Override
     public Registration addSaveListener(EditorSaveListener<T> listener) {
         return eventRouter.addListener(EditorSaveEvent.class, listener,
-                EditorSaveListener.class.getDeclaredMethods()[0]);
+                ReflectTools.getMethod(EditorSaveListener.class));
     }
 
     @Override
     public Registration addCancelListener(EditorCancelListener<T> listener) {
         return eventRouter.addListener(EditorCancelEvent.class, listener,
-                EditorCancelListener.class.getDeclaredMethods()[0]);
+                ReflectTools.getMethod(EditorCancelListener.class));
     }
 
     @Override
     public Registration addOpenListener(EditorOpenListener<T> listener) {
         return eventRouter.addListener(EditorOpenEvent.class, listener,
-                EditorOpenListener.class.getDeclaredMethods()[0]);
+                ReflectTools.getMethod(EditorOpenListener.class));
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/components/grid/GridDragEndListener.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/GridDragEndListener.java
@@ -18,6 +18,7 @@ package com.vaadin.ui.components.grid;
 import java.lang.reflect.Method;
 
 import com.vaadin.event.ConnectorEventListener;
+import com.vaadin.util.ReflectTools;
 
 /**
  * Drop listener for HTML5 drop on a Grid row.
@@ -31,8 +32,8 @@ import com.vaadin.event.ConnectorEventListener;
 @FunctionalInterface
 public interface GridDragEndListener<T> extends ConnectorEventListener {
 
-    static final Method DRAG_END_METHOD = GridDragEndListener.class
-            .getDeclaredMethods()[0];
+    static final Method DRAG_END_METHOD = ReflectTools
+            .getMethod(GridDragEndListener.class);
 
     /**
      * Invoked when the user has dropped the dragged grid rows, or canceled the

--- a/server/src/main/java/com/vaadin/ui/components/grid/GridDragStartListener.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/GridDragStartListener.java
@@ -18,6 +18,7 @@ package com.vaadin.ui.components.grid;
 import java.lang.reflect.Method;
 
 import com.vaadin.event.ConnectorEventListener;
+import com.vaadin.util.ReflectTools;
 
 /**
  * Drag start listener for HTML5 drag start on a Grid row.
@@ -31,8 +32,8 @@ import com.vaadin.event.ConnectorEventListener;
 @FunctionalInterface
 public interface GridDragStartListener<T> extends ConnectorEventListener {
 
-    static final Method DRAG_START_METHOD = GridDragStartListener.class
-            .getDeclaredMethods()[0];
+    static final Method DRAG_START_METHOD = ReflectTools
+            .getMethod(GridDragStartListener.class);
 
     /**
      * Invoked when the user has started dragging grid's rows.

--- a/server/src/main/java/com/vaadin/ui/components/grid/GridDropListener.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/GridDropListener.java
@@ -18,6 +18,7 @@ package com.vaadin.ui.components.grid;
 import java.lang.reflect.Method;
 
 import com.vaadin.event.ConnectorEventListener;
+import com.vaadin.util.ReflectTools;
 
 /**
  * Drop listener for HTML5 drop on a Grid row.
@@ -31,8 +32,8 @@ import com.vaadin.event.ConnectorEventListener;
 @FunctionalInterface
 public interface GridDropListener<T> extends ConnectorEventListener {
 
-    static final Method DROP_METHOD = GridDropListener.class
-            .getDeclaredMethods()[0];
+    static final Method DROP_METHOD = ReflectTools
+            .getMethod(GridDropListener.class);
 
     /**
      * Called when drop event is fired on a Grid row.

--- a/server/src/main/java/com/vaadin/ui/components/grid/TreeGridDropListener.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/TreeGridDropListener.java
@@ -18,6 +18,7 @@ package com.vaadin.ui.components.grid;
 import java.lang.reflect.Method;
 
 import com.vaadin.event.ConnectorEventListener;
+import com.vaadin.util.ReflectTools;
 
 /**
  * Drop listener for HTML5 drop on a TreeGrid row.
@@ -31,8 +32,8 @@ import com.vaadin.event.ConnectorEventListener;
 @FunctionalInterface
 public interface TreeGridDropListener<T> extends ConnectorEventListener {
 
-    static final Method DROP_METHOD = TreeGridDropListener.class
-            .getDeclaredMethods()[0];
+    static final Method DROP_METHOD = ReflectTools
+            .getMethod(TreeGridDropListener.class);
 
     /**
      * Called when drop event is fired on a Grid row.

--- a/server/src/main/java/com/vaadin/ui/dnd/event/DragEndListener.java
+++ b/server/src/main/java/com/vaadin/ui/dnd/event/DragEndListener.java
@@ -20,28 +20,29 @@ import java.lang.reflect.Method;
 import com.vaadin.event.ConnectorEventListener;
 import com.vaadin.ui.AbstractComponent;
 import com.vaadin.ui.dnd.DragSourceExtension;
+import com.vaadin.util.ReflectTools;
 
 /**
- * Interface to be implemented when creating a dragend listener on a drag
- * source for HTML5 drag and drop.
+ * Interface to be implemented when creating a dragend listener on a drag source
+ * for HTML5 drag and drop.
  *
  * @param <T>
- *         Type of draggable component.
+ *            Type of draggable component.
  * @author Vaadin Ltd
  * @see DragSourceExtension#addDragEndListener(DragEndListener)
  * @since 8.1
  */
 @FunctionalInterface
-public interface DragEndListener<T extends AbstractComponent> extends
-        ConnectorEventListener {
-    static final Method DRAGEND_METHOD = DragEndListener.class
-            .getDeclaredMethods()[0];
+public interface DragEndListener<T extends AbstractComponent>
+        extends ConnectorEventListener {
+    static final Method DRAGEND_METHOD = ReflectTools
+            .getMethod(DragEndListener.class);
 
     /**
      * Called when dragend event is fired.
      *
      * @param event
-     *         Server side dragend event.
+     *            Server side dragend event.
      */
     void dragEnd(DragEndEvent<T> event);
 }

--- a/server/src/main/java/com/vaadin/ui/dnd/event/DragStartListener.java
+++ b/server/src/main/java/com/vaadin/ui/dnd/event/DragStartListener.java
@@ -20,28 +20,29 @@ import java.lang.reflect.Method;
 import com.vaadin.event.ConnectorEventListener;
 import com.vaadin.ui.AbstractComponent;
 import com.vaadin.ui.dnd.DragSourceExtension;
+import com.vaadin.util.ReflectTools;
 
 /**
  * Interface to be implemented when creating a dragstart listener on a drag
  * source for HTML5 drag and drop.
  *
  * @param <T>
- *         Type of draggable component.
+ *            Type of draggable component.
  * @author Vaadin Ltd
  * @see DragSourceExtension#addDragStartListener(DragStartListener)
  * @since 8.1
  */
 @FunctionalInterface
-public interface DragStartListener<T extends AbstractComponent> extends
-        ConnectorEventListener {
-    static final Method DRAGSTART_METHOD = DragStartListener.class
-            .getDeclaredMethods()[0];
+public interface DragStartListener<T extends AbstractComponent>
+        extends ConnectorEventListener {
+    static final Method DRAGSTART_METHOD = ReflectTools
+            .getMethod(DragStartListener.class);
 
     /**
      * Called when dragstart event is fired.
      *
      * @param event
-     *         Server side dragstart event.
+     *            Server side dragstart event.
      */
     void dragStart(DragStartEvent<T> event);
 }

--- a/server/src/main/java/com/vaadin/ui/dnd/event/DropListener.java
+++ b/server/src/main/java/com/vaadin/ui/dnd/event/DropListener.java
@@ -20,28 +20,29 @@ import java.lang.reflect.Method;
 import com.vaadin.event.ConnectorEventListener;
 import com.vaadin.ui.AbstractComponent;
 import com.vaadin.ui.dnd.DropTargetExtension;
+import com.vaadin.util.ReflectTools;
 
 /**
  * Interface to be implemented when creating a drop listener on a drop target
  * for HTML5 drag and drop.
  *
  * @param <T>
- *         Type of the drop target component.
+ *            Type of the drop target component.
  * @author Vaadin Ltd
  * @see DropTargetExtension#addDropListener(DropListener)
  * @since 8.1
  */
 @FunctionalInterface
-public interface DropListener<T extends AbstractComponent> extends
-        ConnectorEventListener {
-    static final Method DROP_METHOD = DropListener.class
-            .getDeclaredMethods()[0];
+public interface DropListener<T extends AbstractComponent>
+        extends ConnectorEventListener {
+    static final Method DROP_METHOD = ReflectTools
+            .getMethod(DropListener.class);
 
     /**
      * Called when drop event is fired.
      *
      * @param event
-     *         Server side drop event.
+     *            Server side drop event.
      */
     void drop(DropEvent<T> event);
 }

--- a/server/src/main/java/com/vaadin/util/ReflectTools.java
+++ b/server/src/main/java/com/vaadin/util/ReflectTools.java
@@ -82,9 +82,9 @@ public class ReflectTools implements Serializable {
      * @throws IllegalArgumentException
      *             If the value could not be retrieved
      */
-    public static Object getJavaFieldValue(Object object,
-            Field field) throws IllegalArgumentException,
-            IllegalAccessException, InvocationTargetException {
+    public static Object getJavaFieldValue(Object object, Field field)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException {
         PropertyDescriptor pd;
         try {
             pd = new PropertyDescriptor(field.getName(), object.getClass());
@@ -126,10 +126,9 @@ public class ReflectTools implements Serializable {
      * @throws IllegalArgumentException
      *             If the value could not be retrieved
      */
-    public static Object getJavaFieldValue(Object object,
-            Field field, Class<?> propertyType)
-            throws IllegalArgumentException, IllegalAccessException,
-            InvocationTargetException {
+    public static Object getJavaFieldValue(Object object, Field field,
+            Class<?> propertyType) throws IllegalArgumentException,
+            IllegalAccessException, InvocationTargetException {
         PropertyDescriptor pd;
         try {
             pd = new PropertyDescriptor(field.getName(), object.getClass());
@@ -173,10 +172,9 @@ public class ReflectTools implements Serializable {
      * @throws InvocationTargetException
      *             If the value could not be assigned to the field
      */
-    public static void setJavaFieldValue(Object object,
-            Field field, Object value)
-            throws IllegalAccessException, IllegalArgumentException,
-            InvocationTargetException {
+    public static void setJavaFieldValue(Object object, Field field,
+            Object value) throws IllegalAccessException,
+            IllegalArgumentException, InvocationTargetException {
         PropertyDescriptor pd;
         try {
             pd = new PropertyDescriptor(field.getName(), object.getClass());
@@ -322,4 +320,28 @@ public class ReflectTools implements Serializable {
         }
     }
 
+    /**
+     * Returns the first non-synthetic method of the specified
+     * {@code listenerClass}, which must have single method in the source-code.
+     * 
+     * This is needed, to remove the synthetic methods added if the class is
+     * instrumented.
+     * 
+     * @param listenerClass
+     *            The {@link Class} of the listener, which has a single method
+     *            in the source code
+     * @return the first non-synthetic method
+     * @throws IllegalStateException
+     *             if the specified class does not have found method
+     * @since
+     */
+    public static Method getMethod(Class<?> listenerClass) {
+        for (Method m : listenerClass.getDeclaredMethods()) {
+            if (!m.isSynthetic()) {
+                return m;
+            }
+        }
+        throw new IllegalStateException("Class " + listenerClass.getName()
+                + " does not have a method.");
+    }
 }


### PR DESCRIPTION
Providing test case is difficult, since we either need to provide an instrumented class as a binary file, loaded by JVM, or mock `Class.class`, which I couldn't do (even with `mockito` version 2).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10135)
<!-- Reviewable:end -->
