### PR TITLE
Remove checkstyle "FinalClass"

### DIFF
--- a/checkstyle/vaadin-checkstyle.xml
+++ b/checkstyle/vaadin-checkstyle.xml
@@ -241,7 +241,6 @@
         <module name="DesignForExtension">
             <property name="severity" value="ignore" />
         </module>
-        <module name="FinalClass" />
         <module name="HideUtilityClassConstructor" />
         <module name="InterfaceIsType" />
         <module name="VisibilityModifier">


### PR DESCRIPTION
Since #10051 was not accepted, then the corresponding checkstyle rule should be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10145)
<!-- Reviewable:end -->
