### PR TITLE
Improve role usage in grid

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -1140,6 +1140,7 @@ public class Escalator extends Widget
 
         public static final String GRID_ROLE_ROW="row";
         public static final String GRID_ROLE_ROWHEADER="rowheader";
+        public static final String GRID_ROLE_ROWGROUP="rowgroup";
         public static final String GRID_ROLE_CELL="gridcell";
         public static final String GRID_ROLE_COLUMNHEADER="columnheader";
 
@@ -1196,27 +1197,15 @@ public class Escalator extends Widget
         }
 
         /**
-         * Sets the role attribute '$attr' to the given rowElement.
+         * Sets the role attribute '$attr' to the given element.
          *
-         * @param rowElement row that should get the role attribute
-         * @param attr       attribute to be added
-         *
-         * @since 8.2
-         */
-        public void updateRoleRow(final TableRowElement rowElement, String attr) {
-            rowElement.setAttribute("role", attr);
-        }
-
-        /**
-         * Sets the role attribute '$attr' to the given cellElement.
-         *
-         * @param cellElement cell that should get the role attribute
+         * @param element     element that should get the role attribute
          * @param attr        attribute to be added
          *
          * @since 8.2
          */
-        public void updateRoleCell(final TableCellElement cellElement, String attr) {
-            cellElement.setAttribute("role", attr);
+        public void updateRole(final Element element, String attr) {
+            element.setAttribute("role", attr);
         }
     }
 
@@ -1248,6 +1237,7 @@ public class Escalator extends Widget
 
         public AbstractRowContainer(final TableSectionElement rowContainerElement) {
             root = rowContainerElement;
+            ariaGridHelper.updateRole(root, AriaGridHelper.GRID_ROLE_ROWGROUP);
         }
 
         @Override
@@ -1534,7 +1524,7 @@ public class Escalator extends Widget
                 final TableRowElement tr = TableRowElement.as(DOM.createTR());
                 addedRows.add(tr);
                 tr.addClassName(getStylePrimaryName() + "-row");
-                ariaGridHelper.updateRoleRow(tr, getRowElementRole());
+                ariaGridHelper.updateRole(tr, getRowElementRole());
 
                 for (int col = 0; col < columnConfiguration
                         .getColumnCount(); col++) {
@@ -1542,7 +1532,7 @@ public class Escalator extends Widget
                             .getColumnWidthActual(col);
                     final TableCellElement cellElem = createCellElement(colWidth);
                     tr.appendChild(cellElem);
-                    ariaGridHelper.updateRoleCell(cellElem, getCellElementRole());
+                    ariaGridHelper.updateRole(cellElem, getCellElementRole());
 
                     // Set stylename and position if new cell is frozen
                     if (col < columnConfiguration.frozenColumns) {

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -1138,6 +1138,11 @@ public class Escalator extends Widget
      */
     public class AriaGridHelper {
 
+        public static final String GRID_ROLE_ROW="row";
+        public static final String GRID_ROLE_ROWHEADER="rowheader";
+        public static final String GRID_ROLE_CELL="gridcell";
+        public static final String GRID_ROLE_COLUMNHEADER="columnheader";
+
         /**
          * This field contains the total number of rows from the grid
          * including rows from thead, tbody and tfoot.
@@ -1191,25 +1196,27 @@ public class Escalator extends Widget
         }
 
         /**
-         * Sets the role attribute 'row' to the given rowElement.
+         * Sets the role attribute '$attr' to the given rowElement.
          *
          * @param rowElement row that should get the role attribute
+         * @param attr       attribute to be added
          *
          * @since 8.2
          */
-        public void updateRoleRow(final TableRowElement rowElement) {
-            rowElement.setAttribute("role", "row");
+        public void updateRoleRow(final TableRowElement rowElement, String attr) {
+            rowElement.setAttribute("role", attr);
         }
 
         /**
-         * Sets the role attribute 'gridcell' to the given cellElement.
+         * Sets the role attribute '$attr' to the given cellElement.
          *
          * @param cellElement cell that should get the role attribute
+         * @param attr        attribute to be added
          *
          * @since 8.2
          */
-        public void updateRoleCell(final TableCellElement cellElement) {
-            cellElement.setAttribute("role", "gridcell");
+        public void updateRoleCell(final TableCellElement cellElement, String attr) {
+            cellElement.setAttribute("role", attr);
         }
     }
 
@@ -1260,6 +1267,34 @@ public class Escalator extends Widget
          * @see #createCellElement(double)
          */
         protected abstract String getCellElementTagName();
+
+        /**
+         * Gets the role attribute of an element to represent a cell in a row.
+         * <p>
+         * Usually {@link AriaGridHelper#GRID_ROLE_CELL} except for a cell in
+         * the header.
+         *
+         * @return the role attribute for the element to represent cells
+         *
+         * @since 8.2
+         */
+        protected String getCellElementRole() {
+            return AriaGridHelper.GRID_ROLE_CELL;
+        }
+
+        /**
+         * Gets the role attribute of an element to represent a row in a grid.
+         * <p>
+         * Usually {@link AriaGridHelper#GRID_ROLE_ROW} except for a row in
+         * the header.
+         *
+         * @return the role attribute for the element to represent rows
+         *
+         * @since 8.2
+         */
+        protected String getRowElementRole() {
+            return AriaGridHelper.GRID_ROLE_ROW;
+        }
 
         @Override
         public EscalatorUpdater getEscalatorUpdater() {
@@ -1499,7 +1534,7 @@ public class Escalator extends Widget
                 final TableRowElement tr = TableRowElement.as(DOM.createTR());
                 addedRows.add(tr);
                 tr.addClassName(getStylePrimaryName() + "-row");
-                ariaGridHelper.updateRoleRow(tr);
+                ariaGridHelper.updateRoleRow(tr, getRowElementRole());
 
                 for (int col = 0; col < columnConfiguration
                         .getColumnCount(); col++) {
@@ -1507,7 +1542,7 @@ public class Escalator extends Widget
                             .getColumnWidthActual(col);
                     final TableCellElement cellElem = createCellElement(colWidth);
                     tr.appendChild(cellElem);
-                    ariaGridHelper.updateRoleCell(cellElem);
+                    ariaGridHelper.updateRoleCell(cellElem, getCellElementRole());
 
                     // Set stylename and position if new cell is frozen
                     if (col < columnConfiguration.frozenColumns) {
@@ -2443,6 +2478,16 @@ public class Escalator extends Widget
         @Override
         protected String getCellElementTagName() {
             return "th";
+        }
+
+        @Override
+        protected String getRowElementRole() {
+            return AriaGridHelper.GRID_ROLE_ROWHEADER;
+        }
+
+        @Override
+        protected String getCellElementRole() {
+            return AriaGridHelper.GRID_ROLE_COLUMNHEADER;
         }
 
         @Override

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -1194,12 +1194,12 @@ public class Escalator extends Widget
          * Sets the role attribute {@code roleName} to the given element.
          *
          * @param element     element that should get the role attribute
-         * @param roleName    roleName to be added
+         * @param role        role to be added
          *
          * @since
          */
-        public void updateRole(final Element element, AriaGridRoles roleName) {
-            element.setAttribute("role", roleName.getRoleName());
+        public void updateRole(final Element element, AriaGridRole role) {
+            element.setAttribute("role", role.getRoleName());
         }
     }
 
@@ -1208,7 +1208,7 @@ public class Escalator extends Widget
      *
      * @since
      */
-    private enum AriaGridRoles {
+    private enum AriaGridRole {
 
         ROW("row"),
         ROWHEADER("rowheader"),
@@ -1219,7 +1219,7 @@ public class Escalator extends Widget
         private final String roleName;
 
 
-        AriaGridRoles(String roleName) {
+        AriaGridRole(String roleName) {
             this.roleName = roleName;
         }
 
@@ -1262,7 +1262,7 @@ public class Escalator extends Widget
 
         public AbstractRowContainer(final TableSectionElement rowContainerElement) {
             root = rowContainerElement;
-            ariaGridHelper.updateRole(root, AriaGridRoles.ROWGROUP);
+            ariaGridHelper.updateRole(root, AriaGridRole.ROWGROUP);
         }
 
         @Override
@@ -1286,29 +1286,29 @@ public class Escalator extends Widget
         /**
          * Gets the role attribute of an element to represent a cell in a row.
          * <p>
-         * Usually {@link AriaGridRoles#GRIDCELL} except for a cell in
+         * Usually {@link AriaGridRole#GRIDCELL} except for a cell in
          * the header.
          *
          * @return the role attribute for the element to represent cells
          *
          * @since
          */
-        protected AriaGridRoles getCellElementRole() {
-            return AriaGridRoles.GRIDCELL;
+        protected AriaGridRole getCellElementRole() {
+            return AriaGridRole.GRIDCELL;
         }
 
         /**
          * Gets the role attribute of an element to represent a row in a grid.
          * <p>
-         * Usually {@link AriaGridRoles#ROW} except for a row in
+         * Usually {@link AriaGridRole#ROW} except for a row in
          * the header.
          *
          * @return the role attribute for the element to represent rows
          *
          * @since
          */
-        protected AriaGridRoles getRowElementRole() {
-            return AriaGridRoles.ROW;
+        protected AriaGridRole getRowElementRole() {
+            return AriaGridRole.ROW;
         }
 
         @Override
@@ -2495,13 +2495,13 @@ public class Escalator extends Widget
         }
 
         @Override
-        protected AriaGridRoles getRowElementRole() {
-            return AriaGridRoles.ROWHEADER;
+        protected AriaGridRole getRowElementRole() {
+            return AriaGridRole.ROWHEADER;
         }
 
         @Override
-        protected AriaGridRoles getCellElementRole() {
-            return AriaGridRoles.COLUMNHEADER;
+        protected AriaGridRole getCellElementRole() {
+            return AriaGridRole.COLUMNHEADER;
         }
 
         @Override

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -1132,6 +1132,7 @@ public class Escalator extends Widget
      *
      * <ul>
      *     <li>aria-rowcount (since 8.2)</li>
+     *     <li>roles provided by {@link AriaGridRole} (since 8.2)</li>
      * </ul>
      *
      * @since 8.2
@@ -1191,7 +1192,7 @@ public class Escalator extends Widget
         }
 
         /**
-         * Sets the role attribute {@code roleName} to the given element.
+         * Sets the {@code role} attribute to the given element.
          *
          * @param element     element that should get the role attribute
          * @param role        role to be added
@@ -1199,7 +1200,7 @@ public class Escalator extends Widget
          * @since
          */
         public void updateRole(final Element element, AriaGridRole role) {
-            element.setAttribute("role", role.getRoleName());
+            element.setAttribute("role", role.getName());
         }
     }
 
@@ -1208,7 +1209,7 @@ public class Escalator extends Widget
      *
      * @since
      */
-    private enum AriaGridRole {
+    public enum AriaGridRole {
 
         ROW("row"),
         ROWHEADER("rowheader"),
@@ -1216,21 +1217,20 @@ public class Escalator extends Widget
         GRIDCELL("gridcell"),
         COLUMNHEADER("columnheader");
 
-        private final String roleName;
+        private final String name;
 
 
-        AriaGridRole(String roleName) {
-            this.roleName = roleName;
+        AriaGridRole(String name) {
+            this.name = name;
         }
 
         /**
-         * Returns the roleName used within the role attribute
-         * of rows and cells.
+         * Return the name of the {@link AriaGridRole}.
          *
-         * @return String roleName to be used as role attribute
+         * @return String name to be used as role attribute
          */
-        public String getRoleName() {
-            return roleName;
+        public String getName() {
+            return name;
         }
     }
 

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -1532,8 +1532,6 @@ public class Escalator extends Widget
                             .getColumnWidthActual(col);
                     final TableCellElement cellElem = createCellElement(colWidth);
                     tr.appendChild(cellElem);
-                    ariaGridHelper.updateRole(cellElem, getCellElementRole());
-
                     // Set stylename and position if new cell is frozen
                     if (col < columnConfiguration.frozenColumns) {
                         cellElem.addClassName("frozen");
@@ -1681,6 +1679,7 @@ public class Escalator extends Widget
                 cellElem.getStyle().setWidth(width, Unit.PX);
             }
             cellElem.addClassName(getStylePrimaryName() + "-cell");
+            ariaGridHelper.updateRole(cellElem, getCellElementRole());
             return cellElem;
         }
 

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -1189,6 +1189,28 @@ public class Escalator extends Widget
 
             getTable().setAttribute("aria-rowcount", String.valueOf(allRows));
         }
+
+        /**
+         * Sets the role attribute 'row' to the given rowElement.
+         *
+         * @param rowElement row that should get the role attribute
+         *
+         * @since 8.2
+         */
+        public void updateRoleRow(final TableRowElement rowElement) {
+            rowElement.setAttribute("role", "row");
+        }
+
+        /**
+         * Sets the role attribute 'gridcell' to the given cellElement.
+         *
+         * @param cellElement cell that should get the role attribute
+         *
+         * @since 8.2
+         */
+        public void updateRoleCell(final TableCellElement cellElement) {
+            cellElement.setAttribute("role", "gridcell");
+        }
     }
 
     public abstract class AbstractRowContainer implements RowContainer {
@@ -1477,14 +1499,15 @@ public class Escalator extends Widget
                 final TableRowElement tr = TableRowElement.as(DOM.createTR());
                 addedRows.add(tr);
                 tr.addClassName(getStylePrimaryName() + "-row");
+                ariaGridHelper.updateRoleRow(tr);
 
                 for (int col = 0; col < columnConfiguration
                         .getColumnCount(); col++) {
                     final double colWidth = columnConfiguration
                             .getColumnWidthActual(col);
-                    final TableCellElement cellElem = createCellElement(
-                            colWidth);
+                    final TableCellElement cellElem = createCellElement(colWidth);
                     tr.appendChild(cellElem);
+                    ariaGridHelper.updateRoleCell(cellElem);
 
                     // Set stylename and position if new cell is frozen
                     if (col < columnConfiguration.frozenColumns) {

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -1138,12 +1138,6 @@ public class Escalator extends Widget
      */
     public class AriaGridHelper {
 
-        public static final String GRID_ROLE_ROW="row";
-        public static final String GRID_ROLE_ROWHEADER="rowheader";
-        public static final String GRID_ROLE_ROWGROUP="rowgroup";
-        public static final String GRID_ROLE_CELL="gridcell";
-        public static final String GRID_ROLE_COLUMNHEADER="columnheader";
-
         /**
          * This field contains the total number of rows from the grid
          * including rows from thead, tbody and tfoot.
@@ -1197,15 +1191,46 @@ public class Escalator extends Widget
         }
 
         /**
-         * Sets the role attribute '$attr' to the given element.
+         * Sets the role attribute {@code roleName} to the given element.
          *
          * @param element     element that should get the role attribute
-         * @param attr        attribute to be added
+         * @param roleName    roleName to be added
          *
-         * @since 8.2
+         * @since
          */
-        public void updateRole(final Element element, String attr) {
-            element.setAttribute("role", attr);
+        public void updateRole(final Element element, AriaGridRoles roleName) {
+            element.setAttribute("role", roleName.getRoleName());
+        }
+    }
+
+    /**
+     * Holds the currently used aria roles within the grid for rows and cells.
+     *
+     * @since
+     */
+    private enum AriaGridRoles {
+
+        ROW("row"),
+        ROWHEADER("rowheader"),
+        ROWGROUP("rowgroup"),
+        GRIDCELL("gridcell"),
+        COLUMNHEADER("columnheader");
+
+        private final String roleName;
+
+
+        AriaGridRoles(String roleName) {
+            this.roleName = roleName;
+        }
+
+        /**
+         * Returns the roleName used within the role attribute
+         * of rows and cells.
+         *
+         * @return String roleName to be used as role attribute
+         */
+        public String getRoleName() {
+            return roleName;
         }
     }
 
@@ -1237,7 +1262,7 @@ public class Escalator extends Widget
 
         public AbstractRowContainer(final TableSectionElement rowContainerElement) {
             root = rowContainerElement;
-            ariaGridHelper.updateRole(root, AriaGridHelper.GRID_ROLE_ROWGROUP);
+            ariaGridHelper.updateRole(root, AriaGridRoles.ROWGROUP);
         }
 
         @Override
@@ -1261,29 +1286,29 @@ public class Escalator extends Widget
         /**
          * Gets the role attribute of an element to represent a cell in a row.
          * <p>
-         * Usually {@link AriaGridHelper#GRID_ROLE_CELL} except for a cell in
+         * Usually {@link AriaGridRoles#GRIDCELL} except for a cell in
          * the header.
          *
          * @return the role attribute for the element to represent cells
          *
-         * @since 8.2
+         * @since
          */
-        protected String getCellElementRole() {
-            return AriaGridHelper.GRID_ROLE_CELL;
+        protected AriaGridRoles getCellElementRole() {
+            return AriaGridRoles.GRIDCELL;
         }
 
         /**
          * Gets the role attribute of an element to represent a row in a grid.
          * <p>
-         * Usually {@link AriaGridHelper#GRID_ROLE_ROW} except for a row in
+         * Usually {@link AriaGridRoles#ROW} except for a row in
          * the header.
          *
          * @return the role attribute for the element to represent rows
          *
-         * @since 8.2
+         * @since
          */
-        protected String getRowElementRole() {
-            return AriaGridHelper.GRID_ROLE_ROW;
+        protected AriaGridRoles getRowElementRole() {
+            return AriaGridRoles.ROW;
         }
 
         @Override
@@ -2470,13 +2495,13 @@ public class Escalator extends Widget
         }
 
         @Override
-        protected String getRowElementRole() {
-            return AriaGridHelper.GRID_ROLE_ROWHEADER;
+        protected AriaGridRoles getRowElementRole() {
+            return AriaGridRoles.ROWHEADER;
         }
 
         @Override
-        protected String getCellElementRole() {
-            return AriaGridHelper.GRID_ROLE_COLUMNHEADER;
+        protected AriaGridRoles getCellElementRole() {
+            return AriaGridRoles.COLUMNHEADER;
         }
 
         @Override

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
@@ -38,11 +38,11 @@ public class GridAriaRowcountTest extends SingleBrowserTest {
 
         // default grid should contain at least one of each role
         String gridHtml = grid.getHTML();
-        assertTrue("Grid should contains a role=\"rowheader\"", gridHtml.contains("role=\"rowheader\""));
-        assertTrue("Grid should contains a role=\"columnheader\"", gridHtml.contains("role=\"columnheader\""));
-        assertTrue("Grid should contains a role=\"row\"", gridHtml.contains("role=\"row\""));
-        assertTrue("Grid should contains a role=\"gridcell\"", gridHtml.contains("role=\"gridcell\""));
-        assertTrue("Grid should contains a role=\"rowgroup\"", gridHtml.contains("role=\"rowgroup\""));
+        assertTrue("Grid should contain a role=\"rowheader\"", gridHtml.contains("role=\"rowheader\""));
+        assertTrue("Grid should contain a role=\"columnheader\"", gridHtml.contains("role=\"columnheader\""));
+        assertTrue("Grid should contain a role=\"row\"", gridHtml.contains("role=\"row\""));
+        assertTrue("Grid should contain a role=\"gridcell\"", gridHtml.contains("role=\"gridcell\""));
+        assertTrue("Grid should contain a role=\"rowgroup\"", gridHtml.contains("role=\"rowgroup\""));
 
         // default with 1 header row and 2 body rows.
         assertTrue("Grid should have 3 rows", containsRows(3));

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
@@ -38,10 +38,11 @@ public class GridAriaRowcountTest extends SingleBrowserTest {
 
         // default grid should contain at least one of each role
         String gridHtml = grid.getHTML();
-        assertTrue("Grid should contain a role=\"rowheader\"", gridHtml.contains("role=\"rowheader\""));
-        assertTrue("Grid should contain a role=\"columnheader\"", gridHtml.contains("role=\"columnheader\""));
-        assertTrue("Grid should contain a role=\"row\"", gridHtml.contains("role=\"row\""));
-        assertTrue("Grid should contain a role=\"gridcell\"", gridHtml.contains("role=\"gridcell\""));
+        assertTrue("Grid should contains a role=\"rowheader\"", gridHtml.contains("role=\"rowheader\""));
+        assertTrue("Grid should contains a role=\"columnheader\"", gridHtml.contains("role=\"columnheader\""));
+        assertTrue("Grid should contains a role=\"row\"", gridHtml.contains("role=\"row\""));
+        assertTrue("Grid should contains a role=\"gridcell\"", gridHtml.contains("role=\"gridcell\""));
+        assertTrue("Grid should contains a role=\"rowgroup\"", gridHtml.contains("role=\"rowgroup\""));
 
         // default with 1 header row and 2 body rows.
         assertTrue("Grid should have 3 rows", containsRows(3));

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
@@ -38,6 +38,7 @@ public class GridAriaRowcountTest extends SingleBrowserTest {
 
         // default grid should contain at least one of each role
         String gridHtml = grid.getHTML();
+        System.err.println(">Debug Grid html: "+ gridHtml);
         assertTrue("Grid should contains a role=\"rowheader\"", gridHtml.contains("role=\"rowheader\""));
         assertTrue("Grid should contains a role=\"columnheader\"", gridHtml.contains("role=\"columnheader\""));
         assertTrue("Grid should contains a role=\"row\"", gridHtml.contains("role=\"row\""));

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
@@ -36,6 +36,13 @@ public class GridAriaRowcountTest extends SingleBrowserTest {
 
         grid = $(GridElement.class).first();
 
+        // default grid should contain at least one of each role
+        String gridHtml = grid.getHTML();
+        assertTrue("Grid should contain a role=\"rowheader\"", gridHtml.contains("role=\"rowheader\""));
+        assertTrue("Grid should contain a role=\"columnheader\"", gridHtml.contains("role=\"columnheader\""));
+        assertTrue("Grid should contain a role=\"row\"", gridHtml.contains("role=\"row\""));
+        assertTrue("Grid should contain a role=\"gridcell\"", gridHtml.contains("role=\"gridcell\""));
+
         // default with 1 header row and 2 body rows.
         assertTrue("Grid should have 3 rows", containsRows(3));
 

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
@@ -18,9 +18,9 @@ package com.vaadin.tests.components.grid;
 import com.vaadin.testbench.elements.ButtonElement;
 import com.vaadin.testbench.elements.GridElement;
 import com.vaadin.tests.tb3.SingleBrowserTest;
-import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -38,7 +38,7 @@ public class GridAriaRowcountTest extends SingleBrowserTest {
 
         // default grid should contain at least one of each role
         String gridHtml = grid.getHTML();
-        System.err.println(">Debug Grid html: "+ gridHtml);
+        assertEquals("test: ", gridHtml);
         assertTrue("Grid should contains a role=\"rowheader\"", gridHtml.contains("role=\"rowheader\""));
         assertTrue("Grid should contains a role=\"columnheader\"", gridHtml.contains("role=\"columnheader\""));
         assertTrue("Grid should contains a role=\"row\"", gridHtml.contains("role=\"row\""));

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridAriaRowcountTest.java
@@ -38,7 +38,6 @@ public class GridAriaRowcountTest extends SingleBrowserTest {
 
         // default grid should contain at least one of each role
         String gridHtml = grid.getHTML();
-        assertEquals("test: ", gridHtml);
         assertTrue("Grid should contains a role=\"rowheader\"", gridHtml.contains("role=\"rowheader\""));
         assertTrue("Grid should contains a role=\"columnheader\"", gridHtml.contains("role=\"columnheader\""));
         assertTrue("Grid should contains a role=\"row\"", gridHtml.contains("role=\"row\""));


### PR DESCRIPTION
Hey @tsuoanttila, first improvement after a discussion with our accessibility inspector. This is the first 'easy' task. 

This pull request adds the missing roles

- row
- gridcell
- rowheader
- columnheader
- rowgroup

to Grid. 

> Authors MUST ensure that elements with role gridcell are owned by elements with role row, which in turn are owned by an element with role rowgroup, grid or treegrid. If the author applies any non-global WAI-ARIA states or properties to a native markup element that is acting as a row (such as the tr element in HTML), the author MUST also apply the role of row, as stated in the section on Implementation in Host Languages.

Source: [w3.org/roles#grid](https://www.w3.org/TR/wai-aria/roles#grid)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10206)
<!-- Reviewable:end -->
