### PR TITLE
Fix HTML tags inside code in javadoc

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -1130,11 +1130,9 @@ public class Escalator extends Widget
         private int rows;
 
         /**
-         * The table section element ({@code <thead>}, {@code <tbody>} or
-         * {@code <tfoot>}) the rows (i.e. {@code
-         *
-        <tr>
-         * } tags) are contained in.
+         * The table section element (<code>&lt;thead&gt;</code>,
+         * <code>&lt;tbody&gt;</code> or <code>&lt;tfoot&gt;</code>) the rows
+         * (i.e. <code>&lt;tr&gt;</code> tags) are contained in.
          */
         protected final TableSectionElement root;
 
@@ -6793,7 +6791,7 @@ public class Escalator extends Widget
     }
 
     /**
-     * Returns the {@code <table />} element of the grid.
+     * Returns the <code>&lt;table /&gt;</code> element of the grid.
      *
      * @return the table element
      * @since 8.2

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -6791,10 +6791,7 @@ public class Escalator extends Widget
     }
 
     /**
-     * Returns the {@code 
-     * 
-    <table />
-     * } element of the grid.
+     * Returns the <code>&lt;table&gt;</code> element of the grid.
      *
      * @return the table element
      * @since 8.2

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -1130,9 +1130,9 @@ public class Escalator extends Widget
         private int rows;
 
         /**
-         * The table section element (<code>&lt;thead&gt;</code>,
-         * <code>&lt;tbody&gt;</code> or <code>&lt;tfoot&gt;</code>) the rows
-         * (i.e. <code>&lt;tr&gt;</code> tags) are contained in.
+         * The table section element ({@code <thead>}, {@code <tbody>} or
+         * {@code <tfoot>}) the rows (i.e. <code>&lt;tr&gt;</code> tags) are
+         * contained in.
          */
         protected final TableSectionElement root;
 
@@ -6791,7 +6791,10 @@ public class Escalator extends Widget
     }
 
     /**
-     * Returns the <code>&lt;table /&gt;</code> element of the grid.
+     * Returns the {@code 
+     * 
+    <table />
+     * } element of the grid.
      *
      * @return the table element
      * @since 8.2

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -6316,8 +6316,8 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     }
 
     /**
-     * Adds the given role as 'role="$param"' to the
-     * <code>&lt;table /&gt;</code> element of the grid.
+     * Adds the given role as 'role="$param"' to the <code>&lt;table&gt;</code>
+     * element of the grid.
      *
      * @param role
      *            the role param

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -5599,7 +5599,8 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
             boolean isSelected = hasData && isSelected(rowData);
             if (Grid.this.selectionModel.isSelectionAllowed()) {
-                rowElement.setAttribute("aria-selected", String.valueOf(isSelected));
+                rowElement.setAttribute("aria-selected",
+                        String.valueOf(isSelected));
             } else {
                 rowElement.removeAttribute("aria-selected");
             }
@@ -6315,13 +6316,14 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     }
 
     /**
-     * Adds the given role as 'role="$param"' to the {@code <table />} element
-     * of the grid.
+     * Adds the given role as 'role="$param"' to the
+     * <code>&lt;table /&gt;</code> element of the grid.
      *
-     * @param role the role param
+     * @param role
+     *            the role param
      * @since 8.2
      */
-    protected void setAriaRole(String role){
+    protected void setAriaRole(String role) {
         escalator.getTable().setAttribute("role", role);
     }
 

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Escalator.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Escalator.java
@@ -1124,11 +1124,9 @@ public class Escalator extends Widget
         private int rows;
 
         /**
-         * The table section element ({@code <thead>}, {@code <tbody>} or
-         * {@code <tfoot>}) the rows (i.e. {@code
-         *
-        <tr>
-         * } tags) are contained in.
+         * The table section element (<code>&lt;thead&gt;</code>,
+         * <code>&lt;tbody&gt;</code> or <code>&lt;tfoot&gt;</code>) the rows
+         * (i.e. <code>&lt;tr&gt;</code> tags) are contained in.
          */
         protected final TableSectionElement root;
 

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Escalator.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Escalator.java
@@ -1124,9 +1124,9 @@ public class Escalator extends Widget
         private int rows;
 
         /**
-         * The table section element (<code>&lt;thead&gt;</code>,
-         * <code>&lt;tbody&gt;</code> or <code>&lt;tfoot&gt;</code>) the rows
-         * (i.e. <code>&lt;tr&gt;</code> tags) are contained in.
+         * The table section element ({@code <thead>}, {@code <tbody>} or
+         * {@code <tfoot>}) the rows (i.e. <code>&lt;tr&gt;</code> tags) are
+         * contained in.
          */
         protected final TableSectionElement root;
 


### PR DESCRIPTION
Change `{@code }` to `<code>`, because Eclipse auto formatting doesn't handle HTML tags inside `{@code}`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10160)
<!-- Reviewable:end -->
