### PR TITLE
adds simple fix for missing label text in grid select checkboxes

### DIFF
--- a/client/src/main/java/com/vaadin/client/widget/grid/selection/MultiSelectionRenderer.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/selection/MultiSelectionRenderer.java
@@ -626,8 +626,8 @@ public class MultiSelectionRenderer<T>
     public void render(final RendererCellReference cell, final Boolean data,
             CheckBox checkBox) {
         checkBox.setValue(data, false);
-        // won't implement ordinal numbers here, this should be a temp fix.
-        checkBox.setText("Selects the " + getDOMRowIndex(cell) + " row.");
+        // this should be a temp fix.
+        checkBox.setText("Selects row number " + getDOMRowIndex(cell) + ".");
         checkBox.setEnabled(grid.isEnabled() && !grid.isEditorActive());
     }
 

--- a/client/src/main/java/com/vaadin/client/widget/grid/selection/MultiSelectionRenderer.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/selection/MultiSelectionRenderer.java
@@ -604,6 +604,9 @@ public class MultiSelectionRenderer<T>
 
         CheckBoxEventHandler handler = new CheckBoxEventHandler(checkBox);
 
+        // label of checkbox should only be visible for assistive devices
+        checkBox.addStyleName("v-assistive-device-only-label");
+
         // Sink events
         checkBox.sinkBitlessEvent(BrowserEvents.MOUSEDOWN);
         checkBox.sinkBitlessEvent(BrowserEvents.TOUCHSTART);
@@ -623,7 +626,16 @@ public class MultiSelectionRenderer<T>
     public void render(final RendererCellReference cell, final Boolean data,
             CheckBox checkBox) {
         checkBox.setValue(data, false);
+        // won't implement ordinal numbers here, this should be a temp fix.
+        checkBox.setText("Selects the " + getDOMRowIndex(cell) + " row.");
         checkBox.setEnabled(grid.isEnabled() && !grid.isEditorActive());
+    }
+
+    private int getDOMRowIndex(RendererCellReference cell){
+        // getRowIndex starts with zero, that's why we add an additional 1.
+        // getDOMRowIndex should include getHeaderRows as well, this number
+        // should be equals to aria-rowindex.
+        return cell.getGrid().getHeaderRowCount() + cell.getRowIndex() + 1;
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -2928,11 +2928,14 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 selectAllCheckBox = GWT.create(CheckBox.class);
                 selectAllCheckBox.setStylePrimaryName(
                         getStylePrimaryName() + SELECT_ALL_CHECKBOX_CLASSNAME);
+                // label of checkbox should only be visible for assistive devices
+                selectAllCheckBox.addStyleName("v-assistive-device-only-label");
                 selectAllCheckBox.addValueChangeHandler(event -> {
                     selected = event.getValue();
                     fireEvent(new SelectAllEvent<>(getSelectionModel(),
                             selected));
                 });
+                selectAllCheckBox.setText("Selects all rows of the table.");
                 selectAllCheckBox.setValue(selected);
 
                 addHeaderClickHandler(this::onHeaderClickEvent);

--- a/themes/src/main/themes/VAADIN/themes/valo/shared/_global.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/shared/_global.scss
@@ -128,7 +128,7 @@ $valo-global-included: false !default;
       overflow:auto;
     }
 
-    .v-assistive-device-only {
+    .v-assistive-device-only, .v-assistive-device-only-label label {
       position: absolute;
       top: -2000px;
       left: -2000px;


### PR DESCRIPTION
Hey @tsuoanttila  - this is the first approach, I mailed you. 

This pull requests adds assistive device only text (thanks to css) to the checkbox to select rows / all rows in Grid. This should only be a **temp fix**, because it is missing i18n and a Server API to define the value. 

Why this? 

Using a screenreader to navigate in the table, every checkbox is meaningless without a proper label - a sightless user has no clue why there are checkboxes and even what this checkboxes select after pressing them. 

Why not aria-label instead you created a new css selector?

- GWT's Checkbox adds a empty label to the input, we have to use this - otherwise some screenreader read the following 'Checkbox, Empty Label, Label from Aria-Label' (really annoying)
- I couldn't extend Checkbox and add .v-assistive-device-only only to the label

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10223)
<!-- Reviewable:end -->
