### PR TITLE
Fix wrong method name in Grid docs

### DIFF
--- a/documentation/components/components-grid.asciidoc
+++ b/documentation/components/components-grid.asciidoc
@@ -239,7 +239,7 @@ and column.
 
 [source, java]
 ----
-grid.addCellClickListener(event ->
+grid.addItemClickListener(event ->
     Notification.show("Value: " + event.getItem()));
 ----
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10171)
<!-- Reviewable:end -->
