### PR TITLE
Fix IDE usage of Elemental in vaadin-shared

### DIFF
--- a/checkstyle/vaadin-checkstyle.xml
+++ b/checkstyle/vaadin-checkstyle.xml
@@ -271,4 +271,8 @@
         
     </module>
 
+    <module name="SuppressionFilter">
+        <property name="file" value="${config_loc}/suppressions.xml" />
+    </module>
+
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -459,7 +459,7 @@
                         </dependency>
                     </dependencies>
                     <configuration>
-                        <propertyExpansion>config_loc=../checkstyle</propertyExpansion>
+                        <propertyExpansion>config_loc=${basedir}/../checkstyle</propertyExpansion>
                         <configLocation>../checkstyle/vaadin-checkstyle.xml</configLocation>
                         <headerLocation>../checkstyle/header</headerLocation>
 <!--                        <suppressionsLocation>../checkstyle/suppressions.xml</suppressionsLocation> -->

--- a/pom.xml
+++ b/pom.xml
@@ -459,9 +459,10 @@
                         </dependency>
                     </dependencies>
                     <configuration>
+                        <propertyExpansion>config_loc=../checkstyle</propertyExpansion>
                         <configLocation>../checkstyle/vaadin-checkstyle.xml</configLocation>
                         <headerLocation>../checkstyle/header</headerLocation>
-                        <suppressionsLocation>../checkstyle/suppressions.xml</suppressionsLocation>
+<!--                        <suppressionsLocation>../checkstyle/suppressions.xml</suppressionsLocation> -->
                         <encoding>UTF-8</encoding>
                         <consoleOutput>false</consoleOutput>
                         <failsOnError>false</failsOnError>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -80,6 +80,27 @@
                 </executions>
             </plugin>
 
+            <!-- Unpacked Dependencies as source -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+
+                <!-- Needs extra source folder for unpacked dependencies -->
+                <executions>
+                    <execution>
+                        <id>add-source-path</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${dependency.unpack.directory}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
This patch also fixes the Checkstyle suppressions usage for Eclipse.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10178)
<!-- Reviewable:end -->
