### PR TITLE
Remove deprecated usage of ApplicationConnection.hasEventListeners()

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VAbstractTextualDate.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractTextualDate.java
@@ -398,8 +398,7 @@ public abstract class VAbstractTextualDate<R extends Enum<R>>
         } else {
             text.removeStyleName(styleName);
         }
-        if (getClient() != null && getClient()
-                .hasEventListeners(VAbstractTextualDate.this, eventId)) {
+        if (getClient() != null && connector.hasEventListener(eventId)) {
             // may excessively send events if if focus went to another
             // sub-component
             if (EventId.FOCUS.equals(eventId)) {

--- a/client/src/main/java/com/vaadin/client/ui/VDateField.java
+++ b/client/src/main/java/com/vaadin/client/ui/VDateField.java
@@ -27,6 +27,7 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HasEnabled;
 import com.vaadin.client.ApplicationConnection;
 import com.vaadin.client.DateTimeService;
+import com.vaadin.client.ui.datefield.AbstractDateFieldConnector;
 import com.vaadin.shared.ui.datefield.AbstractDateFieldServerRpc;
 
 /**
@@ -43,10 +44,10 @@ public abstract class VDateField<R extends Enum<R>> extends FlowPanel
     public static final String CLASSNAME = "v-datefield";
 
     /** For internal use only. May be removed or replaced in the future. */
-    public String paintableId;
+    public ApplicationConnection client;
 
     /** For internal use only. May be removed or replaced in the future. */
-    public ApplicationConnection client;
+    public AbstractDateFieldConnector<R> connector;
 
     private R currentResolution;
 
@@ -58,7 +59,7 @@ public abstract class VDateField<R extends Enum<R>> extends FlowPanel
 
     /**
      * The RPC send calls to the server.
-     * 
+     *
      * @since
      */
     public AbstractDateFieldServerRpc rpc;
@@ -66,11 +67,11 @@ public abstract class VDateField<R extends Enum<R>> extends FlowPanel
     /**
      * A temporary holder of the time units (resolutions), which would be sent
      * to the server through {@link #sendBufferedValues()}.
-     * 
+     *
      * The key is the resolution.
-     * 
+     *
      * The value can be {@code null}.
-     * 
+     *
      * @since
      */
     protected Map<R, Integer> bufferedResolutions = new HashMap<>();
@@ -78,7 +79,7 @@ public abstract class VDateField<R extends Enum<R>> extends FlowPanel
     /**
      * A temporary holder of the date string, which would be sent to the server
      * through {@link #sendBufferedValues()}.
-     * 
+     *
      * @since
      */
     protected String bufferedDateString;
@@ -200,7 +201,7 @@ public abstract class VDateField<R extends Enum<R>> extends FlowPanel
     }
 
     public String getId() {
-        return paintableId;
+        return connector.getConnectorId();
     }
 
     public ApplicationConnection getClient() {
@@ -264,7 +265,7 @@ public abstract class VDateField<R extends Enum<R>> extends FlowPanel
     /**
      * Sends the {@link #bufferedDateString} and {@link #bufferedResolutions} to
      * the server, and clears their values.
-     * 
+     *
      * @since
      */
     public void sendBufferedValues() {

--- a/client/src/main/java/com/vaadin/client/ui/VWindow.java
+++ b/client/src/main/java/com/vaadin/client/ui/VWindow.java
@@ -62,6 +62,7 @@ import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.debug.internal.VDebugWindow;
 import com.vaadin.client.ui.ShortcutActionHandler.ShortcutActionHandlerOwner;
 import com.vaadin.client.ui.aria.AriaHelper;
+import com.vaadin.client.ui.window.WindowConnector;
 import com.vaadin.client.ui.window.WindowMoveEvent;
 import com.vaadin.client.ui.window.WindowMoveHandler;
 import com.vaadin.client.ui.window.WindowOrderEvent;
@@ -132,6 +133,9 @@ public class VWindow extends VOverlay implements ShortcutActionHandlerOwner,
 
     /** For internal use only. May be removed or replaced in the future. */
     public ApplicationConnection client;
+
+    /** For internal use only. May be removed or replaced in the future. */
+    public WindowConnector connector;
 
     /** For internal use only. May be removed or replaced in the future. */
     public String id;
@@ -1358,14 +1362,14 @@ public class VWindow extends VOverlay implements ShortcutActionHandlerOwner,
 
     @Override
     public void onBlur(BlurEvent event) {
-        if (client.hasEventListeners(this, EventId.BLUR)) {
+        if (connector.hasEventListener(EventId.BLUR)) {
             client.updateVariable(id, EventId.BLUR, "", true);
         }
     }
 
     @Override
     public void onFocus(FocusEvent event) {
-        if (client.hasEventListeners(this, EventId.FOCUS)) {
+        if (connector.hasEventListener(EventId.FOCUS)) {
             client.updateVariable(id, EventId.FOCUS, "", true);
         }
     }

--- a/client/src/main/java/com/vaadin/client/ui/datefield/AbstractDateFieldConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/datefield/AbstractDateFieldConnector.java
@@ -62,7 +62,7 @@ public abstract class AbstractDateFieldConnector<R extends Enum<R>>
     /**
      * Returns the default date (when no date is selected) components as a map
      * from Resolution to the corresponding value.
-     * 
+     *
      * @return default date component map
      * @since
      */
@@ -95,7 +95,7 @@ public abstract class AbstractDateFieldConnector<R extends Enum<R>>
 
         // Save details
         widget.client = getConnection();
-        widget.paintableId = getConnectorId();
+        widget.connector = this;
 
         widget.setReadonly(isReadOnly());
         widget.setEnabled(isEnabled());

--- a/client/src/main/java/com/vaadin/client/ui/window/WindowConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/window/WindowConnector.java
@@ -105,6 +105,7 @@ public class WindowConnector extends AbstractSingleComponentContainerConnector
         VWindow window = getWidget();
         window.id = getConnectorId();
         window.client = getConnection();
+        window.connector = this;
 
         getLayoutManager().registerDependency(this,
                 window.contentPanel.getElement());


### PR DESCRIPTION
From VDateField and VWindow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10248)
<!-- Reviewable:end -->
