### PR TITLE
set default ContentMode PREFORMATTED for tooltipInfo - fixes #10264

### DIFF
--- a/client/src/main/java/com/vaadin/client/TooltipInfo.java
+++ b/client/src/main/java/com/vaadin/client/TooltipInfo.java
@@ -42,6 +42,7 @@ public class TooltipInfo {
      * Constructs a new tooltip info instance.
      */
     public TooltipInfo() {
+        this("", ContentMode.PREFORMATTED);
     }
 
     /**


### PR DESCRIPTION
set default ContentMode PREFORMATTED in parameterless TooltipInfo constructor, fixes undefined enum value access in `VTooltip.setTooltipText`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10263)
<!-- Reviewable:end -->
