### PR TITLE
Use slf4j-api as a logging frontend (#9713)

### DIFF
--- a/client-compiler/pom.xml
+++ b/client-compiler/pom.xml
@@ -28,6 +28,16 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-sass-compiler</artifactId>
         </dependency>
+
+        <!-- Logging Facade -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/client-compiler/src/main/java/com/vaadin/tools/ReportUsage.java
+++ b/client-compiler/src/main/java/com/vaadin/tools/ReportUsage.java
@@ -15,20 +15,18 @@
  */
 package com.vaadin.tools;
 
+import com.google.gwt.dev.shell.CheckForUpdates;
+import com.vaadin.shared.Version;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
-import java.util.logging.Logger;
 import java.util.prefs.Preferences;
-
-import org.apache.commons.io.IOUtils;
-
-import com.google.gwt.dev.shell.CheckForUpdates;
-import com.vaadin.shared.Version;
 
 public class ReportUsage {
 
@@ -121,17 +119,15 @@ public class ReportUsage {
             // TODO use the results
             IOUtils.toByteArray(is);
             return;
-        } catch (MalformedURLException e) {
-            caught = e;
         } catch (IOException e) {
             caught = e;
         } finally {
             IOUtils.closeQuietly(is);
         }
 
-        Logger.getLogger(ReportUsage.class.getName())
-                .fine("Caught an exception while executing HTTP query: "
-                        + caught.getMessage());
+        LoggerFactory.getLogger(ReportUsage.class)
+                .debug("Caught an exception while executing HTTP query: {}",
+                        caught.getMessage());
     }
 
     private static String makeUserAgent() {

--- a/client-compiler/src/main/java/com/vaadin/tools/WidgetsetCompiler.java
+++ b/client-compiler/src/main/java/com/vaadin/tools/WidgetsetCompiler.java
@@ -15,10 +15,8 @@
  */
 package com.vaadin.tools;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.server.widgetsetutils.WidgetSetBuilder;
+import org.slf4j.LoggerFactory;
 
 /**
  * A wrapper for the GWT compiler that runs the compiler in a new thread after
@@ -79,8 +77,7 @@ public class WidgetsetCompiler {
                         System.out.println("Starting GWT compiler");
                         com.google.gwt.dev.Compiler.main(args);
                     } catch (Throwable thr) {
-                        getLogger().log(Level.SEVERE,
-                                "Widgetset compilation failed", thr);
+                        getLogger().error("Widgetset compilation failed", thr);
                     }
                 }
             };
@@ -89,11 +86,11 @@ public class WidgetsetCompiler {
             runThread.join();
             System.out.println("Widgetset compilation finished");
         } catch (Throwable thr) {
-            getLogger().log(Level.SEVERE, "Widgetset compilation failed", thr);
+            getLogger().error("Widgetset compilation failed", thr);
         }
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(WidgetsetCompiler.class.getName());
+    private static org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(WidgetsetCompiler.class);
     }
 }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -37,6 +37,18 @@
             </exclusions>
         </dependency>
 
+        <!-- SLF4J API and implementation -->
+        <dependency>
+            <groupId>ru.finam</groupId>
+            <artifactId>slf4j-gwt</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.gwt</groupId>
+                    <artifactId>gwt-user</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Needed GWT dependencies, includes gwt-user -->
         <dependency>
             <groupId>com.google.gwt</groupId>

--- a/client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -15,35 +15,13 @@
  */
 package com.vaadin.client;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.google.gwt.core.client.EntryPoint;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.core.client.JsArrayString;
-import com.google.gwt.core.client.RunAsyncCallback;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.ScriptInjector;
+import com.google.gwt.core.client.*;
+import com.google.gwt.core.client.GWT.UncaughtExceptionHandler;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.logging.client.LogConfiguration;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Window;
-import com.vaadin.client.debug.internal.ErrorNotificationHandler;
-import com.vaadin.client.debug.internal.HierarchySection;
-import com.vaadin.client.debug.internal.InfoSection;
-import com.vaadin.client.debug.internal.LogSection;
-import com.vaadin.client.debug.internal.NetworkSection;
-import com.vaadin.client.debug.internal.ProfilerSection;
-import com.vaadin.client.debug.internal.Section;
-import com.vaadin.client.debug.internal.TestBenchSection;
-import com.vaadin.client.debug.internal.VDebugWindow;
+import com.vaadin.client.debug.internal.*;
 import com.vaadin.client.debug.internal.theme.DebugWindowStyles;
 import com.vaadin.client.event.PointerEventSupport;
 import com.vaadin.client.metadata.NoDataException;
@@ -53,6 +31,12 @@ import com.vaadin.client.ui.UnknownExtensionConnector;
 import com.vaadin.client.ui.ui.UIConnector;
 import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.shared.ui.ui.UIConstants;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class ApplicationConfiguration implements EntryPoint {
 
@@ -682,7 +666,7 @@ public class ApplicationConfiguration implements EntryPoint {
         // Don't run twice if the module has been inherited several times,
         // and don't continue if vaadinBootstrap was not executed.
         if (moduleLoaded || !vaadinBootstrapLoaded()) {
-            getLogger().log(Level.WARNING,
+            getLogger().warn(
                     "vaadinBootstrap.js was not loaded, skipping vaadin application configuration.");
             return;
         }
@@ -715,11 +699,11 @@ public class ApplicationConfiguration implements EntryPoint {
                  * errors helps nobody, especially end user. It does not work
                  * tells just as much.
                  */
-                getLogger().log(Level.SEVERE, throwable.getMessage(),
-                        throwable);
+                getLogger().error(throwable.getMessage(), throwable);
             });
 
             if (isProductionMode()) {
+                // Set up logging in JUL, since slf4j-gwt use it as backend
                 // Disable all logging if in production mode
                 Logger.getLogger("").setLevel(Level.OFF);
             }
@@ -784,6 +768,7 @@ public class ApplicationConfiguration implements EntryPoint {
         // Connect to the legacy API
         VConsole.setImplementation(window);
 
+        // Set up logging in JUL, since slf4j-gwt use it as backend
         Handler errorNotificationHandler = GWT
                 .create(ErrorNotificationHandler.class);
         Logger.getLogger("").addHandler(errorNotificationHandler);
@@ -895,7 +880,7 @@ public class ApplicationConfiguration implements EntryPoint {
         widgetsetVersionSent = true;
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(ApplicationConfiguration.class.getName());
+    private static org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(ApplicationConfiguration.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/ConnectorMap.java
+++ b/client/src/main/java/com/vaadin/client/ConnectorMap.java
@@ -15,15 +15,16 @@
  */
 package com.vaadin.client;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Widget;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class ConnectorMap {
 
@@ -173,7 +174,7 @@ public class ConnectorMap {
      */
     public void unregisterConnector(ServerConnector connector) {
         if (connector == null) {
-            getLogger().severe("Trying to unregister null connector");
+            getLogger().error("Trying to unregister null connector");
             return;
         }
 
@@ -290,6 +291,6 @@ public class ConnectorMap {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(ConnectorMap.class.getName());
+        return LoggerFactory.getLogger(ConnectorMap.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/DateTimeService.java
+++ b/client/src/main/java/com/vaadin/client/DateTimeService.java
@@ -16,14 +16,14 @@
 
 package com.vaadin.client;
 
-import java.util.Date;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.i18n.client.TimeZone;
 import com.google.gwt.i18n.shared.DateTimeFormat;
 import com.vaadin.shared.ui.datefield.DateResolution;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
 
 /**
  * This class provides date/time parsing services to all components on the
@@ -75,7 +75,7 @@ public class DateTimeService {
         try {
             return LocaleService.getMonthNames(locale)[month];
         } catch (final LocaleNotLoadedException e) {
-            getLogger().log(Level.SEVERE, "Error in getMonth", e);
+            getLogger().error("Error in getMonth", e);
             return null;
         }
     }
@@ -84,7 +84,7 @@ public class DateTimeService {
         try {
             return LocaleService.getShortMonthNames(locale)[month];
         } catch (final LocaleNotLoadedException e) {
-            getLogger().log(Level.SEVERE, "Error in getShortMonth", e);
+            getLogger().error("Error in getShortMonth", e);
             return null;
         }
     }
@@ -93,7 +93,7 @@ public class DateTimeService {
         try {
             return LocaleService.getDayNames(locale)[day];
         } catch (final LocaleNotLoadedException e) {
-            getLogger().log(Level.SEVERE, "Error in getDay", e);
+            getLogger().error("Error in getDay", e);
             return null;
         }
     }
@@ -109,7 +109,7 @@ public class DateTimeService {
         try {
             return LocaleService.getShortDayNames(locale)[day];
         } catch (final LocaleNotLoadedException e) {
-            getLogger().log(Level.SEVERE, "Error in getShortDay", e);
+            getLogger().error("Error in getShortDay", e);
             return null;
         }
     }
@@ -123,7 +123,7 @@ public class DateTimeService {
         try {
             return LocaleService.getFirstDayOfWeek(locale);
         } catch (final LocaleNotLoadedException e) {
-            getLogger().log(Level.SEVERE, "Error in getFirstDayOfWeek", e);
+            getLogger().error("Error in getFirstDayOfWeek", e);
             return 0;
         }
     }
@@ -138,7 +138,7 @@ public class DateTimeService {
         try {
             return LocaleService.isTwelveHourClock(locale);
         } catch (final LocaleNotLoadedException e) {
-            getLogger().log(Level.SEVERE, "Error in isTwelveHourClock", e);
+            getLogger().error("Error in isTwelveHourClock", e);
             return false;
         }
     }
@@ -147,7 +147,7 @@ public class DateTimeService {
         try {
             return LocaleService.getClockDelimiter(locale);
         } catch (final LocaleNotLoadedException e) {
-            getLogger().log(Level.SEVERE, "Error in getClockDelimiter", e);
+            getLogger().error("Error in getClockDelimiter", e);
             return ":";
         }
     }
@@ -159,7 +159,7 @@ public class DateTimeService {
             return LocaleService.getAmPmStrings(locale);
         } catch (final LocaleNotLoadedException e) {
             // TODO can this practically even happen? Should die instead?
-            getLogger().log(Level.SEVERE,
+            getLogger().error(
                     "Locale not loaded, using fallback : AM/PM", e);
             return DEFAULT_AMPM_STRINGS;
         }
@@ -179,8 +179,7 @@ public class DateTimeService {
         try {
             firstDay = LocaleService.getFirstDayOfWeek(locale);
         } catch (final LocaleNotLoadedException e) {
-            getLogger().log(Level.SEVERE, "Locale not loaded, using fallback 0",
-                    e);
+            getLogger().error("Locale not loaded, using fallback 0", e);
             firstDay = 0;
         }
         int start = dateForFirstOfThisMonth.getDay() - firstDay;
@@ -606,6 +605,6 @@ public class DateTimeService {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(DateTimeService.class.getName());
+        return LoggerFactory.getLogger(DateTimeService.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/DependencyLoader.java
+++ b/client/src/main/java/com/vaadin/client/DependencyLoader.java
@@ -15,12 +15,12 @@
  */
 package com.vaadin.client;
 
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.user.client.Command;
 import com.vaadin.client.ResourceLoader.ResourceLoadEvent;
 import com.vaadin.client.ResourceLoader.ResourceLoadListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles loading of dependencies (style sheets and scripts) in the
@@ -52,7 +52,7 @@ public class DependencyLoader {
             if (event.getResourceUrl().endsWith("css")) {
                 error += " or the load detection failed because the stylesheet is empty.";
             }
-            getLogger().severe(error);
+            getLogger().error(error);
             // The show must go on
             onLoad(event);
         }
@@ -119,7 +119,7 @@ public class DependencyLoader {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(DependencyLoader.class.getName());
+        return LoggerFactory.getLogger(DependencyLoader.class);
     }
 
 }

--- a/client/src/main/java/com/vaadin/client/JavaScriptConnectorHelper.java
+++ b/client/src/main/java/com/vaadin/client/JavaScriptConnectorHelper.java
@@ -16,15 +16,6 @@
 
 package com.vaadin.client;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.dom.client.Element;
@@ -33,8 +24,12 @@ import com.vaadin.client.communication.ServerRpcQueue;
 import com.vaadin.client.ui.layout.ElementResizeListener;
 import com.vaadin.shared.JavaScriptConnectorState;
 import com.vaadin.shared.communication.MethodInvocation;
-
 import elemental.json.JsonArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.Map.Entry;
 
 public class JavaScriptConnectorHelper {
 
@@ -154,8 +149,8 @@ public class JavaScriptConnectorHelper {
                 this.initFunctionName = initFunctionName;
                 return true;
             } else {
-                getLogger().warning("No JavaScript function " + initFunctionName
-                        + " found");
+                getLogger().warn("No JavaScript function {} found",
+                        initFunctionName);
             }
         }
         getLogger().info("No JavaScript init for connector found");
@@ -514,6 +509,6 @@ public class JavaScriptConnectorHelper {
     }-*/;
 
     private static Logger getLogger() {
-        return Logger.getLogger(JavaScriptConnectorHelper.class.getName());
+        return LoggerFactory.getLogger(JavaScriptConnectorHelper.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/LayoutManager.java
+++ b/client/src/main/java/com/vaadin/client/LayoutManager.java
@@ -15,14 +15,6 @@
  */
 package com.vaadin.client;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.Duration;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.Element;
@@ -37,6 +29,10 @@ import com.vaadin.client.ui.VNotification;
 import com.vaadin.client.ui.layout.ElementResizeEvent;
 import com.vaadin.client.ui.layout.ElementResizeListener;
 import com.vaadin.client.ui.layout.LayoutDependencyTree;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 public class LayoutManager {
     private static final String STATE_CHANGE_MESSAGE = "Cannot run layout while processing state change from the server.";
@@ -234,8 +230,8 @@ public class LayoutManager {
         }
         layoutCounts.put(layout.getConnectorId(), count);
         if (count.intValue() > 2) {
-            getLogger().severe(Util.getConnectorString(layout)
-                    + " has been layouted " + count.intValue() + " times");
+            getLogger().error(Util.getConnectorString(layout)
+                    + " has been layouted {} times", count.intValue());
         }
     }
 
@@ -257,7 +253,7 @@ public class LayoutManager {
             assert false : STATE_CHANGE_MESSAGE;
 
             // Else just log a warning and postpone the layout
-            getLogger().warning(STATE_CHANGE_MESSAGE);
+            getLogger().warn(STATE_CHANGE_MESSAGE);
 
             // Framework will call layoutNow when the state update is completed
             return;
@@ -382,8 +378,7 @@ public class LayoutManager {
                                     Profiler.leave(key);
                                 }
                             } catch (RuntimeException e) {
-                                getLogger().log(Level.SEVERE,
-                                        "Error in resize listener", e);
+                                getLogger().error("Error in resize listener", e);
                             }
                         }
                         Profiler.leave(
@@ -426,8 +421,7 @@ public class LayoutManager {
                                 Profiler.leave(key);
                             }
                         } catch (RuntimeException e) {
-                            getLogger().log(Level.SEVERE,
-                                    "Error in ManagedLayout handling", e);
+                            getLogger().error("Error in ManagedLayout handling", e);
                         }
                         countLayout(layoutCounts, cl);
                     } else {
@@ -450,7 +444,7 @@ public class LayoutManager {
                                 Profiler.leave(key);
                             }
                         } catch (RuntimeException e) {
-                            getLogger().log(Level.SEVERE,
+                            getLogger().error(
                                     "Error in SimpleManagedLayout (horizontal) handling",
                                     e);
 
@@ -486,7 +480,7 @@ public class LayoutManager {
                                 Profiler.leave(key);
                             }
                         } catch (RuntimeException e) {
-                            getLogger().log(Level.SEVERE,
+                            getLogger().error(
                                     "Error in DirectionalManagedLayout handling",
                                     e);
                         }
@@ -511,7 +505,7 @@ public class LayoutManager {
                                 Profiler.leave(key);
                             }
                         } catch (RuntimeException e) {
-                            getLogger().log(Level.SEVERE,
+                            getLogger().error(
                                     "Error in SimpleManagedLayout (vertical) handling",
                                     e);
                         }
@@ -560,7 +554,7 @@ public class LayoutManager {
                     + " layouts.");
 
             if (passes > 100) {
-                getLogger().severe(LOOP_ABORT_MESSAGE);
+                getLogger().error(LOOP_ABORT_MESSAGE);
                 if (ApplicationConfiguration.isDebugMode()) {
                     VNotification
                             .createNotification(VNotification.DELAY_FOREVER,
@@ -597,7 +591,7 @@ public class LayoutManager {
 
         // Ensure temporary variables are cleaned
         if (!pendingOverflowFixes.isEmpty()) {
-            getLogger().warning(
+            getLogger().warn(
                     "pendingOverflowFixes is not empty at the end of doLayout: "
                             + pendingOverflowFixes.dump());
             pendingOverflowFixes = FastStringSet.create();
@@ -912,7 +906,7 @@ public class LayoutManager {
      */
     public final void setNeedsHorizontalLayout(ManagedLayout layout) {
         if (isLayoutRunning()) {
-            getLogger().warning(
+            getLogger().warn(
                     "setNeedsHorizontalLayout should not be run while a layout phase is in progress.");
         }
         needsHorizontalLayout.add(layout.getConnectorId());
@@ -937,7 +931,7 @@ public class LayoutManager {
      */
     public final void setNeedsVerticalLayout(ManagedLayout layout) {
         if (isLayoutRunning()) {
-            getLogger().warning(
+            getLogger().warn(
                     "setNeedsVerticalLayout should not be run while a layout phase is in progress.");
         }
         needsVerticalLayout.add(layout.getConnectorId());
@@ -1824,7 +1818,7 @@ public class LayoutManager {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(LayoutManager.class.getName());
+        return LoggerFactory.getLogger(LayoutManager.class);
     }
 
     /**

--- a/client/src/main/java/com/vaadin/client/LocaleService.java
+++ b/client/src/main/java/com/vaadin/client/LocaleService.java
@@ -16,13 +16,14 @@
 
 package com.vaadin.client;
 
+import com.vaadin.shared.ui.ui.UIState.LocaleData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Logger;
-
-import com.vaadin.shared.ui.ui.UIState.LocaleData;
 
 /**
  * Date / time etc. localization service for all widgets. Caches all loaded
@@ -42,7 +43,7 @@ public class LocaleService {
         if (cache.containsKey(key)) {
             cache.remove(key);
         }
-        getLogger().fine("Received locale data for " + key);
+        getLogger().debug("Received locale data for {}", key);
         cache.put(key, localeData);
         if (cache.size() == 1) {
             setDefaultLocale(key);
@@ -140,6 +141,6 @@ public class LocaleService {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(LocaleService.class.getName());
+        return LoggerFactory.getLogger(LocaleService.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/MeasuredSize.java
+++ b/client/src/main/java/com/vaadin/client/MeasuredSize.java
@@ -15,10 +15,10 @@
  */
 package com.vaadin.client;
 
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MeasuredSize {
     private static final boolean DEBUG_SIZE_CHANGES = false;
@@ -293,7 +293,7 @@ public class MeasuredSize {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(MeasuredSize.class.getName());
+        return LoggerFactory.getLogger(MeasuredSize.class);
     }
 
 }

--- a/client/src/main/java/com/vaadin/client/Profiler.java
+++ b/client/src/main/java/com/vaadin/client/Profiler.java
@@ -16,23 +16,14 @@
 
 package com.vaadin.client;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.Duration;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 /**
  * Lightweight profiling tool that can be used to collect profiling data with
@@ -445,7 +436,7 @@ public class Profiler {
      */
     public static void logTimings() {
         if (!isEnabled()) {
-            getLogger().warning(
+            getLogger().warn(
                     "Profiler is not enabled, no data has been collected.");
             return;
         }
@@ -455,7 +446,7 @@ public class Profiler {
         stack.add(rootNode);
         JsArray<GwtStatsEvent> gwtStatsEvents = getGwtStatsEvents();
         if (gwtStatsEvents.length() == 0) {
-            getLogger().warning(
+            getLogger().warn(
                     "No profiling events recorded, this might happen if another __gwtStatsEvent handler is installed.");
             return;
         }
@@ -495,7 +486,7 @@ public class Profiler {
 
             if (type.equals("end")) {
                 if (!inEvent) {
-                    getLogger().severe("Got end event for " + eventName
+                    getLogger().error("Got end event for " + eventName
                             + " but is currently in " + stackTop.getName());
                     return;
                 }
@@ -529,7 +520,7 @@ public class Profiler {
         }
 
         if (stack.size() != 1) {
-            getLogger().warning("Not all nodes are left, the last node is "
+            getLogger().warn("Not all nodes are left, the last node is "
                     + stack.getLast().getName());
             return;
         }
@@ -676,7 +667,7 @@ public class Profiler {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(Profiler.class.getName());
+        return LoggerFactory.getLogger(Profiler.class);
     }
 
     private static native boolean hasHighPrecisionTime()

--- a/client/src/main/java/com/vaadin/client/ResourceLoader.java
+++ b/client/src/main/java/com/vaadin/client/ResourceLoader.java
@@ -16,24 +16,16 @@
 
 package com.vaadin.client;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.Duration;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.LinkElement;
-import com.google.gwt.dom.client.NodeList;
-import com.google.gwt.dom.client.ScriptElement;
+import com.google.gwt.dom.client.*;
 import com.google.gwt.user.client.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 /**
  * ResourceLoader lets you dynamically include external scripts and styles on
@@ -466,7 +458,7 @@ public class ResourceLoader {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(ResourceLoader.class.getName());
+        return LoggerFactory.getLogger(ResourceLoader.class);
     }
 
     private static native boolean supportsHtmlWhenReady()

--- a/client/src/main/java/com/vaadin/client/SuperDevMode.java
+++ b/client/src/main/java/com/vaadin/client/SuperDevMode.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.client;
 
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.http.client.UrlBuilder;
@@ -25,6 +23,8 @@ import com.google.gwt.storage.client.Storage;
 import com.google.gwt.user.client.Window.Location;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.vaadin.client.ui.VNotification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class that enables SuperDevMode using a ?superdevmode parameter in the url.
@@ -67,10 +67,10 @@ public class SuperDevMode {
 
                     @Override
                     public void onSuccess(RecompileResult result) {
-                        getLogger().fine("JSONP compile call successful");
+                        getLogger().debug("JSONP compile call successful");
 
                         if (!result.ok()) {
-                            getLogger().fine("* result: " + result);
+                            getLogger().debug("* result: " + result);
                             failed();
                             return;
                         }
@@ -80,16 +80,16 @@ public class SuperDevMode {
                                         serverUrl));
                         setSession(SKIP_RECOMPILE, "1");
 
-                        getLogger().fine("* result: OK. Reloading");
+                        getLogger().debug("* result: OK. Reloading");
                         Location.reload();
                     }
 
                     @Override
                     public void onFailure(Throwable caught) {
-                        getLogger().severe("JSONP compile call failed");
+                        getLogger().error("JSONP compile call failed");
                         // Don't log exception as they are shown as
                         // notifications
-                        getLogger().severe(caught.getClass().getSimpleName()
+                        getLogger().error(caught.getClass().getSimpleName()
                                 + ": " + caught.getMessage());
                         failed();
 
@@ -263,6 +263,6 @@ public class SuperDevMode {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(SuperDevMode.class.getName());
+        return LoggerFactory.getLogger(SuperDevMode.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/Util.java
+++ b/client/src/main/java/com/vaadin/client/Util.java
@@ -16,14 +16,6 @@
 
 package com.vaadin.client;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
@@ -44,9 +36,12 @@ import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.shared.communication.MethodInvocation;
 import com.vaadin.shared.ui.ComponentStateUtil;
 import com.vaadin.shared.util.SharedUtil;
-
 import elemental.js.json.JsJsonValue;
 import elemental.json.JsonValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 public class Util {
 
@@ -733,7 +728,7 @@ public class Util {
         if (connector != null) {
             getLogger().info("\t" + id + " (" + connector.getClass() + ") :");
         } else {
-            getLogger().warning("\t" + id
+            getLogger().warn("\t" + id
                     + ": Warning: no corresponding connector for id " + id);
         }
         for (MethodInvocation invocation : invocations) {
@@ -794,7 +789,7 @@ public class Util {
                 printConnectorInvocations(invocations, curId, c);
             }
         } catch (Exception e) {
-            getLogger().log(Level.SEVERE, "Error logging method invocations",
+            getLogger().error("Error logging method invocations",
                     e);
         }
     }
@@ -1256,6 +1251,6 @@ public class Util {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(Util.class.getName());
+        return LoggerFactory.getLogger(Util.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/VCaption.java
+++ b/client/src/main/java/com/vaadin/client/VCaption.java
@@ -16,8 +16,6 @@
 
 package com.vaadin.client;
 
-import java.util.logging.Logger;
-
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style.Unit;
@@ -27,16 +25,14 @@ import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.HasHTML;
 import com.vaadin.client.WidgetUtil.ErrorUtil;
 import com.vaadin.client.communication.StateChangeEvent;
-import com.vaadin.client.ui.HasErrorIndicator;
-import com.vaadin.client.ui.HasErrorIndicatorElement;
-import com.vaadin.client.ui.HasRequiredIndicator;
-import com.vaadin.client.ui.Icon;
-import com.vaadin.client.ui.ImageIcon;
+import com.vaadin.client.ui.*;
 import com.vaadin.client.ui.aria.AriaHelper;
 import com.vaadin.shared.AbstractComponentState;
 import com.vaadin.shared.ComponentConstants;
 import com.vaadin.shared.ui.ComponentStateUtil;
 import com.vaadin.shared.ui.ErrorLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class VCaption extends HTML implements HasErrorIndicatorElement {
 
@@ -444,7 +440,7 @@ public class VCaption extends HTML implements HasErrorIndicatorElement {
             if (owner != null) {
                 Util.notifyParentOfSizeChange(owner.getWidget(), true);
             } else {
-                getLogger().warning(
+                getLogger().warn(
                         "Warning: Icon load event was not propagated because VCaption owner is unknown.");
             }
         }
@@ -770,7 +766,7 @@ public class VCaption extends HTML implements HasErrorIndicatorElement {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(VCaption.class.getName());
+        return LoggerFactory.getLogger(VCaption.class);
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/VConsole.java
+++ b/client/src/main/java/com/vaadin/client/VConsole.java
@@ -15,16 +15,17 @@
  */
 package com.vaadin.client;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.logging.client.LogConfiguration;
 import com.vaadin.client.debug.internal.VDebugWindow;
+import org.slf4j.LoggerFactory;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A helper class to do some client side logging.
  *
- * @deprecated as of 7.1, use {@link Logger} from java.util.logging instead.
+ * @deprecated as of 7.1, use {@link Logger} from org.slf4j instead.
  */
 @Deprecated
 public class VConsole {
@@ -43,7 +44,7 @@ public class VConsole {
         if (LogConfiguration.loggingIsEnabled(Level.INFO)) {
             // Check for null, so no NullPointerException is generated when
             // formatting (#12588)
-            getLogger().log(Level.INFO, msg == null ? "null" : msg);
+            getLogger().info(msg == null ? "null" : msg);
         }
     }
 
@@ -51,7 +52,7 @@ public class VConsole {
         if (LogConfiguration.loggingIsEnabled(Level.INFO)) {
             // Check for null, so no NullPointerException is generated when
             // formatting (#12588)
-            getLogger().log(Level.INFO,
+            getLogger().info(
                     e.getMessage() == null ? "" : e.getMessage(), e);
         }
     }
@@ -60,7 +61,7 @@ public class VConsole {
         if (LogConfiguration.loggingIsEnabled(Level.SEVERE)) {
             // Check for null, so no NullPointerException is generated when
             // formatting (#12588)
-            getLogger().log(Level.SEVERE,
+            getLogger().error(
                     e.getMessage() == null ? "" : e.getMessage(), e);
         }
     }
@@ -69,7 +70,7 @@ public class VConsole {
         if (LogConfiguration.loggingIsEnabled(Level.SEVERE)) {
             // Check for null, so no NullPointerException is generated when
             // formatting (#12588)
-            getLogger().log(Level.SEVERE, msg == null ? "null" : msg);
+            getLogger().error(msg == null ? "null" : msg);
         }
     }
 
@@ -96,8 +97,7 @@ public class VConsole {
         }
     }
 
-    private static Logger getLogger() {
-        return Logger.getLogger(VConsole.class.getName());
+    private static org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(VConsole.class);
     }
-
 }

--- a/client/src/main/java/com/vaadin/client/WidgetSet.java
+++ b/client/src/main/java/com/vaadin/client/WidgetSet.java
@@ -16,9 +16,6 @@
 
 package com.vaadin.client;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.GWT;
 import com.vaadin.client.metadata.BundleLoadCallback;
 import com.vaadin.client.metadata.ConnectorBundleLoader;
@@ -26,6 +23,8 @@ import com.vaadin.client.metadata.NoDataException;
 import com.vaadin.client.metadata.TypeData;
 import com.vaadin.client.ui.UnknownComponentConnector;
 import com.vaadin.client.ui.UnknownExtensionConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WidgetSet {
     /**
@@ -63,7 +62,7 @@ public class WidgetSet {
                         .getUnknownServerClassNameByTag(tag);
                 if (classType == UnknownExtensionConnector.class) {
                     // Display message in the console for non-visual connectors
-                    getLogger().severe(UnknownComponentConnector
+                    getLogger().error(UnknownComponentConnector
                             .createMessage(serverSideName));
                     return GWT.create(UnknownExtensionConnector.class);
                 } else {
@@ -145,8 +144,7 @@ public class WidgetSet {
 
                 @Override
                 public void failed(Throwable reason) {
-                    getLogger().log(Level.SEVERE, "Error loading bundle",
-                            reason);
+                    getLogger().error("Error loading bundle", reason);
                     ApplicationConfiguration.endDependencyLoading();
                 }
             });
@@ -154,6 +152,6 @@ public class WidgetSet {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(WidgetSet.class.getName());
+        return LoggerFactory.getLogger(WidgetSet.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/WidgetUtil.java
+++ b/client/src/main/java/com/vaadin/client/WidgetUtil.java
@@ -16,36 +16,26 @@
 
 package com.vaadin.client;
 
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.dom.client.AnchorElement;
-import com.google.gwt.dom.client.DivElement;
-import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.dom.client.Node;
-import com.google.gwt.dom.client.NodeList;
-import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.dom.client.Touch;
 import com.google.gwt.event.dom.client.KeyEvent;
 import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;
-import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.DOM;
-import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.EventListener;
-import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.*;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.shared.ui.ErrorLevel;
 import com.vaadin.shared.util.SharedUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Utility methods which are related to client side code only.
@@ -126,7 +116,7 @@ public class WidgetUtil {
         try {
             return Float.parseFloat(size.substring(0, size.length() - 1));
         } catch (Exception e) {
-            getLogger().warning("Unable to parse relative size");
+            getLogger().warn("Unable to parse relative size");
             return -1;
         }
     }
@@ -1590,7 +1580,7 @@ public class WidgetUtil {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(WidgetUtil.class.getName());
+        return LoggerFactory.getLogger(WidgetUtil.class);
     }
 
     /**

--- a/client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
+++ b/client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
@@ -16,8 +16,6 @@
 
 package com.vaadin.client.communication;
 
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.Command;
@@ -35,8 +33,9 @@ import com.vaadin.shared.communication.PushConstants;
 import com.vaadin.shared.ui.ui.UIConstants;
 import com.vaadin.shared.ui.ui.UIState.PushConfigurationState;
 import com.vaadin.shared.util.SharedUtil;
-
 import elemental.json.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The default {@link PushConnection} implementation that uses Atmosphere for
@@ -377,7 +376,7 @@ public class AtmospherePushConnection implements PushConnection {
      * tried.
      */
     protected void onTransportFailure() {
-        getLogger().warning("Push connection using primary method ("
+        getLogger().warn("Push connection using primary method ("
                 + getConfig().getTransport() + ") failed. Trying with "
                 + getConfig().getFallbackTransport());
     }
@@ -613,7 +612,7 @@ public class AtmospherePushConnection implements PushConnection {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(AtmospherePushConnection.class.getName());
+        return LoggerFactory.getLogger(AtmospherePushConnection.class);
     }
 
     private ConnectionStateHandler getConnectionStateHandler() {

--- a/client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
+++ b/client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.client.communication;
 
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.shared.GWT;
 import com.google.gwt.http.client.Request;
@@ -29,8 +27,8 @@ import com.vaadin.client.ApplicationConnection.ApplicationStoppedEvent;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.communication.AtmospherePushConnection.AtmosphereResponse;
 import com.vaadin.shared.ui.ui.UIState.ReconnectDialogConfigurationState;
-
 import elemental.json.JsonObject;
+import org.slf4j.LoggerFactory;
 
 /**
  * Default implementation of the connection state handler.
@@ -118,8 +116,8 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
         return reconnectionCause != null;
     }
 
-    private static Logger getLogger() {
-        return Logger.getLogger(DefaultConnectionStateHandler.class.getName());
+    private static org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(DefaultConnectionStateHandler.class);
     }
 
     /**
@@ -139,14 +137,14 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
 
     @Override
     public void heartbeatException(Request request, Throwable exception) {
-        getLogger().severe("Heartbeat exception: " + exception.getMessage());
+        getLogger().error("Heartbeat exception: ", exception.getMessage());
         handleRecoverableError(Type.HEARTBEAT, null);
     }
 
     @Override
     public void heartbeatInvalidStatusCode(Request request, Response response) {
         int statusCode = response.getStatusCode();
-        getLogger().warning("Heartbeat request returned " + statusCode);
+        getLogger().warn("Heartbeat request returned " + statusCode);
 
         if (response.getStatusCode() == Response.SC_GONE) {
             // Session expired
@@ -171,7 +169,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
 
     private void debug(String msg) {
         if (false) {
-            getLogger().warning(msg);
+            getLogger().warn(msg);
         }
     }
 
@@ -195,7 +193,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
         if (!isReconnecting()) {
             // First problem encounter
             reconnectionCause = type;
-            getLogger().warning("Reconnecting because of " + type + " failure");
+            getLogger().warn("Reconnecting because of " + type + " failure");
             // Precaution only as there should never be a dialog at this point
             // and no timer running
             stopDialogTimer();
@@ -212,7 +210,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
             // If a higher priority issues is resolved, we can assume the lower
             // one will be also
             if (type.isHigherPriorityThan(reconnectionCause)) {
-                getLogger().warning(
+                getLogger().warn(
                         "Now reconnecting because of " + type + " failure");
                 reconnectionCause = type;
             }
@@ -277,7 +275,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
         if (!connection.isApplicationRunning()) {
             // This should not happen as nobody should call this if the
             // application has been stopped
-            getLogger().warning(
+            getLogger().warn(
                     "Trying to reconnect after application has been stopped. Giving up");
             return;
         }
@@ -449,7 +447,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
 
         Response response = xhrConnectionError.getResponse();
         int statusCode = response.getStatusCode();
-        getLogger().warning("Server returned " + statusCode + " for xhr");
+        getLogger().warn("Server returned " + statusCode + " for xhr");
 
         if (statusCode == 401) {
             // Authentication/authorization failed, no need to re-try

--- a/client/src/main/java/com/vaadin/client/communication/Heartbeat.java
+++ b/client/src/main/java/com/vaadin/client/communication/Heartbeat.java
@@ -15,18 +15,14 @@
  */
 package com.vaadin.client.communication;
 
-import java.util.logging.Logger;
-
-import com.google.gwt.http.client.Request;
-import com.google.gwt.http.client.RequestBuilder;
-import com.google.gwt.http.client.RequestCallback;
-import com.google.gwt.http.client.RequestException;
-import com.google.gwt.http.client.Response;
+import com.google.gwt.http.client.*;
 import com.google.gwt.user.client.Timer;
 import com.vaadin.client.ApplicationConnection;
 import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.shared.ui.ui.UIConstants;
 import com.vaadin.shared.util.SharedUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles sending of heartbeats to the server and reacting to the response.
@@ -48,7 +44,7 @@ public class Heartbeat {
     private int interval = -1;
 
     private static Logger getLogger() {
-        return Logger.getLogger(Heartbeat.class.getName());
+        return LoggerFactory.getLogger(Heartbeat.class);
     }
 
     /**
@@ -113,7 +109,7 @@ public class Heartbeat {
         rb.setCallback(callback);
 
         try {
-            getLogger().fine("Sending heartbeat request...");
+            getLogger().debug("Sending heartbeat request...");
             rb.send();
         } catch (RequestException re) {
             callback.onError(null, re);
@@ -134,11 +130,10 @@ public class Heartbeat {
      */
     public void schedule() {
         if (interval > 0) {
-            getLogger()
-                    .fine("Scheduling heartbeat in " + interval + " seconds");
+            getLogger().debug("Scheduling heartbeat in {} seconds", interval);
             timer.schedule(interval * 1000);
         } else {
-            getLogger().fine("Disabling heartbeat");
+            getLogger().debug("Disabling heartbeat");
             timer.cancel();
         }
     }

--- a/client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -15,53 +15,16 @@
  */
 package com.vaadin.client.communication;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.google.gwt.core.client.Duration;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.JsArrayString;
-import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.*;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Widget;
-import com.vaadin.client.ApplicationConfiguration;
-import com.vaadin.client.ApplicationConnection;
+import com.vaadin.client.*;
 import com.vaadin.client.ApplicationConnection.ApplicationState;
 import com.vaadin.client.ApplicationConnection.MultiStepDuration;
 import com.vaadin.client.ApplicationConnection.ResponseHandlingStartedEvent;
-import com.vaadin.client.ComponentConnector;
-import com.vaadin.client.ConnectorHierarchyChangeEvent;
-import com.vaadin.client.ConnectorMap;
-import com.vaadin.client.FastStringSet;
-import com.vaadin.client.HasComponentsConnector;
-import com.vaadin.client.JsArrayObject;
-import com.vaadin.client.LayoutManager;
-import com.vaadin.client.LocaleService;
-import com.vaadin.client.Paintable;
-import com.vaadin.client.Profiler;
-import com.vaadin.client.ServerConnector;
-import com.vaadin.client.UIDL;
-import com.vaadin.client.Util;
-import com.vaadin.client.VCaption;
-import com.vaadin.client.VConsole;
-import com.vaadin.client.ValueMap;
-import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.extensions.AbstractExtensionConnector;
-import com.vaadin.client.metadata.ConnectorBundleLoader;
-import com.vaadin.client.metadata.NoDataException;
-import com.vaadin.client.metadata.Property;
-import com.vaadin.client.metadata.Type;
-import com.vaadin.client.metadata.TypeData;
+import com.vaadin.client.metadata.*;
 import com.vaadin.client.ui.AbstractConnector;
 import com.vaadin.client.ui.VNotification;
 import com.vaadin.client.ui.dd.VDragAndDropManager;
@@ -70,10 +33,13 @@ import com.vaadin.client.ui.window.WindowConnector;
 import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.shared.communication.MethodInvocation;
 import com.vaadin.shared.communication.SharedState;
-
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 /**
  * A MessageHandler is responsible for handling all incoming messages (JSON)
@@ -221,7 +187,7 @@ public class MessageHandler {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(MessageHandler.class.getName());
+        return LoggerFactory.getLogger(MessageHandler.class);
     }
 
     /**
@@ -237,7 +203,7 @@ public class MessageHandler {
                     "The json to handle cannot be null");
         }
         if (getServerId(json) == -1) {
-            getLogger().severe("Response didn't contain a server id. "
+            getLogger().error("Response didn't contain a server id. "
                     + "Please verify that the server is up-to-date and that the response data has not been modified in transmission.");
         }
 
@@ -254,7 +220,7 @@ public class MessageHandler {
                 }
             });
         } else {
-            getLogger().warning(
+            getLogger().warn(
                     "Ignored received message because application has already been stopped");
             return;
         }
@@ -289,7 +255,7 @@ public class MessageHandler {
                 // Unexpected server id
                 if (serverId <= lastSeenServerSyncId) {
                     // Why is the server re-sending an old package? Ignore it
-                    getLogger().warning("Received message with server id "
+                    getLogger().warn("Received message with server id "
                             + serverId + " but have already seen "
                             + lastSeenServerSyncId + ". Ignoring it");
                     endRequestIfResponse(json);
@@ -513,8 +479,7 @@ public class MessageHandler {
                         layoutManager.layoutNow();
                     }
                 } catch (final Throwable e) {
-                    getLogger().log(Level.SEVERE, "Error processing layouts",
-                            e);
+                    getLogger().error("Error processing layouts", e);
                 }
                 Profiler.leave("Layout processing");
 
@@ -552,7 +517,7 @@ public class MessageHandler {
                     if (fetchStart != 0) {
                         int time = (int) (Duration.currentTimeMillis()
                                 - fetchStart);
-                        getLogger().log(Level.INFO, "First response processed "
+                        getLogger().info("First response processed "
                                 + time + " ms after fetchStart");
                     }
 
@@ -759,7 +724,7 @@ public class MessageHandler {
                     try {
                         sce.getConnector().fireEvent(sce);
                     } catch (final Throwable e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error sending state change events", e);
                     }
                 }
@@ -778,7 +743,7 @@ public class MessageHandler {
                     ServerConnector c = currentConnectors.get(i);
                     if (c.getParent() != null) {
                         if (!c.getParent().getChildren().contains(c)) {
-                            getLogger().severe("ERROR: Connector "
+                            getLogger().error("ERROR: Connector "
                                     + c.getConnectorId()
                                     + " is connected to a parent but the parent ("
                                     + c.getParent().getConnectorId()
@@ -792,7 +757,7 @@ public class MessageHandler {
                     } else {
                         // The connector has been detached from the
                         // hierarchy but was not unregistered.
-                        getLogger().severe("ERROR: Connector "
+                        getLogger().error("ERROR: Connector "
                                 + c.getConnectorId()
                                 + " is not attached to a parent but has not been unregistered");
                     }
@@ -885,8 +850,7 @@ public class MessageHandler {
                             createdConnectors.push(connectorId);
                         }
                     } catch (final Throwable e) {
-                        getLogger().log(Level.SEVERE,
-                                "Error handling type data", e);
+                        getLogger().error("Error handling type data", e);
                     }
                 }
 
@@ -932,12 +896,12 @@ public class MessageHandler {
                                 Profiler.leave(key);
                             }
                         } else if (legacyConnector == null) {
-                            getLogger().severe("Received update for "
+                            getLogger().error("Received update for "
                                     + uidl.getTag()
                                     + ", but there is no such paintable ("
                                     + connectorId + ") rendered.");
                         } else {
-                            getLogger().severe(
+                            getLogger().error(
                                     "Server sent Vaadin 6 style updates for "
                                             + Util.getConnectorString(
                                                     legacyConnector)
@@ -945,7 +909,7 @@ public class MessageHandler {
                         }
 
                     } catch (final Throwable e) {
-                        getLogger().log(Level.SEVERE, "Error handling UIDL", e);
+                        getLogger().error("Error handling UIDL", e);
                     }
                 }
 
@@ -967,7 +931,7 @@ public class MessageHandler {
                         logHierarchyChange(event);
                         event.getConnector().fireEvent(event);
                     } catch (final Throwable e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error sending hierarchy change events", e);
                     }
                 }
@@ -1083,8 +1047,7 @@ public class MessageHandler {
                             Profiler.leave("updateConnectorState inner loop");
                         }
                     } catch (final Throwable e) {
-                        getLogger().log(Level.SEVERE,
-                                "Error updating connector states", e);
+                        getLogger().error("Error updating connector states", e);
                     }
                 }
 
@@ -1230,7 +1193,7 @@ public class MessageHandler {
                         ServerConnector childConnector = connectorMap
                                 .getConnector(childConnectorId);
                         if (childConnector == null) {
-                            getLogger().severe("Hierarchy claims that "
+                            getLogger().error("Hierarchy claims that "
                                     + childConnectorId + " is a child for "
                                     + connectorId + " ("
                                     + parentConnector.getClass().getName()
@@ -1292,7 +1255,7 @@ public class MessageHandler {
                             result.events.add(event);
                         }
                     } else if (!newComponents.isEmpty()) {
-                        getLogger().severe("Hierachy claims "
+                        getLogger().error("Hierachy claims "
                                 + Util.getConnectorString(parentConnector)
                                 + " has component children even though it isn't a HasComponentsConnector");
                     }
@@ -1330,8 +1293,7 @@ public class MessageHandler {
                     Profiler.leave(
                             "updateConnectorHierarchy find removed children");
                 } catch (final Throwable e) {
-                    getLogger().log(Level.SEVERE,
-                            "Error updating connector hierarchy", e);
+                    getLogger().error("Error updating connector hierarchy", e);
                 } finally {
                     Profiler.leave("updateConnectorHierarchy hierarchy entry");
                 }
@@ -1483,7 +1445,7 @@ public class MessageHandler {
                             }
 
                         } catch (final Throwable e) {
-                            getLogger().log(Level.SEVERE,
+                            getLogger().error(
                                     "Error performing server to client RPC calls",
                                     e);
                         }
@@ -1558,7 +1520,7 @@ public class MessageHandler {
             if (!responseHandlingLocks.isEmpty()) {
                 // Lock which was never release -> bug in locker or things just
                 // too slow
-                getLogger().warning(
+                getLogger().warn(
                         "WARNING: reponse handling was never resumed, forcibly removing locks...");
                 responseHandlingLocks.clear();
             } else {
@@ -1566,7 +1528,7 @@ public class MessageHandler {
                 // Do one final check and resynchronize if the message is not
                 // there. The final check is only a precaution as this timer
                 // should have been cancelled if the message has arrived
-                getLogger().warning("Gave up waiting for message "
+                getLogger().warn("Gave up waiting for message "
                         + getExpectedServerId() + " from the server");
 
             }
@@ -1792,7 +1754,7 @@ public class MessageHandler {
                     + "ms");
             return json;
         } catch (final Exception e) {
-            getLogger().severe("Unable to parse JSON: " + jsonText);
+            getLogger().error("Unable to parse JSON: " + jsonText);
             return null;
         }
     }

--- a/client/src/main/java/com/vaadin/client/communication/MessageSender.java
+++ b/client/src/main/java/com/vaadin/client/communication/MessageSender.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.client.communication;
 
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.Command;
@@ -29,11 +27,12 @@ import com.vaadin.client.VLoadingIndicator;
 import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.shared.Version;
 import com.vaadin.shared.ui.ui.UIState.PushConfigurationState;
-
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * MessageSender is responsible for sending messages to the server.
@@ -73,12 +72,12 @@ public class MessageSender {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(MessageSender.class.getName());
+        return LoggerFactory.getLogger(MessageSender.class);
     }
 
     public void sendInvocationsToServer() {
         if (!connection.isApplicationRunning()) {
-            getLogger().warning(
+            getLogger().warn(
                     "Trying to send RPC from not yet started or stopped application");
             return;
         }
@@ -114,7 +113,7 @@ public class MessageSender {
         if (reqJson.length() == 0) {
             // Nothing to send, all invocations were filtered out (for
             // non-existing connectors)
-            getLogger().warning(
+            getLogger().warn(
                     "All RPCs filtered out, not sending anything to the server");
             return;
         }
@@ -226,7 +225,7 @@ public class MessageSender {
 
     public void startRequest() {
         if (hasActiveRequest) {
-            getLogger().severe(
+            getLogger().error(
                     "Trying to start a new request while another is active");
         }
         hasActiveRequest = true;
@@ -235,7 +234,7 @@ public class MessageSender {
 
     public void endRequest() {
         if (!hasActiveRequest) {
-            getLogger().severe("No active request");
+            getLogger().error("No active request");
         }
         // After sendInvocationsToServer() there may be a new active
         // request, so we must set hasActiveRequest to false before, not after,
@@ -390,7 +389,7 @@ public class MessageSender {
                 getLogger().info("Updating client-to-server id to "
                         + nextExpectedId + " based on server");
             } else {
-                getLogger().warning(
+                getLogger().warn(
                         "Server expects next client-to-server id to be "
                                 + nextExpectedId + " but we were going to use "
                                 + clientToServerMessageId + ". Will use "

--- a/client/src/main/java/com/vaadin/client/communication/RpcManager.java
+++ b/client/src/main/java/com/vaadin/client/communication/RpcManager.java
@@ -16,9 +16,6 @@
 
 package com.vaadin.client.communication;
 
-import java.util.Collection;
-import java.util.logging.Logger;
-
 import com.vaadin.client.ApplicationConnection;
 import com.vaadin.client.ConnectorMap;
 import com.vaadin.client.ServerConnector;
@@ -27,8 +24,11 @@ import com.vaadin.client.metadata.NoDataException;
 import com.vaadin.client.metadata.Type;
 import com.vaadin.shared.communication.ClientRpc;
 import com.vaadin.shared.communication.MethodInvocation;
-
 import elemental.json.JsonArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
 
 /**
  * Client side RPC manager that can invoke methods based on RPC calls received
@@ -144,6 +144,6 @@ public class RpcManager {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(RpcManager.class.getName());
+        return LoggerFactory.getLogger(RpcManager.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/communication/ServerRpcQueue.java
+++ b/client/src/main/java/com/vaadin/client/communication/ServerRpcQueue.java
@@ -15,11 +15,6 @@
  */
 package com.vaadin.client.communication;
 
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.vaadin.client.ApplicationConnection;
@@ -30,10 +25,15 @@ import com.vaadin.client.metadata.Type;
 import com.vaadin.client.metadata.TypeDataStore;
 import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.shared.communication.MethodInvocation;
-
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 
 /**
  * Manages the queue of server invocations (RPC) which are waiting to be sent to
@@ -78,7 +78,7 @@ public class ServerRpcQueue {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(ServerRpcQueue.class.getName());
+        return LoggerFactory.getLogger(ServerRpcQueue.class);
     }
 
     /**
@@ -112,7 +112,7 @@ public class ServerRpcQueue {
      */
     public void add(MethodInvocation invocation, boolean lastOnly) {
         if (!connection.isApplicationRunning()) {
-            getLogger().warning(
+            getLogger().warn(
                     "Trying to invoke method on not yet started or stopped application");
             return;
         }

--- a/client/src/main/java/com/vaadin/client/communication/XhrConnection.java
+++ b/client/src/main/java/com/vaadin/client/communication/XhrConnection.java
@@ -15,32 +15,23 @@
  */
 package com.vaadin.client.communication;
 
-import java.util.logging.Logger;
-
-import com.google.gwt.http.client.Request;
-import com.google.gwt.http.client.RequestBuilder;
-import com.google.gwt.http.client.RequestCallback;
-import com.google.gwt.http.client.RequestException;
-import com.google.gwt.http.client.Response;
+import com.google.gwt.http.client.*;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.Window.ClosingEvent;
 import com.google.gwt.user.client.Window.ClosingHandler;
-import com.vaadin.client.ApplicationConnection;
+import com.vaadin.client.*;
 import com.vaadin.client.ApplicationConnection.CommunicationHandler;
 import com.vaadin.client.ApplicationConnection.RequestStartingEvent;
 import com.vaadin.client.ApplicationConnection.ResponseHandlingEndedEvent;
 import com.vaadin.client.ApplicationConnection.ResponseHandlingStartedEvent;
-import com.vaadin.client.BrowserInfo;
-import com.vaadin.client.Profiler;
-import com.vaadin.client.Util;
-import com.vaadin.client.ValueMap;
 import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.shared.JsonConstants;
 import com.vaadin.shared.ui.ui.UIConstants;
 import com.vaadin.shared.util.SharedUtil;
-
 import elemental.json.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provides a connection to the /UIDL url on the server and knows how to send
@@ -102,7 +93,7 @@ public class XhrConnection {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(XhrConnection.class.getName());
+        return LoggerFactory.getLogger(XhrConnection.class);
     }
 
     protected XhrResponseHandler createResponseHandler() {

--- a/client/src/main/java/com/vaadin/client/connectors/JavaScriptRendererConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/JavaScriptRendererConnector.java
@@ -15,11 +15,6 @@
  */
 package com.vaadin.client.connectors;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.NativeEvent;
@@ -34,9 +29,14 @@ import com.vaadin.client.widget.grid.CellReference;
 import com.vaadin.client.widget.grid.RendererCellReference;
 import com.vaadin.shared.JavaScriptExtensionState;
 import com.vaadin.shared.ui.Connect;
-
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Connector for server-side renderer implemented using JavaScript.
@@ -139,7 +139,7 @@ public class JavaScriptRendererConnector
         }
 
         if (hasFunction("destory")) {
-            getLogger().severe("Your JavaScript connector ("
+            getLogger().error("Your JavaScript connector ("
                     + helper.getInitFunctionName()
                     + ") has a typo. The destory method should be renamed to destroy.");
         }
@@ -192,7 +192,7 @@ public class JavaScriptRendererConnector
 
             @Override
             public void destroy(RendererCellReference cell) {
-                getLogger().warning("Destprying: " + cell.getRowIndex() + " "
+                getLogger().warn("Destroying: " + cell.getRowIndex() + " "
                         + cell.getColumnIndexDOM());
                 if (hasDestroy) {
                     destroy(helper.getConnectorWrapper(), getJsCell(cell));
@@ -274,7 +274,7 @@ public class JavaScriptRendererConnector
     }
 
     private Logger getLogger() {
-        return Logger.getLogger(JavaScriptRendererConnector.class.getName());
+        return LoggerFactory.getLogger(JavaScriptRendererConnector.class);
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/debug/internal/ConnectorInfoPanel.java
+++ b/client/src/main/java/com/vaadin/client/debug/internal/ConnectorInfoPanel.java
@@ -15,12 +15,6 @@
  */
 package com.vaadin.client.debug.internal;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTML;
 import com.vaadin.client.ComponentConnector;
@@ -32,6 +26,12 @@ import com.vaadin.client.metadata.Property;
 import com.vaadin.client.ui.AbstractConnector;
 import com.vaadin.shared.AbstractComponentState;
 import com.vaadin.shared.communication.SharedState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Connector information view panel of the debug window.
@@ -85,7 +85,7 @@ public class ConnectorInfoPanel extends FlowPanel {
             }
         } catch (NoDataException e) {
             html += "<div>Could not read state, error has been logged to the console</div>";
-            getLogger().log(Level.SEVERE, "Could not read state", e);
+            getLogger().error("Could not read state", e);
         }
 
         clear();
@@ -108,6 +108,6 @@ public class ConnectorInfoPanel extends FlowPanel {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(ConnectorInfoPanel.class.getName());
+        return LoggerFactory.getLogger(ConnectorInfoPanel.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/debug/internal/LogSection.java
+++ b/client/src/main/java/com/vaadin/client/debug/internal/LogSection.java
@@ -149,6 +149,7 @@ public class LogSection implements Section {
             selectText(el);
         });
 
+        // Set up logging in JUL, since slf4j-gwt use it as backend
         // Add handler to the root logger
         Logger.getLogger("").addHandler(new LogSectionHandler());
     }

--- a/client/src/main/java/com/vaadin/client/debug/internal/OptimizedWidgetsetPanel.java
+++ b/client/src/main/java/com/vaadin/client/debug/internal/OptimizedWidgetsetPanel.java
@@ -15,10 +15,6 @@
  */
 package com.vaadin.client.debug.internal;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTML;
 import com.vaadin.client.ApplicationConfiguration;
@@ -27,6 +23,11 @@ import com.vaadin.client.ServerConnector;
 import com.vaadin.client.Util;
 import com.vaadin.client.ui.UnknownComponentConnector;
 import com.vaadin.client.ui.UnknownExtensionConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Optimized widgetset view panel of the debug window.
@@ -97,7 +98,7 @@ public class OptimizedWidgetsetPanel extends FlowPanel {
             tag++;
             if (tag > 10000) {
                 // Sanity check
-                getLogger().severe(
+                getLogger().error(
                         "Search for used connector classes was forcefully terminated");
                 break;
             }
@@ -140,6 +141,6 @@ public class OptimizedWidgetsetPanel extends FlowPanel {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(OptimizedWidgetsetPanel.class.getName());
+        return LoggerFactory.getLogger(OptimizedWidgetsetPanel.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/DragSourceExtensionConnector.java
@@ -15,11 +15,6 @@
  */
 package com.vaadin.client.extensions;
 
-import java.util.LinkedHashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import com.google.gwt.animation.client.AnimationScheduler;
 import com.google.gwt.dom.client.DataTransfer;
 import com.google.gwt.dom.client.Element;
@@ -39,10 +34,14 @@ import com.vaadin.shared.ui.dnd.DragSourceRpc;
 import com.vaadin.shared.ui.dnd.DragSourceState;
 import com.vaadin.shared.ui.dnd.DropEffect;
 import com.vaadin.ui.dnd.DragSourceExtension;
-
 import elemental.events.Event;
 import elemental.events.EventListener;
 import elemental.events.EventTarget;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Extension to add drag source functionality to a widget for using HTML5 drag
@@ -362,7 +361,7 @@ public class DragSourceExtensionConnector extends AbstractExtensionConnector {
                     .trim();
             return Integer.parseInt(x);
         } catch (NumberFormatException nfe) {
-            Logger.getLogger(DragSourceExtensionConnector.class.getName()).info(
+            LoggerFactory.getLogger(DragSourceExtensionConnector.class).info(
                     "Unable to parse \"transform: translate(...)\" matrix " + n
                             + ". value from computed style, matrix \"" + matrix
                             + "\", drag image might not be visible");

--- a/client/src/main/java/com/vaadin/client/extensions/ResponsiveConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/ResponsiveConnector.java
@@ -16,9 +16,6 @@
 
 package com.vaadin.client.extensions;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.vaadin.client.LayoutManager;
 import com.vaadin.client.ServerConnector;
@@ -30,6 +27,8 @@ import com.vaadin.server.Responsive;
 import com.vaadin.shared.extension.responsive.ResponsiveState;
 import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.util.SharedUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The client side connector for the Responsive extension.
@@ -76,15 +75,15 @@ public class ResponsiveConnector extends AbstractExtensionConnector
     protected static String parsedTheme;
 
     private static Logger getLogger() {
-        return Logger.getLogger(ResponsiveConnector.class.getName());
+        return LoggerFactory.getLogger(ResponsiveConnector.class);
     }
 
     private static void error(String message) {
-        getLogger().log(Level.SEVERE, message);
+        getLogger().error(message);
     }
 
     private static void warning(String message) {
-        getLogger().warning(message);
+        getLogger().warn(message);
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/metadata/ConnectorBundleLoader.java
+++ b/client/src/main/java/com/vaadin/client/metadata/ConnectorBundleLoader.java
@@ -15,24 +15,19 @@
  */
 package com.vaadin.client.metadata;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.shared.GWT;
 import com.google.gwt.dom.client.Style;
-import com.google.gwt.dom.client.Style.Display;
-import com.google.gwt.dom.client.Style.Position;
-import com.google.gwt.dom.client.Style.TextAlign;
-import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.dom.client.Style.Visibility;
-import com.google.gwt.dom.client.Style.WhiteSpace;
+import com.google.gwt.dom.client.Style.*;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.vaadin.client.FastStringMap;
 import com.vaadin.client.metadata.AsyncBundleLoader.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class ConnectorBundleLoader {
 
@@ -213,7 +208,7 @@ public abstract class ConnectorBundleLoader {
 
                 @Override
                 public void failed(Throwable reason) {
-                    getLogger().log(Level.SEVERE,
+                    getLogger().error(
                             "Error loading deferred bundle", reason);
                 }
             });
@@ -221,7 +216,7 @@ public abstract class ConnectorBundleLoader {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(ConnectorBundleLoader.class.getName());
+        return LoggerFactory.getLogger(ConnectorBundleLoader.class);
     }
 
     /**

--- a/client/src/main/java/com/vaadin/client/ui/VOverlay.java
+++ b/client/src/main/java/com/vaadin/client/ui/VOverlay.java
@@ -16,8 +16,6 @@
 
 package com.vaadin.client.ui;
 
-import java.util.logging.Logger;
-
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
@@ -27,6 +25,7 @@ import com.vaadin.client.ApplicationConnection;
 import com.vaadin.client.ComponentConnector;
 import com.vaadin.client.Util;
 import com.vaadin.client.widgets.Overlay;
+import org.slf4j.LoggerFactory;
 
 /**
  * In Vaadin UI this VOverlay should always be used for all elements that
@@ -108,7 +107,7 @@ public class VOverlay extends Overlay {
         if (ac == null) {
             // could not figure out which one we belong to, styling will
             // probably fail
-            Logger.getLogger(getClass().getSimpleName()).warning(
+            LoggerFactory.getLogger(getClass()).warn(
                     "Could not determine ApplicationConnection for Overlay. Overlay will be attached directly to the root panel");
             return super.getOverlayContainer();
         } else {

--- a/client/src/main/java/com/vaadin/client/ui/combobox/ComboBoxConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/combobox/ComboBoxConnector.java
@@ -15,10 +15,6 @@
  */
 package com.vaadin.client.ui.combobox;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.logging.Logger;
-
 import com.vaadin.client.Profiler;
 import com.vaadin.client.annotations.OnStateChange;
 import com.vaadin.client.communication.StateChangeEvent;
@@ -42,8 +38,10 @@ import com.vaadin.shared.ui.combobox.ComboBoxConstants;
 import com.vaadin.shared.ui.combobox.ComboBoxServerRpc;
 import com.vaadin.shared.ui.combobox.ComboBoxState;
 import com.vaadin.ui.ComboBox;
-
 import elemental.json.JsonObject;
+
+import java.util.List;
+import java.util.Objects;
 
 @Connect(ComboBox.class)
 public class ComboBoxConnector extends AbstractListingConnector
@@ -379,9 +377,6 @@ public class ComboBoxConnector extends AbstractListingConnector
             getWidget().currentPage = 0;
         }
     }
-
-    private static final Logger LOGGER = Logger
-            .getLogger(ComboBoxConnector.class.getName());
 
     private class PagedDataChangeHandler implements DataChangeHandler {
 

--- a/client/src/main/java/com/vaadin/client/ui/customfield/CustomFieldConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/customfield/CustomFieldConnector.java
@@ -15,10 +15,6 @@
  */
 package com.vaadin.client.ui.customfield;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.logging.Logger;
-
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.client.ComponentConnector;
@@ -32,6 +28,11 @@ import com.vaadin.client.ui.VCustomField;
 import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.ui.customfield.CustomFieldState;
 import com.vaadin.ui.CustomField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
 
 @Connect(value = CustomField.class)
 public class CustomFieldConnector extends AbstractFieldConnector
@@ -73,7 +74,7 @@ public class CustomFieldConnector extends AbstractFieldConnector
                 getWidget().setFocusDelegate(
                         (com.google.gwt.user.client.ui.Focusable) widget);
             } else {
-                getLogger().warning(
+                getLogger().warn(
                         "The given focus delegate does not implement Focusable: "
                                 + widget.getClass().getName());
             }
@@ -84,7 +85,7 @@ public class CustomFieldConnector extends AbstractFieldConnector
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(CustomFieldConnector.class.getName());
+        return LoggerFactory.getLogger(CustomFieldConnector.class);
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/ui/customlayout/CustomLayoutConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/customlayout/CustomLayoutConnector.java
@@ -15,15 +15,9 @@
  */
 package com.vaadin.client.ui.customlayout;
 
-import java.util.logging.Logger;
-
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Widget;
-import com.vaadin.client.ApplicationConnection;
-import com.vaadin.client.ComponentConnector;
-import com.vaadin.client.ConnectorHierarchyChangeEvent;
-import com.vaadin.client.Paintable;
-import com.vaadin.client.UIDL;
+import com.vaadin.client.*;
 import com.vaadin.client.communication.StateChangeEvent;
 import com.vaadin.client.ui.AbstractLayoutConnector;
 import com.vaadin.client.ui.SimpleManagedLayout;
@@ -31,6 +25,8 @@ import com.vaadin.client.ui.VCustomLayout;
 import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.ui.customlayout.CustomLayoutState;
 import com.vaadin.ui.CustomLayout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Connect(CustomLayout.class)
 public class CustomLayoutConnector extends AbstractLayoutConnector
@@ -111,7 +107,7 @@ public class CustomLayoutConnector extends AbstractLayoutConnector
                 getWidget().setWidget(child.getWidget(), location);
             } catch (final IllegalArgumentException e) {
                 // If no location is found, this component is not visible
-                getLogger().warning("Child not rendered as no slot with id '"
+                getLogger().warn("Child not rendered as no slot with id '"
                         + location + "' has been defined");
             }
         }
@@ -151,6 +147,6 @@ public class CustomLayoutConnector extends AbstractLayoutConnector
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(CustomLayoutConnector.class.getName());
+        return LoggerFactory.getLogger(CustomLayoutConnector.class);
     }
 }

--- a/client/src/main/java/com/vaadin/client/ui/draganddropwrapper/DragAndDropWrapperConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/draganddropwrapper/DragAndDropWrapperConnector.java
@@ -15,17 +15,7 @@
  */
 package com.vaadin.client.ui.draganddropwrapper;
 
-import java.util.HashMap;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.vaadin.client.ApplicationConnection;
-import com.vaadin.client.ComponentConnector;
-import com.vaadin.client.ConnectorMap;
-import com.vaadin.client.Paintable;
-import com.vaadin.client.UIDL;
-import com.vaadin.client.VConsole;
+import com.vaadin.client.*;
 import com.vaadin.client.extensions.DragSourceExtensionConnector;
 import com.vaadin.client.extensions.DropTargetExtensionConnector;
 import com.vaadin.client.ui.VDragAndDropWrapper;
@@ -34,6 +24,11 @@ import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.ui.draganddropwrapper.DragAndDropWrapperConstants;
 import com.vaadin.shared.ui.draganddropwrapper.DragAndDropWrapperServerRpc;
 import com.vaadin.ui.DragAndDropWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Set;
 
 /**
  *
@@ -113,7 +108,7 @@ public class DragAndDropWrapperConnector extends CustomComponentConnector
                         .getConnector(dragImageComponentConnectorId);
 
                 if (connector == null) {
-                    getLogger().log(Level.WARNING,
+                    getLogger().warn(
                             "DragAndDropWrapper drag image component"
                                     + " connector now found. Make sure the"
                                     + " component is attached.");
@@ -136,7 +131,7 @@ public class DragAndDropWrapperConnector extends CustomComponentConnector
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(DragAndDropWrapperConnector.class.getName());
+        return LoggerFactory.getLogger(DragAndDropWrapperConnector.class);
     }
 
     @Override

--- a/client/src/main/java/com/vaadin/client/ui/layout/LayoutDependencyTree.java
+++ b/client/src/main/java/com/vaadin/client/ui/layout/LayoutDependencyTree.java
@@ -15,25 +15,16 @@
  */
 package com.vaadin.client.ui.layout;
 
+import com.google.gwt.core.client.JsArrayString;
+import com.vaadin.client.*;
+import com.vaadin.client.ui.ManagedLayout;
+import com.vaadin.shared.AbstractComponentState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.Logger;
-
-import com.google.gwt.core.client.JsArrayString;
-import com.vaadin.client.ApplicationConnection;
-import com.vaadin.client.ComponentConnector;
-import com.vaadin.client.ConnectorMap;
-import com.vaadin.client.FastStringMap;
-import com.vaadin.client.FastStringSet;
-import com.vaadin.client.HasComponentsConnector;
-import com.vaadin.client.JsArrayObject;
-import com.vaadin.client.Profiler;
-import com.vaadin.client.ServerConnector;
-import com.vaadin.client.Util;
-import com.vaadin.client.VConsole;
-import com.vaadin.client.ui.ManagedLayout;
-import com.vaadin.shared.AbstractComponentState;
 
 /**
  * Internal class used to keep track of layout dependencies during one layout
@@ -498,7 +489,7 @@ public class LayoutDependencyTree {
                 connector = (ComponentConnector) ConnectorMap.get(connection)
                         .getConnector(connectorId);
                 if (connector == null) {
-                    getLogger().warning("No connector found for id "
+                    getLogger().warn("No connector found for id "
                             + connectorId + " while creating LayoutDependency");
                     return null;
                 }
@@ -537,8 +528,7 @@ public class LayoutDependencyTree {
         if (dependency != null) {
             dependency.setNeedsLayout(needsLayout);
         } else {
-            getLogger()
-                    .warning("No dependency found in setNeedsHorizontalLayout");
+            getLogger().warn("No dependency found in setNeedsHorizontalLayout");
         }
     }
 
@@ -562,10 +552,8 @@ public class LayoutDependencyTree {
         if (dependency != null) {
             dependency.setNeedsLayout(needsLayout);
         } else {
-            getLogger()
-                    .warning("No dependency found in setNeedsVerticalLayout");
+            getLogger().warn("No dependency found in setNeedsVerticalLayout");
         }
-
     }
 
     public void markAsHorizontallyLayouted(ManagedLayout layout) {
@@ -756,7 +744,6 @@ public class LayoutDependencyTree {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(LayoutDependencyTree.class.getName());
+        return LoggerFactory.getLogger(LayoutDependencyTree.class);
     }
-
 }

--- a/client/src/main/java/com/vaadin/client/ui/treegrid/TreeGridConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/treegrid/TreeGridConnector.java
@@ -15,13 +15,6 @@
  */
 package com.vaadin.client.ui.treegrid;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.BrowserEvents;
 import com.google.gwt.dom.client.Element;
@@ -42,13 +35,11 @@ import com.vaadin.shared.Range;
 import com.vaadin.shared.data.DataCommunicatorConstants;
 import com.vaadin.shared.data.HierarchicalDataCommunicatorConstants;
 import com.vaadin.shared.ui.Connect;
-import com.vaadin.shared.ui.treegrid.FocusParentRpc;
-import com.vaadin.shared.ui.treegrid.FocusRpc;
-import com.vaadin.shared.ui.treegrid.NodeCollapseRpc;
-import com.vaadin.shared.ui.treegrid.TreeGridClientRpc;
-import com.vaadin.shared.ui.treegrid.TreeGridState;
-
+import com.vaadin.shared.ui.treegrid.*;
 import elemental.json.JsonObject;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 /**
  * A connector class for the TreeGrid component.
@@ -143,8 +134,8 @@ public class TreeGridConnector extends GridConnector {
 
                 hierarchyColumnId = newHierarchyColumnId;
             } else {
-                Logger.getLogger(TreeGridConnector.class.getName()).warning(
-                        "Couldn't find column: " + newHierarchyColumnId);
+                LoggerFactory.getLogger(TreeGridConnector.class).warn(
+                        "Couldn't find column: {}", newHierarchyColumnId);
             }
         });
         hierarchyColumnUpdateScheduled = true;

--- a/client/src/main/java/com/vaadin/client/ui/ui/UIConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/ui/UIConnector.java
@@ -15,93 +15,47 @@
  */
 package com.vaadin.client.ui.ui;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.HeadElement;
-import com.google.gwt.dom.client.LinkElement;
-import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.dom.client.NodeList;
-import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Position;
-import com.google.gwt.dom.client.StyleInjector;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwt.event.dom.client.ScrollHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.DOM;
-import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.History;
+import com.google.gwt.user.client.*;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.Widget;
-import com.vaadin.client.ApplicationConnection;
+import com.vaadin.client.*;
 import com.vaadin.client.ApplicationConnection.ApplicationStoppedEvent;
-import com.vaadin.client.BrowserInfo;
-import com.vaadin.client.ComponentConnector;
-import com.vaadin.client.ConnectorHierarchyChangeEvent;
-import com.vaadin.client.Focusable;
-import com.vaadin.client.Paintable;
-import com.vaadin.client.ResourceLoader;
 import com.vaadin.client.ResourceLoader.ResourceLoadEvent;
 import com.vaadin.client.ResourceLoader.ResourceLoadListener;
-import com.vaadin.client.ServerConnector;
-import com.vaadin.client.UIDL;
-import com.vaadin.client.Util;
-import com.vaadin.client.VConsole;
-import com.vaadin.client.ValueMap;
 import com.vaadin.client.annotations.OnStateChange;
 import com.vaadin.client.communication.StateChangeEvent;
 import com.vaadin.client.communication.StateChangeEvent.StateChangeHandler;
 import com.vaadin.client.extensions.DragSourceExtensionConnector;
 import com.vaadin.client.extensions.DropTargetExtensionConnector;
-import com.vaadin.client.ui.AbstractConnector;
-import com.vaadin.client.ui.AbstractSingleComponentContainerConnector;
-import com.vaadin.client.ui.ClickEventHandler;
-import com.vaadin.client.ui.ShortcutActionHandler;
-import com.vaadin.client.ui.VOverlay;
-import com.vaadin.client.ui.VUI;
-import com.vaadin.client.ui.VWindow;
+import com.vaadin.client.ui.*;
 import com.vaadin.client.ui.layout.MayScrollChildren;
 import com.vaadin.client.ui.window.WindowConnector;
 import com.vaadin.client.ui.window.WindowOrderEvent;
 import com.vaadin.client.ui.window.WindowOrderHandler;
 import com.vaadin.server.Page.Styles;
-import com.vaadin.shared.ApplicationConstants;
-import com.vaadin.shared.Connector;
-import com.vaadin.shared.EventId;
-import com.vaadin.shared.MouseEventDetails;
-import com.vaadin.shared.Version;
+import com.vaadin.shared.*;
 import com.vaadin.shared.communication.MethodInvocation;
 import com.vaadin.shared.ui.ComponentStateUtil;
 import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.ui.Connect.LoadStyle;
 import com.vaadin.shared.ui.WindowOrderRpc;
-import com.vaadin.shared.ui.ui.DebugWindowClientRpc;
-import com.vaadin.shared.ui.ui.DebugWindowServerRpc;
-import com.vaadin.shared.ui.ui.PageClientRpc;
-import com.vaadin.shared.ui.ui.PageState;
-import com.vaadin.shared.ui.ui.ScrollClientRpc;
-import com.vaadin.shared.ui.ui.UIClientRpc;
-import com.vaadin.shared.ui.ui.UIConstants;
-import com.vaadin.shared.ui.ui.UIServerRpc;
-import com.vaadin.shared.ui.ui.UIState;
+import com.vaadin.shared.ui.ui.*;
 import com.vaadin.shared.util.SharedUtil;
 import com.vaadin.ui.UI;
-
 import elemental.client.Browser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 @Connect(value = UI.class, loadStyle = LoadStyle.EAGER)
 public class UIConnector extends AbstractSingleComponentContainerConnector
@@ -389,7 +343,7 @@ public class UIConnector extends AbstractSingleComponentContainerConnector
                     } else if (toBeFocused instanceof Focusable) {
                         ((Focusable) toBeFocused).focus();
                     } else {
-                        getLogger().severe(
+                        getLogger().error(
                                 "Server is trying to set focus to the widget of connector "
                                         + Util.getConnectorString(connector)
                                         + " but it is not focusable. The widget should implement either "
@@ -939,7 +893,7 @@ public class UIConnector extends AbstractSingleComponentContainerConnector
 
             if (tagToReplace == null) {
                 getLogger()
-                        .warning("Did not find the link tag for the old theme ("
+                        .warn("Did not find the link tag for the old theme ("
                                 + oldThemeUrl
                                 + "), adding a new stylesheet for the new theme ("
                                 + newThemeUrl + ")");
@@ -1036,7 +990,7 @@ public class UIConnector extends AbstractSingleComponentContainerConnector
 
                     @Override
                     public void onError(ResourceLoadEvent event) {
-                        getLogger().warning("Could not load theme from "
+                        getLogger().warn("Could not load theme from "
                                 + getThemeUrl(newTheme));
                     }
                 }, null);
@@ -1100,7 +1054,7 @@ public class UIConnector extends AbstractSingleComponentContainerConnector
             if (child instanceof AbstractConnector) {
                 forceStateChangeRecursively((AbstractConnector) child);
             } else {
-                getLogger().warning(
+                getLogger().warn(
                         "Could not force state change for unknown connector type: "
                                 + child.getClass().getName());
             }
@@ -1151,7 +1105,7 @@ public class UIConnector extends AbstractSingleComponentContainerConnector
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(UIConnector.class.getName());
+        return LoggerFactory.getLogger(UIConnector.class);
     }
 
     private void setWindowOrderAndPosition() {

--- a/client/src/main/java/com/vaadin/client/ui/window/WindowConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/window/WindowConnector.java
@@ -15,14 +15,8 @@
  */
 package com.vaadin.client.ui.window;
 
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.dom.client.Node;
-import com.google.gwt.dom.client.NodeList;
-import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -31,25 +25,16 @@ import com.google.gwt.event.dom.client.DoubleClickEvent;
 import com.google.gwt.event.dom.client.DoubleClickHandler;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Window;
-import com.vaadin.client.ApplicationConnection;
-import com.vaadin.client.ComponentConnector;
-import com.vaadin.client.ConnectorHierarchyChangeEvent;
-import com.vaadin.client.LayoutManager;
-import com.vaadin.client.Paintable;
-import com.vaadin.client.UIDL;
+import com.vaadin.client.*;
 import com.vaadin.client.communication.StateChangeEvent;
-import com.vaadin.client.ui.AbstractSingleComponentContainerConnector;
-import com.vaadin.client.ui.ClickEventHandler;
-import com.vaadin.client.ui.PostLayoutListener;
-import com.vaadin.client.ui.ShortcutActionHandler;
-import com.vaadin.client.ui.SimpleManagedLayout;
-import com.vaadin.client.ui.VWindow;
+import com.vaadin.client.ui.*;
 import com.vaadin.client.ui.layout.MayScrollChildren;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.ui.window.WindowMode;
 import com.vaadin.shared.ui.window.WindowServerRpc;
 import com.vaadin.shared.ui.window.WindowState;
+import org.slf4j.LoggerFactory;
 
 @Connect(value = com.vaadin.ui.Window.class)
 public class WindowConnector extends AbstractSingleComponentContainerConnector
@@ -274,8 +259,8 @@ public class WindowConnector extends AbstractSingleComponentContainerConnector
         VWindow window = getWidget();
 
         if (!window.isAttached()) {
-            Logger.getLogger(WindowConnector.class.getName())
-                    .warning("Called postLayout to detached Window.");
+            LoggerFactory.getLogger(WindowConnector.class)
+                    .warn("Called postLayout to detached Window.");
             return;
         }
         if (window.centered && getState().windowMode != WindowMode.MAXIMIZED) {

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -15,22 +15,6 @@
  */
 package com.vaadin.client.widgets;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.TreeMap;
-import java.util.function.Consumer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.animation.client.Animation;
 import com.google.gwt.animation.client.AnimationScheduler;
 import com.google.gwt.animation.client.AnimationScheduler.AnimationCallback;
@@ -40,19 +24,9 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.dom.client.DivElement;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.dom.client.Node;
-import com.google.gwt.dom.client.NodeList;
-import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.dom.client.TableCellElement;
-import com.google.gwt.dom.client.TableRowElement;
-import com.google.gwt.dom.client.TableSectionElement;
-import com.google.gwt.dom.client.Touch;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.logging.client.LogConfiguration;
 import com.google.gwt.user.client.DOM;
@@ -61,31 +35,15 @@ import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.UIObject;
 import com.google.gwt.user.client.ui.Widget;
-import com.vaadin.client.BrowserInfo;
-import com.vaadin.client.ComputedStyle;
-import com.vaadin.client.DeferredWorker;
-import com.vaadin.client.Profiler;
-import com.vaadin.client.WidgetUtil;
+import com.vaadin.client.*;
 import com.vaadin.client.ui.SubPartAware;
-import com.vaadin.client.widget.escalator.Cell;
-import com.vaadin.client.widget.escalator.ColumnConfiguration;
-import com.vaadin.client.widget.escalator.EscalatorUpdater;
-import com.vaadin.client.widget.escalator.FlyweightCell;
-import com.vaadin.client.widget.escalator.FlyweightRow;
-import com.vaadin.client.widget.escalator.PositionFunction;
+import com.vaadin.client.widget.escalator.*;
 import com.vaadin.client.widget.escalator.PositionFunction.Translate3DPosition;
 import com.vaadin.client.widget.escalator.PositionFunction.TranslatePosition;
 import com.vaadin.client.widget.escalator.PositionFunction.WebkitTranslate3DPosition;
-import com.vaadin.client.widget.escalator.Row;
-import com.vaadin.client.widget.escalator.RowContainer;
 import com.vaadin.client.widget.escalator.RowContainer.BodyRowContainer;
-import com.vaadin.client.widget.escalator.RowVisibilityChangeEvent;
-import com.vaadin.client.widget.escalator.RowVisibilityChangeHandler;
-import com.vaadin.client.widget.escalator.ScrollbarBundle;
 import com.vaadin.client.widget.escalator.ScrollbarBundle.HorizontalScrollbarBundle;
 import com.vaadin.client.widget.escalator.ScrollbarBundle.VerticalScrollbarBundle;
-import com.vaadin.client.widget.escalator.Spacer;
-import com.vaadin.client.widget.escalator.SpacerUpdater;
 import com.vaadin.client.widget.escalator.events.RowHeightChangedEvent;
 import com.vaadin.client.widget.grid.events.ScrollEvent;
 import com.vaadin.client.widget.grid.events.ScrollHandler;
@@ -94,6 +52,12 @@ import com.vaadin.shared.Range;
 import com.vaadin.shared.ui.grid.HeightMode;
 import com.vaadin.shared.ui.grid.ScrollDestination;
 import com.vaadin.shared.util.SharedUtil;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+import java.util.logging.Level;
 
 /*-
 
@@ -2574,8 +2538,8 @@ public class Escalator extends Widget
 
         private void setTopRowLogicalIndex(int topRowLogicalIndex) {
             if (LogConfiguration.loggingIsEnabled(Level.INFO)) {
-                Logger.getLogger("Escalator.BodyRowContainer")
-                        .fine("topRowLogicalIndex: " + this.topRowLogicalIndex
+                LoggerFactory.getLogger("Escalator.BodyRowContainer")
+                        .debug("topRowLogicalIndex: " + this.topRowLogicalIndex
                                 + " -> " + topRowLogicalIndex);
             }
             assert topRowLogicalIndex >= 0 : "topRowLogicalIndex became negative (top left cell contents: "
@@ -2949,14 +2913,14 @@ public class Escalator extends Widget
                             rowTop += getDefaultRowHeight();
                         }
                     } catch (Exception e) {
-                        Logger logger = getLogger();
-                        logger.warning(
+                        org.slf4j.Logger logger = getLogger();
+                        logger.warn(
                                 "Ignored out-of-bounds row element access");
-                        logger.warning("Escalator state: start=" + start
+                        logger.warn("Escalator state: start=" + start
                                 + ", end=" + end + ", visualTargetIndex="
                                 + visualTargetIndex + ", visualRowOrder.size()="
                                 + visualRowOrder.size());
-                        logger.warning(e.toString());
+                        logger.warn(e.toString());
                     }
                 }
 
@@ -6037,8 +6001,8 @@ public class Escalator extends Widget
         }
     }
 
-    private Logger getLogger() {
-        return Logger.getLogger(getClass().getName());
+    private org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(getClass());
     }
 
     private static native boolean hasProperty(Style style, String name)
@@ -6971,7 +6935,7 @@ public class Escalator extends Widget
                 try {
                     return getSubPart(container, indices);
                 } catch (Exception e) {
-                    getLogger().log(Level.SEVERE, e.getMessage());
+                    getLogger().error(e.getMessage());
                 }
             }
         }
@@ -7088,7 +7052,7 @@ public class Escalator extends Widget
     }
 
     private void logWarning(String message) {
-        getLogger().warning(message);
+        getLogger().warn(message);
     }
 
     /**

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -15,46 +15,13 @@
  */
 package com.vaadin.client.widgets;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.core.shared.GWT;
-import com.google.gwt.dom.client.BrowserEvents;
-import com.google.gwt.dom.client.DivElement;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.EventTarget;
-import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.dom.client.Node;
-import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.dom.client.TableCellElement;
-import com.google.gwt.dom.client.TableRowElement;
-import com.google.gwt.dom.client.TableSectionElement;
-import com.google.gwt.dom.client.Touch;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.dom.client.KeyCodes;
-import com.google.gwt.event.dom.client.KeyDownEvent;
-import com.google.gwt.event.dom.client.KeyDownHandler;
-import com.google.gwt.event.dom.client.KeyEvent;
-import com.google.gwt.event.dom.client.MouseEvent;
+import com.google.gwt.event.dom.client.*;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -62,17 +29,7 @@ import com.google.gwt.touch.client.Point;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.CheckBox;
-import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HasEnabled;
-import com.google.gwt.user.client.ui.HasWidgets;
-import com.google.gwt.user.client.ui.MenuBar;
-import com.google.gwt.user.client.ui.MenuItem;
-import com.google.gwt.user.client.ui.PopupPanel;
-import com.google.gwt.user.client.ui.ResizeComposite;
-import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.user.client.ui.*;
 import com.vaadin.client.BrowserInfo;
 import com.vaadin.client.DeferredWorker;
 import com.vaadin.client.Focusable;
@@ -89,77 +46,18 @@ import com.vaadin.client.ui.dd.DragAndDropHandler;
 import com.vaadin.client.ui.dd.DragAndDropHandler.DragAndDropCallback;
 import com.vaadin.client.ui.dd.DragHandle;
 import com.vaadin.client.ui.dd.DragHandle.DragHandleCallback;
-import com.vaadin.client.widget.escalator.Cell;
-import com.vaadin.client.widget.escalator.ColumnConfiguration;
-import com.vaadin.client.widget.escalator.EscalatorUpdater;
-import com.vaadin.client.widget.escalator.FlyweightCell;
-import com.vaadin.client.widget.escalator.Row;
-import com.vaadin.client.widget.escalator.RowContainer;
-import com.vaadin.client.widget.escalator.RowVisibilityChangeHandler;
+import com.vaadin.client.widget.escalator.*;
 import com.vaadin.client.widget.escalator.ScrollbarBundle.Direction;
-import com.vaadin.client.widget.escalator.Spacer;
-import com.vaadin.client.widget.escalator.SpacerUpdater;
 import com.vaadin.client.widget.escalator.events.RowHeightChangedEvent;
 import com.vaadin.client.widget.escalator.events.RowHeightChangedHandler;
-import com.vaadin.client.widget.grid.AutoScroller;
+import com.vaadin.client.widget.grid.*;
 import com.vaadin.client.widget.grid.AutoScroller.AutoScrollerCallback;
 import com.vaadin.client.widget.grid.AutoScroller.ScrollAxis;
-import com.vaadin.client.widget.grid.CellReference;
-import com.vaadin.client.widget.grid.CellStyleGenerator;
-import com.vaadin.client.widget.grid.DataAvailableEvent;
-import com.vaadin.client.widget.grid.DataAvailableHandler;
-import com.vaadin.client.widget.grid.DefaultEditorEventHandler;
-import com.vaadin.client.widget.grid.DetailsGenerator;
-import com.vaadin.client.widget.grid.EditorHandler;
 import com.vaadin.client.widget.grid.EditorHandler.EditorRequest;
-import com.vaadin.client.widget.grid.EventCellReference;
-import com.vaadin.client.widget.grid.GridEventHandler;
-import com.vaadin.client.widget.grid.HeightAwareDetailsGenerator;
-import com.vaadin.client.widget.grid.RendererCellReference;
-import com.vaadin.client.widget.grid.RowReference;
-import com.vaadin.client.widget.grid.RowStyleGenerator;
-import com.vaadin.client.widget.grid.events.AbstractGridKeyEventHandler;
-import com.vaadin.client.widget.grid.events.AbstractGridMouseEventHandler;
-import com.vaadin.client.widget.grid.events.BodyClickHandler;
-import com.vaadin.client.widget.grid.events.BodyDoubleClickHandler;
-import com.vaadin.client.widget.grid.events.BodyKeyDownHandler;
-import com.vaadin.client.widget.grid.events.BodyKeyPressHandler;
-import com.vaadin.client.widget.grid.events.BodyKeyUpHandler;
-import com.vaadin.client.widget.grid.events.ColumnReorderEvent;
-import com.vaadin.client.widget.grid.events.ColumnReorderHandler;
-import com.vaadin.client.widget.grid.events.ColumnResizeEvent;
-import com.vaadin.client.widget.grid.events.ColumnResizeHandler;
-import com.vaadin.client.widget.grid.events.ColumnVisibilityChangeEvent;
-import com.vaadin.client.widget.grid.events.ColumnVisibilityChangeHandler;
-import com.vaadin.client.widget.grid.events.FooterClickHandler;
-import com.vaadin.client.widget.grid.events.FooterDoubleClickHandler;
-import com.vaadin.client.widget.grid.events.FooterKeyDownHandler;
-import com.vaadin.client.widget.grid.events.FooterKeyPressHandler;
-import com.vaadin.client.widget.grid.events.FooterKeyUpHandler;
-import com.vaadin.client.widget.grid.events.GridClickEvent;
-import com.vaadin.client.widget.grid.events.GridDoubleClickEvent;
-import com.vaadin.client.widget.grid.events.GridEnabledEvent;
-import com.vaadin.client.widget.grid.events.GridEnabledHandler;
-import com.vaadin.client.widget.grid.events.GridKeyDownEvent;
-import com.vaadin.client.widget.grid.events.GridKeyPressEvent;
-import com.vaadin.client.widget.grid.events.GridKeyUpEvent;
-import com.vaadin.client.widget.grid.events.GridSelectionAllowedEvent;
-import com.vaadin.client.widget.grid.events.GridSelectionAllowedHandler;
-import com.vaadin.client.widget.grid.events.HeaderClickHandler;
-import com.vaadin.client.widget.grid.events.HeaderDoubleClickHandler;
-import com.vaadin.client.widget.grid.events.HeaderKeyDownHandler;
-import com.vaadin.client.widget.grid.events.HeaderKeyPressHandler;
-import com.vaadin.client.widget.grid.events.HeaderKeyUpHandler;
+import com.vaadin.client.widget.grid.events.*;
 import com.vaadin.client.widget.grid.events.ScrollEvent;
 import com.vaadin.client.widget.grid.events.ScrollHandler;
-import com.vaadin.client.widget.grid.events.SelectAllEvent;
-import com.vaadin.client.widget.grid.events.SelectAllHandler;
-import com.vaadin.client.widget.grid.selection.HasSelectionHandlers;
-import com.vaadin.client.widget.grid.selection.MultiSelectionRenderer;
-import com.vaadin.client.widget.grid.selection.SelectionEvent;
-import com.vaadin.client.widget.grid.selection.SelectionHandler;
-import com.vaadin.client.widget.grid.selection.SelectionModel;
-import com.vaadin.client.widget.grid.selection.SelectionModelWithSelectionColumn;
+import com.vaadin.client.widget.grid.selection.*;
 import com.vaadin.client.widget.grid.sort.Sort;
 import com.vaadin.client.widget.grid.sort.SortEvent;
 import com.vaadin.client.widget.grid.sort.SortHandler;
@@ -172,13 +70,14 @@ import com.vaadin.client.widgets.Grid.StaticSection.StaticRow;
 import com.vaadin.shared.Range;
 import com.vaadin.shared.Registration;
 import com.vaadin.shared.data.sort.SortDirection;
-import com.vaadin.shared.ui.grid.ColumnResizeMode;
-import com.vaadin.shared.ui.grid.GridConstants;
+import com.vaadin.shared.ui.grid.*;
 import com.vaadin.shared.ui.grid.GridConstants.Section;
-import com.vaadin.shared.ui.grid.GridStaticCellType;
-import com.vaadin.shared.ui.grid.HeightMode;
-import com.vaadin.shared.ui.grid.ScrollDestination;
 import com.vaadin.shared.util.SharedUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * A data grid view that supports columns and lazy loading of data rows from a
@@ -1365,7 +1264,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         private final Timer saveTimeout = new Timer() {
             @Override
             public void run() {
-                getLogger().warning(
+                getLogger().warn(
                         "Editor save action is taking longer than expected ("
                                 + SAVE_TIMEOUT_MS + "ms). Does your "
                                 + EditorHandler.class.getSimpleName()
@@ -1401,7 +1300,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         private final Timer bindTimeout = new Timer() {
             @Override
             public void run() {
-                getLogger().warning(
+                getLogger().warn(
                         "Editor bind action is taking longer than expected ("
                                 + BIND_TIMEOUT_MS + "ms). Does your "
                                 + EditorHandler.class.getSimpleName()
@@ -3654,7 +3553,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             try {
                 detailsWidget = detailsGenerator.getDetails(rowIndex);
             } catch (Throwable e) {
-                getLogger().log(Level.SEVERE,
+                getLogger().error(
                         "Exception while generating details for row "
                                 + rowIndex,
                         e);
@@ -4678,7 +4577,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             @Override
             public void render(RendererCellReference cell, Object data) {
                 if (!warned && !(data instanceof String)) {
-                    getLogger().warning(
+                    getLogger().warn(
                             Column.this + ": " + DEFAULT_RENDERER_WARNING);
                     warned = true;
                 }
@@ -5485,7 +5384,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         ((ComplexRenderer<?>) renderer)
                                 .init(rendererCellReference);
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error initing cell in column "
                                         + cell.getColumn(),
                                 e);
@@ -5515,7 +5414,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         // Logical attach
                         setParent(widget, Grid.this);
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error attaching child widget in column "
                                         + cell.getColumn(),
                                 e);
@@ -5567,7 +5466,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                                 .getStyle(rowReference);
                         setCustomStyleName(rowElement, rowStylename);
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error generating styles for row "
                                         + row.getRow(),
                                 e);
@@ -5602,7 +5501,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                                 .getStyle(cellReference);
                         setCustomStyleName(cell.getElement(), generatedStyle);
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error generating style for cell in column "
                                         + cell.getColumn(),
                                 e);
@@ -5644,7 +5543,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         cell.getElement().removeAllChildren();
                     }
                 } catch (RuntimeException e) {
-                    getLogger().log(Level.SEVERE,
+                    getLogger().error(
                             "Error rendering cell in column "
                                     + cell.getColumn(),
                             e);
@@ -5669,7 +5568,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                             cell.getElement().removeChild(w.getElement());
                         }
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error detaching widget in column "
                                         + cell.getColumn(),
                                 e);
@@ -5695,7 +5594,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         ((ComplexRenderer) renderer)
                                 .destroy(rendererCellReference);
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error destroying cell in column "
                                         + cell.getColumn(),
                                 e);
@@ -5760,7 +5659,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         content.setClassName(getStylePrimaryName()
                                 + "-column-footer-content");
                     } else {
-                        getLogger().severe("Unhandled static row type "
+                        getLogger().error("Unhandled static row type "
                                 + staticRow.getClass().getCanonicalName());
                     }
 
@@ -7293,8 +7192,8 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         return escalator.getScrollWidth();
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(Grid.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(Grid.class);
     }
 
     /**
@@ -7787,7 +7686,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             int detailIdx = subPart.indexOf("/");
             if (detailIdx > 0) {
                 String detail = subPart.substring(detailIdx + 1);
-                getLogger().severe("Looking up detail from index " + detailIdx
+                getLogger().error("Looking up detail from index " + detailIdx
                         + " onward: \"" + detail + "\"");
                 if (detail.equalsIgnoreCase("content")) {
                     // XXX: Fix this to look up by class name!

--- a/client/src/main/resources/com/vaadin/Vaadin.gwt.xml
+++ b/client/src/main/resources/com/vaadin/Vaadin.gwt.xml
@@ -13,6 +13,7 @@
     <inherits name="com.google.gwt.http.HTTP" />
 
     <inherits name="com.google.gwt.logging.Logging" />
+    <inherits name="ru.finam.slf4jgwt.logging.gwt.Logging"/>
     <set-property name="gwt.logging.enabled" value="TRUE" />
 
     <source path="client" />

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/GridConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/GridConnector.java
@@ -16,18 +16,6 @@
 
 package com.vaadin.v7.client.connectors;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Element;
@@ -37,13 +25,7 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Widget;
-import com.vaadin.client.ComponentConnector;
-import com.vaadin.client.ConnectorHierarchyChangeEvent;
-import com.vaadin.client.DeferredWorker;
-import com.vaadin.client.MouseEventDetailsBuilder;
-import com.vaadin.client.ServerConnector;
-import com.vaadin.client.TooltipInfo;
-import com.vaadin.client.WidgetUtil;
+import com.vaadin.client.*;
 import com.vaadin.client.communication.StateChangeEvent;
 import com.vaadin.client.communication.StateChangeEvent.StateChangeHandler;
 import com.vaadin.client.ui.AbstractComponentConnector;
@@ -59,47 +41,24 @@ import com.vaadin.v7.client.connectors.RpcDataSourceConnector.DetailsListener;
 import com.vaadin.v7.client.connectors.RpcDataSourceConnector.RpcDataSource;
 import com.vaadin.v7.client.widget.escalator.events.RowHeightChangedEvent;
 import com.vaadin.v7.client.widget.escalator.events.RowHeightChangedHandler;
-import com.vaadin.v7.client.widget.grid.CellReference;
-import com.vaadin.v7.client.widget.grid.CellStyleGenerator;
-import com.vaadin.v7.client.widget.grid.EditorHandler;
-import com.vaadin.v7.client.widget.grid.EventCellReference;
-import com.vaadin.v7.client.widget.grid.HeightAwareDetailsGenerator;
-import com.vaadin.v7.client.widget.grid.RowReference;
-import com.vaadin.v7.client.widget.grid.RowStyleGenerator;
-import com.vaadin.v7.client.widget.grid.events.BodyClickHandler;
-import com.vaadin.v7.client.widget.grid.events.BodyDoubleClickHandler;
-import com.vaadin.v7.client.widget.grid.events.ColumnReorderEvent;
-import com.vaadin.v7.client.widget.grid.events.ColumnReorderHandler;
-import com.vaadin.v7.client.widget.grid.events.ColumnResizeEvent;
-import com.vaadin.v7.client.widget.grid.events.ColumnResizeHandler;
-import com.vaadin.v7.client.widget.grid.events.ColumnVisibilityChangeEvent;
-import com.vaadin.v7.client.widget.grid.events.ColumnVisibilityChangeHandler;
-import com.vaadin.v7.client.widget.grid.events.GridClickEvent;
-import com.vaadin.v7.client.widget.grid.events.GridDoubleClickEvent;
+import com.vaadin.v7.client.widget.grid.*;
+import com.vaadin.v7.client.widget.grid.events.*;
 import com.vaadin.v7.client.widget.grid.sort.SortEvent;
 import com.vaadin.v7.client.widget.grid.sort.SortHandler;
 import com.vaadin.v7.client.widget.grid.sort.SortOrder;
 import com.vaadin.v7.client.widgets.Grid;
-import com.vaadin.v7.client.widgets.Grid.Column;
-import com.vaadin.v7.client.widgets.Grid.FooterCell;
-import com.vaadin.v7.client.widgets.Grid.FooterRow;
-import com.vaadin.v7.client.widgets.Grid.HeaderCell;
-import com.vaadin.v7.client.widgets.Grid.HeaderRow;
-import com.vaadin.v7.shared.ui.grid.EditorClientRpc;
-import com.vaadin.v7.shared.ui.grid.EditorServerRpc;
-import com.vaadin.v7.shared.ui.grid.GridClientRpc;
-import com.vaadin.v7.shared.ui.grid.GridColumnState;
-import com.vaadin.v7.shared.ui.grid.GridConstants;
+import com.vaadin.v7.client.widgets.Grid.*;
+import com.vaadin.v7.shared.ui.grid.*;
 import com.vaadin.v7.shared.ui.grid.GridConstants.Section;
-import com.vaadin.v7.shared.ui.grid.GridServerRpc;
-import com.vaadin.v7.shared.ui.grid.GridState;
-import com.vaadin.v7.shared.ui.grid.GridStaticSectionState;
 import com.vaadin.v7.shared.ui.grid.GridStaticSectionState.CellState;
 import com.vaadin.v7.shared.ui.grid.GridStaticSectionState.RowState;
-import com.vaadin.v7.shared.ui.grid.ScrollDestination;
-
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * Connects the client side {@link Grid} widget with the server side
@@ -469,7 +428,7 @@ public class GridConnector extends AbstractHasComponentsConnector
                         }
                     }
                 } else {
-                    getLogger().warning(
+                    getLogger().warn(
                             "Visibility changed for a unknown column type in Grid: "
                                     + column + ", type " + column.getClass());
                 }
@@ -1209,7 +1168,7 @@ public class GridConnector extends AbstractHasComponentsConnector
     }
 
     private Logger getLogger() {
-        return Logger.getLogger(getClass().getName());
+        return LoggerFactory.getLogger(getClass());
     }
 
     /**

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/JavaScriptRendererConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/JavaScriptRendererConnector.java
@@ -15,11 +15,6 @@
  */
 package com.vaadin.v7.client.connectors;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.NativeEvent;
@@ -33,9 +28,14 @@ import com.vaadin.v7.client.renderers.Renderer;
 import com.vaadin.v7.client.widget.grid.CellReference;
 import com.vaadin.v7.client.widget.grid.RendererCellReference;
 import com.vaadin.v7.ui.renderers.AbstractJavaScriptRenderer;
-
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Connector for server-side renderer implemented using JavaScript.
@@ -138,7 +138,7 @@ public class JavaScriptRendererConnector
         }
 
         if (hasFunction("destory")) {
-            getLogger().severe("Your JavaScript connector ("
+            getLogger().error("Your JavaScript connector ("
                     + helper.getInitFunctionName()
                     + ") has a typo. The destory method should be renamed to destroy.");
 
@@ -272,7 +272,7 @@ public class JavaScriptRendererConnector
     }
 
     private Logger getLogger() {
-        return Logger.getLogger(JavaScriptRendererConnector.class.getName());
+        return LoggerFactory.getLogger(JavaScriptRendererConnector.class);
     }
 
     @Override

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/MultiSelectionModelConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/MultiSelectionModelConnector.java
@@ -15,15 +15,6 @@
  */
 package com.vaadin.v7.client.connectors;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.vaadin.client.ServerConnector;
@@ -51,8 +42,11 @@ import com.vaadin.v7.shared.ui.grid.GridState;
 import com.vaadin.v7.shared.ui.grid.selection.MultiSelectionModelServerRpc;
 import com.vaadin.v7.shared.ui.grid.selection.MultiSelectionModelState;
 import com.vaadin.v7.ui.Grid.MultiSelectionModel;
-
 import elemental.json.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 /**
  * Connector for server-side {@link MultiSelectionModel}.
@@ -104,7 +98,7 @@ public class MultiSelectionModelConnector extends
             ((HasUserSelectionAllowed) selectionModel)
                     .setUserSelectionAllowed(getState().userSelectionAllowed);
         } else {
-            getLogger().warning("userSelectionAllowed set to "
+            getLogger().warn("userSelectionAllowed set to "
                     + getState().userSelectionAllowed
                     + " but the selection model does not implement "
                     + HasUserSelectionAllowed.class.getSimpleName());
@@ -112,7 +106,7 @@ public class MultiSelectionModelConnector extends
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(MultiSelectionModelConnector.class.getName());
+        return LoggerFactory.getLogger(MultiSelectionModelConnector.class);
     }
 
     /**

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/SingleSelectionModelConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/SingleSelectionModelConnector.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.v7.client.connectors;
 
-import java.util.logging.Logger;
-
 import com.vaadin.client.ServerConnector;
 import com.vaadin.client.annotations.OnStateChange;
 import com.vaadin.client.data.DataSource.RowHandle;
@@ -31,8 +29,9 @@ import com.vaadin.v7.shared.ui.grid.GridState;
 import com.vaadin.v7.shared.ui.grid.selection.SingleSelectionModelServerRpc;
 import com.vaadin.v7.shared.ui.grid.selection.SingleSelectionModelState;
 import com.vaadin.v7.ui.Grid.SingleSelectionModel;
-
 import elemental.json.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Connector for server-side {@link SingleSelectionModel}.
@@ -85,7 +84,7 @@ public class SingleSelectionModelConnector extends
             ((HasUserSelectionAllowed) selectionModel)
                     .setUserSelectionAllowed(getState().userSelectionAllowed);
         } else {
-            getLogger().warning("userSelectionAllowed set to "
+            getLogger().warn("userSelectionAllowed set to "
                     + getState().userSelectionAllowed
                     + " but the selection model does not implement "
                     + HasUserSelectionAllowed.class.getSimpleName());
@@ -93,7 +92,7 @@ public class SingleSelectionModelConnector extends
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(SingleSelectionModelConnector.class.getName());
+        return LoggerFactory.getLogger(SingleSelectionModelConnector.class);
     }
 
     /**

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
@@ -16,107 +16,37 @@
 
 package com.vaadin.v7.client.ui;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.dom.client.Node;
-import com.google.gwt.dom.client.NodeList;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.dom.client.Style.Display;
-import com.google.gwt.dom.client.Style.Overflow;
-import com.google.gwt.dom.client.Style.Position;
-import com.google.gwt.dom.client.Style.TextAlign;
-import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.dom.client.Style.Visibility;
-import com.google.gwt.dom.client.TableCellElement;
-import com.google.gwt.dom.client.TableRowElement;
-import com.google.gwt.dom.client.TableSectionElement;
-import com.google.gwt.dom.client.Touch;
-import com.google.gwt.event.dom.client.BlurEvent;
-import com.google.gwt.event.dom.client.BlurHandler;
-import com.google.gwt.event.dom.client.FocusEvent;
-import com.google.gwt.event.dom.client.FocusHandler;
-import com.google.gwt.event.dom.client.KeyCodes;
-import com.google.gwt.event.dom.client.KeyDownEvent;
-import com.google.gwt.event.dom.client.KeyDownHandler;
-import com.google.gwt.event.dom.client.KeyPressEvent;
-import com.google.gwt.event.dom.client.KeyPressHandler;
-import com.google.gwt.event.dom.client.KeyUpEvent;
-import com.google.gwt.event.dom.client.KeyUpHandler;
-import com.google.gwt.event.dom.client.ScrollEvent;
-import com.google.gwt.event.dom.client.ScrollHandler;
+import com.google.gwt.dom.client.Style.*;
+import com.google.gwt.event.dom.client.*;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;
-import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.DOM;
-import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.*;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HasWidgets;
-import com.google.gwt.user.client.ui.Panel;
-import com.google.gwt.user.client.ui.PopupPanel;
-import com.google.gwt.user.client.ui.UIObject;
-import com.google.gwt.user.client.ui.Widget;
-import com.vaadin.client.ApplicationConnection;
-import com.vaadin.client.BrowserInfo;
-import com.vaadin.client.ComponentConnector;
-import com.vaadin.client.ConnectorMap;
-import com.vaadin.client.DeferredWorker;
+import com.google.gwt.user.client.ui.*;
+import com.vaadin.client.*;
 import com.vaadin.client.Focusable;
 import com.vaadin.client.HasChildMeasurementHintConnector.ChildMeasurementHint;
-import com.vaadin.client.MouseEventDetailsBuilder;
-import com.vaadin.client.StyleConstants;
-import com.vaadin.client.TooltipInfo;
-import com.vaadin.client.UIDL;
-import com.vaadin.client.Util;
-import com.vaadin.client.VConsole;
-import com.vaadin.client.VTooltip;
-import com.vaadin.client.WidgetUtil;
-import com.vaadin.client.ui.Action;
-import com.vaadin.client.ui.ActionOwner;
-import com.vaadin.client.ui.FocusableScrollPanel;
-import com.vaadin.client.ui.Icon;
-import com.vaadin.client.ui.SubPartAware;
-import com.vaadin.client.ui.TouchScrollDelegate;
-import com.vaadin.client.ui.TreeAction;
-import com.vaadin.client.ui.VContextMenu;
-import com.vaadin.client.ui.VEmbedded;
-import com.vaadin.client.ui.VOverlay;
-import com.vaadin.client.ui.dd.DDUtil;
-import com.vaadin.client.ui.dd.VAbstractDropHandler;
-import com.vaadin.client.ui.dd.VAcceptCallback;
-import com.vaadin.client.ui.dd.VDragAndDropManager;
-import com.vaadin.client.ui.dd.VDragEvent;
-import com.vaadin.client.ui.dd.VHasDropHandler;
-import com.vaadin.client.ui.dd.VTransferable;
+import com.vaadin.client.ui.*;
+import com.vaadin.client.ui.dd.*;
 import com.vaadin.shared.AbstractComponentState;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.dd.VerticalDropLocation;
 import com.vaadin.v7.client.ui.VScrollTable.VScrollTableBody.VScrollTableRow;
 import com.vaadin.v7.shared.ui.table.CollapseMenuContent;
 import com.vaadin.v7.shared.ui.table.TableConstants;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 /**
  * VScrollTable
@@ -788,9 +718,6 @@ public class VScrollTable extends FlowPanel
     private HandlerRegistration addCloseHandler;
 
     /**
-     * Changes to manage mouseDown and mouseUp
-     */
-    /**
      * The element where the last mouse down event was registered.
      */
     private Element lastMouseDownTarget;
@@ -822,7 +749,7 @@ public class VScrollTable extends FlowPanel
                         .isOrHasChild(elementUnderMouse)) {
                     mouseUpPreviewMatched = true;
                 } else {
-                    getLogger().log(Level.FINEST,
+                    getLogger().trace(
                             "Ignoring mouseup from " + elementUnderMouse
                                     + " when mousedown was on "
                                     + lastMouseDownTarget);
@@ -8380,8 +8307,8 @@ public class VScrollTable extends FlowPanel
         return lazyAdjustColumnWidths.isRunning();
     }
 
-    private static Logger getLogger() {
-        return Logger.getLogger(VScrollTable.class.getName());
+    private static org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(VScrollTable.class);
     }
 
     public ChildMeasurementHint getChildMeasurementHint() {
@@ -8398,7 +8325,7 @@ public class VScrollTable extends FlowPanel
                     .getIEFocusedElement();
             if (!getElement().isOrHasChild(focusedElement)) {
                 // Does not really have focus but a blur event has been lost
-                getLogger().warning(
+                getLogger().warn(
                         "IE did not send a blur event, firing manually");
                 onBlur();
             }

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/customfield/CustomFieldConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/customfield/CustomFieldConnector.java
@@ -15,10 +15,6 @@
  */
 package com.vaadin.v7.client.ui.customfield;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.logging.Logger;
-
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.client.ComponentConnector;
@@ -31,6 +27,11 @@ import com.vaadin.shared.ui.Connect;
 import com.vaadin.v7.client.ui.AbstractFieldConnector;
 import com.vaadin.v7.client.ui.VCustomField;
 import com.vaadin.v7.ui.CustomField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
 
 @Connect(value = CustomField.class)
 public class CustomFieldConnector extends AbstractFieldConnector
@@ -67,7 +68,7 @@ public class CustomFieldConnector extends AbstractFieldConnector
                 getWidget().setFocusDelegate(
                         (com.google.gwt.user.client.ui.Focusable) widget);
             } else {
-                getLogger().warning(
+                getLogger().warn(
                         "The given focus delegate does not implement Focusable: "
                                 + widget.getClass().getName());
             }
@@ -78,7 +79,7 @@ public class CustomFieldConnector extends AbstractFieldConnector
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(CustomFieldConnector.class.getName());
+        return LoggerFactory.getLogger(CustomFieldConnector.class);
     }
 
     @Override

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Escalator.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Escalator.java
@@ -15,20 +15,6 @@
  */
 package com.vaadin.v7.client.widgets;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.TreeMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.animation.client.Animation;
 import com.google.gwt.animation.client.AnimationScheduler;
 import com.google.gwt.animation.client.AnimationScheduler.AnimationCallback;
@@ -38,19 +24,9 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.dom.client.DivElement;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.dom.client.Node;
-import com.google.gwt.dom.client.NodeList;
-import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.dom.client.TableCellElement;
-import com.google.gwt.dom.client.TableRowElement;
-import com.google.gwt.dom.client.TableSectionElement;
-import com.google.gwt.dom.client.Touch;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.logging.client.LogConfiguration;
 import com.google.gwt.user.client.Command;
@@ -67,32 +43,25 @@ import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.ui.SubPartAware;
 import com.vaadin.shared.Range;
 import com.vaadin.shared.util.SharedUtil;
-import com.vaadin.v7.client.widget.escalator.Cell;
-import com.vaadin.v7.client.widget.escalator.ColumnConfiguration;
-import com.vaadin.v7.client.widget.escalator.EscalatorUpdater;
-import com.vaadin.v7.client.widget.escalator.FlyweightCell;
-import com.vaadin.v7.client.widget.escalator.FlyweightRow;
-import com.vaadin.v7.client.widget.escalator.PositionFunction;
+import com.vaadin.v7.client.widget.escalator.*;
 import com.vaadin.v7.client.widget.escalator.PositionFunction.AbsolutePosition;
 import com.vaadin.v7.client.widget.escalator.PositionFunction.Translate3DPosition;
 import com.vaadin.v7.client.widget.escalator.PositionFunction.TranslatePosition;
 import com.vaadin.v7.client.widget.escalator.PositionFunction.WebkitTranslate3DPosition;
-import com.vaadin.v7.client.widget.escalator.Row;
-import com.vaadin.v7.client.widget.escalator.RowContainer;
 import com.vaadin.v7.client.widget.escalator.RowContainer.BodyRowContainer;
-import com.vaadin.v7.client.widget.escalator.RowVisibilityChangeEvent;
-import com.vaadin.v7.client.widget.escalator.RowVisibilityChangeHandler;
-import com.vaadin.v7.client.widget.escalator.ScrollbarBundle;
 import com.vaadin.v7.client.widget.escalator.ScrollbarBundle.HorizontalScrollbarBundle;
 import com.vaadin.v7.client.widget.escalator.ScrollbarBundle.VerticalScrollbarBundle;
-import com.vaadin.v7.client.widget.escalator.Spacer;
-import com.vaadin.v7.client.widget.escalator.SpacerUpdater;
 import com.vaadin.v7.client.widget.escalator.events.RowHeightChangedEvent;
 import com.vaadin.v7.client.widget.grid.events.ScrollEvent;
 import com.vaadin.v7.client.widget.grid.events.ScrollHandler;
 import com.vaadin.v7.client.widgets.Escalator.JsniUtil.TouchHandlerBundle;
 import com.vaadin.v7.shared.ui.grid.HeightMode;
 import com.vaadin.v7.shared.ui.grid.ScrollDestination;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.logging.Level;
 
 /*-
 
@@ -2412,8 +2381,8 @@ public class Escalator extends Widget
 
         private void setTopRowLogicalIndex(int topRowLogicalIndex) {
             if (LogConfiguration.loggingIsEnabled(Level.INFO)) {
-                Logger.getLogger("Escalator.BodyRowContainer")
-                        .fine("topRowLogicalIndex: " + this.topRowLogicalIndex
+                LoggerFactory.getLogger("Escalator.BodyRowContainer")
+                        .debug("topRowLogicalIndex: " + this.topRowLogicalIndex
                                 + " -> " + topRowLogicalIndex);
             }
             assert topRowLogicalIndex >= 0 : "topRowLogicalIndex became negative (top left cell contents: "
@@ -2788,14 +2757,14 @@ public class Escalator extends Widget
                             rowTop += getDefaultRowHeight();
                         }
                     } catch (Exception e) {
-                        Logger logger = getLogger();
-                        logger.warning(
+                        org.slf4j.Logger logger = getLogger();
+                        logger.warn(
                                 "Ignored out-of-bounds row element access");
-                        logger.warning("Escalator state: start=" + start
+                        logger.warn("Escalator state: start=" + start
                                 + ", end=" + end + ", visualTargetIndex="
                                 + visualTargetIndex + ", visualRowOrder.size()="
                                 + visualRowOrder.size());
-                        logger.warning(e.toString());
+                        logger.warn(e.toString());
                     }
                 }
 
@@ -5883,8 +5852,8 @@ public class Escalator extends Widget
         }
     }
 
-    private Logger getLogger() {
-        return Logger.getLogger(getClass().getName());
+    private org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(getClass());
     }
 
     private static native boolean hasProperty(Style style, String name)
@@ -6761,7 +6730,7 @@ public class Escalator extends Widget
                 try {
                     return getSubPart(container, indices);
                 } catch (Exception e) {
-                    getLogger().log(Level.SEVERE, e.getMessage());
+                    getLogger().error(e.getMessage());
                 }
             }
         }
@@ -6878,7 +6847,7 @@ public class Escalator extends Widget
     }
 
     private void logWarning(String message) {
-        getLogger().warning(message);
+        getLogger().warn(message);
     }
 
     /**

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
@@ -15,46 +15,13 @@
  */
 package com.vaadin.v7.client.widgets;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.core.shared.GWT;
-import com.google.gwt.dom.client.BrowserEvents;
-import com.google.gwt.dom.client.DivElement;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.EventTarget;
-import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.dom.client.Node;
-import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.dom.client.TableCellElement;
-import com.google.gwt.dom.client.TableRowElement;
-import com.google.gwt.dom.client.TableSectionElement;
-import com.google.gwt.dom.client.Touch;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.dom.client.KeyCodes;
-import com.google.gwt.event.dom.client.KeyDownEvent;
-import com.google.gwt.event.dom.client.KeyDownHandler;
-import com.google.gwt.event.dom.client.KeyEvent;
-import com.google.gwt.event.dom.client.MouseEvent;
+import com.google.gwt.event.dom.client.*;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -66,17 +33,7 @@ import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.CheckBox;
-import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HasEnabled;
-import com.google.gwt.user.client.ui.HasWidgets;
-import com.google.gwt.user.client.ui.MenuBar;
-import com.google.gwt.user.client.ui.MenuItem;
-import com.google.gwt.user.client.ui.PopupPanel;
-import com.google.gwt.user.client.ui.ResizeComposite;
-import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.user.client.ui.*;
 import com.vaadin.client.BrowserInfo;
 import com.vaadin.client.DeferredWorker;
 import com.vaadin.client.Focusable;
@@ -96,87 +53,22 @@ import com.vaadin.shared.Range;
 import com.vaadin.shared.Registration;
 import com.vaadin.shared.data.sort.SortDirection;
 import com.vaadin.shared.util.SharedUtil;
-import com.vaadin.v7.client.renderers.ComplexRenderer;
-import com.vaadin.v7.client.renderers.ProgressBarRenderer;
-import com.vaadin.v7.client.renderers.Renderer;
-import com.vaadin.v7.client.renderers.TextRenderer;
-import com.vaadin.v7.client.renderers.WidgetRenderer;
-import com.vaadin.v7.client.widget.escalator.Cell;
-import com.vaadin.v7.client.widget.escalator.ColumnConfiguration;
-import com.vaadin.v7.client.widget.escalator.EscalatorUpdater;
-import com.vaadin.v7.client.widget.escalator.FlyweightCell;
-import com.vaadin.v7.client.widget.escalator.Row;
-import com.vaadin.v7.client.widget.escalator.RowContainer;
-import com.vaadin.v7.client.widget.escalator.RowVisibilityChangeEvent;
-import com.vaadin.v7.client.widget.escalator.RowVisibilityChangeHandler;
+import com.vaadin.v7.client.renderers.*;
+import com.vaadin.v7.client.widget.escalator.*;
 import com.vaadin.v7.client.widget.escalator.ScrollbarBundle.Direction;
-import com.vaadin.v7.client.widget.escalator.Spacer;
-import com.vaadin.v7.client.widget.escalator.SpacerUpdater;
 import com.vaadin.v7.client.widget.escalator.events.RowHeightChangedEvent;
 import com.vaadin.v7.client.widget.escalator.events.RowHeightChangedHandler;
-import com.vaadin.v7.client.widget.grid.AutoScroller;
+import com.vaadin.v7.client.widget.grid.*;
 import com.vaadin.v7.client.widget.grid.AutoScroller.AutoScrollerCallback;
 import com.vaadin.v7.client.widget.grid.AutoScroller.ScrollAxis;
-import com.vaadin.v7.client.widget.grid.CellReference;
-import com.vaadin.v7.client.widget.grid.CellStyleGenerator;
-import com.vaadin.v7.client.widget.grid.DataAvailableEvent;
-import com.vaadin.v7.client.widget.grid.DataAvailableHandler;
-import com.vaadin.v7.client.widget.grid.DefaultEditorEventHandler;
-import com.vaadin.v7.client.widget.grid.DetailsGenerator;
-import com.vaadin.v7.client.widget.grid.EditorHandler;
 import com.vaadin.v7.client.widget.grid.EditorHandler.EditorRequest;
-import com.vaadin.v7.client.widget.grid.EventCellReference;
-import com.vaadin.v7.client.widget.grid.GridEventHandler;
-import com.vaadin.v7.client.widget.grid.HeightAwareDetailsGenerator;
-import com.vaadin.v7.client.widget.grid.RendererCellReference;
-import com.vaadin.v7.client.widget.grid.RowReference;
-import com.vaadin.v7.client.widget.grid.RowStyleGenerator;
 import com.vaadin.v7.client.widget.grid.datasources.ListDataSource;
-import com.vaadin.v7.client.widget.grid.events.AbstractGridKeyEventHandler;
-import com.vaadin.v7.client.widget.grid.events.AbstractGridMouseEventHandler;
-import com.vaadin.v7.client.widget.grid.events.BodyClickHandler;
-import com.vaadin.v7.client.widget.grid.events.BodyDoubleClickHandler;
-import com.vaadin.v7.client.widget.grid.events.BodyKeyDownHandler;
-import com.vaadin.v7.client.widget.grid.events.BodyKeyPressHandler;
-import com.vaadin.v7.client.widget.grid.events.BodyKeyUpHandler;
-import com.vaadin.v7.client.widget.grid.events.ColumnReorderEvent;
-import com.vaadin.v7.client.widget.grid.events.ColumnReorderHandler;
-import com.vaadin.v7.client.widget.grid.events.ColumnResizeEvent;
-import com.vaadin.v7.client.widget.grid.events.ColumnResizeHandler;
-import com.vaadin.v7.client.widget.grid.events.ColumnVisibilityChangeEvent;
-import com.vaadin.v7.client.widget.grid.events.ColumnVisibilityChangeHandler;
-import com.vaadin.v7.client.widget.grid.events.FooterClickHandler;
-import com.vaadin.v7.client.widget.grid.events.FooterDoubleClickHandler;
-import com.vaadin.v7.client.widget.grid.events.FooterKeyDownHandler;
-import com.vaadin.v7.client.widget.grid.events.FooterKeyPressHandler;
-import com.vaadin.v7.client.widget.grid.events.FooterKeyUpHandler;
-import com.vaadin.v7.client.widget.grid.events.GridClickEvent;
-import com.vaadin.v7.client.widget.grid.events.GridDoubleClickEvent;
-import com.vaadin.v7.client.widget.grid.events.GridEnabledEvent;
-import com.vaadin.v7.client.widget.grid.events.GridEnabledHandler;
-import com.vaadin.v7.client.widget.grid.events.GridKeyDownEvent;
-import com.vaadin.v7.client.widget.grid.events.GridKeyPressEvent;
-import com.vaadin.v7.client.widget.grid.events.GridKeyUpEvent;
-import com.vaadin.v7.client.widget.grid.events.HeaderClickHandler;
-import com.vaadin.v7.client.widget.grid.events.HeaderDoubleClickHandler;
-import com.vaadin.v7.client.widget.grid.events.HeaderKeyDownHandler;
-import com.vaadin.v7.client.widget.grid.events.HeaderKeyPressHandler;
-import com.vaadin.v7.client.widget.grid.events.HeaderKeyUpHandler;
+import com.vaadin.v7.client.widget.grid.events.*;
 import com.vaadin.v7.client.widget.grid.events.ScrollEvent;
 import com.vaadin.v7.client.widget.grid.events.ScrollHandler;
-import com.vaadin.v7.client.widget.grid.events.SelectAllEvent;
-import com.vaadin.v7.client.widget.grid.events.SelectAllHandler;
-import com.vaadin.v7.client.widget.grid.selection.HasSelectionHandlers;
-import com.vaadin.v7.client.widget.grid.selection.HasUserSelectionAllowed;
-import com.vaadin.v7.client.widget.grid.selection.MultiSelectionRenderer;
-import com.vaadin.v7.client.widget.grid.selection.SelectionEvent;
-import com.vaadin.v7.client.widget.grid.selection.SelectionHandler;
-import com.vaadin.v7.client.widget.grid.selection.SelectionModel;
+import com.vaadin.v7.client.widget.grid.selection.*;
 import com.vaadin.v7.client.widget.grid.selection.SelectionModel.Multi;
 import com.vaadin.v7.client.widget.grid.selection.SelectionModel.Single;
-import com.vaadin.v7.client.widget.grid.selection.SelectionModelMulti;
-import com.vaadin.v7.client.widget.grid.selection.SelectionModelNone;
-import com.vaadin.v7.client.widget.grid.selection.SelectionModelSingle;
 import com.vaadin.v7.client.widget.grid.sort.Sort;
 import com.vaadin.v7.client.widget.grid.sort.SortEvent;
 import com.vaadin.v7.client.widget.grid.sort.SortHandler;
@@ -186,12 +78,13 @@ import com.vaadin.v7.client.widgets.Escalator.SubPartArguments;
 import com.vaadin.v7.client.widgets.Grid.Editor.State;
 import com.vaadin.v7.client.widgets.Grid.StaticSection.StaticCell;
 import com.vaadin.v7.client.widgets.Grid.StaticSection.StaticRow;
-import com.vaadin.v7.shared.ui.grid.ColumnResizeMode;
-import com.vaadin.v7.shared.ui.grid.GridConstants;
+import com.vaadin.v7.shared.ui.grid.*;
 import com.vaadin.v7.shared.ui.grid.GridConstants.Section;
-import com.vaadin.v7.shared.ui.grid.GridStaticCellType;
-import com.vaadin.v7.shared.ui.grid.HeightMode;
-import com.vaadin.v7.shared.ui.grid.ScrollDestination;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * A data grid view that supports columns and lazy loading of data rows from a
@@ -1380,7 +1273,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         private final Timer saveTimeout = new Timer() {
             @Override
             public void run() {
-                getLogger().warning(
+                getLogger().warn(
                         "Editor save action is taking longer than expected ("
                                 + SAVE_TIMEOUT_MS + "ms). Does your "
                                 + EditorHandler.class.getSimpleName()
@@ -1416,7 +1309,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         private final Timer bindTimeout = new Timer() {
             @Override
             public void run() {
-                getLogger().warning(
+                getLogger().warn(
                         "Editor bind action is taking longer than expected ("
                                 + BIND_TIMEOUT_MS + "ms). Does your "
                                 + EditorHandler.class.getSimpleName()
@@ -2456,7 +2349,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      * An initial height that is given to new details rows before rendering the
      * appropriate widget that we then can be measure
      *
-     * @see GridSpacerUpdater
+     * @see Grid.GridSpacerUpdater
      */
     private static final double DETAILS_ROW_INITIAL_HEIGHT = 50;
 
@@ -3638,7 +3531,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             try {
                 detailsWidget = detailsGenerator.getDetails(rowIndex);
             } catch (Throwable e) {
-                getLogger().log(Level.SEVERE,
+                getLogger().error(
                         "Exception while generating details for row "
                                 + rowIndex,
                         e);
@@ -4713,7 +4606,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             @Override
             public void render(RendererCellReference cell, Object data) {
                 if (!warned && !(data instanceof String)) {
-                    getLogger().warning(
+                    getLogger().warn(
                             Column.this + ": " + DEFAULT_RENDERER_WARNING);
                     warned = true;
                 }
@@ -5475,7 +5368,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         ((ComplexRenderer<?>) renderer)
                                 .init(rendererCellReference);
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error initing cell in column "
                                         + cell.getColumn(),
                                 e);
@@ -5505,7 +5398,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         // Logical attach
                         setParent(widget, Grid.this);
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error attaching child widget in column "
                                         + cell.getColumn(),
                                 e);
@@ -5551,7 +5444,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                                 .getStyle(rowReference);
                         setCustomStyleName(rowElement, rowStylename);
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error generating styles for row "
                                         + row.getRow(),
                                 e);
@@ -5586,7 +5479,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                                 .getStyle(cellReference);
                         setCustomStyleName(cell.getElement(), generatedStyle);
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error generating style for cell in column "
                                         + cell.getColumn(),
                                 e);
@@ -5628,7 +5521,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         cell.getElement().removeAllChildren();
                     }
                 } catch (RuntimeException e) {
-                    getLogger().log(Level.SEVERE,
+                    getLogger().error(
                             "Error rendering cell in column "
                                     + cell.getColumn(),
                             e);
@@ -5653,7 +5546,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                             cell.getElement().removeChild(w.getElement());
                         }
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error detaching widget in column "
                                         + cell.getColumn(),
                                 e);
@@ -5679,7 +5572,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         ((ComplexRenderer) renderer)
                                 .destroy(rendererCellReference);
                     } catch (RuntimeException e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Error destroying cell in column "
                                         + cell.getColumn(),
                                 e);
@@ -5744,7 +5637,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         content.setClassName(getStylePrimaryName()
                                 + "-column-footer-content");
                     } else {
-                        getLogger().severe("Unhandled static row type "
+                        getLogger().error("Unhandled static row type "
                                 + staticRow.getClass().getCanonicalName());
                     }
 
@@ -7259,8 +7152,8 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         return escalator.getScrollWidth();
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(Grid.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(Grid.class);
     }
 
     /**
@@ -7736,7 +7629,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             int detailIdx = subPart.indexOf("/");
             if (detailIdx > 0) {
                 String detail = subPart.substring(detailIdx + 1);
-                getLogger().severe("Looking up detail from index " + detailIdx
+                getLogger().error("Looking up detail from index " + detailIdx
                         + " onward: \"" + detail + "\"");
                 if (detail.equalsIgnoreCase("content")) {
                     // XXX: Fix this to look up by class name!

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/HierarchicalContainer.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/HierarchicalContainer.java
@@ -16,19 +16,12 @@
 
 package com.vaadin.v7.data.util;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.v7.data.Container;
 import com.vaadin.v7.data.Item;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 /**
  * A specialized Container whose contents can be accessed like it was a
@@ -449,7 +442,7 @@ public class HierarchicalContainer extends IndexedContainer
 
     private void enableAndFireContentsChangeEvents() {
         if (contentChangedEventsDisabledCount <= 0) {
-            getLogger().log(Level.WARNING,
+            getLogger().warn(
                     "Mismatched calls to disable and enable contents change events in HierarchicalContainer");
             contentChangedEventsDisabledCount = 0;
         } else {
@@ -819,7 +812,7 @@ public class HierarchicalContainer extends IndexedContainer
         }
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(HierarchicalContainer.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(HierarchicalContainer.class);
     }
 }

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/MethodProperty.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/MethodProperty.java
@@ -16,7 +16,14 @@
 
 package com.vaadin.v7.data.util;
 
-import static com.vaadin.util.ReflectTools.convertPrimitiveType;
+import com.vaadin.data.Binder;
+import com.vaadin.data.ValueProvider;
+import com.vaadin.server.Setter;
+import com.vaadin.shared.util.SharedUtil;
+import com.vaadin.v7.data.Property;
+import com.vaadin.v7.util.SerializerHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -24,15 +31,8 @@ import java.io.ObjectOutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
-import com.vaadin.data.Binder;
-import com.vaadin.data.ValueProvider;
-import com.vaadin.server.Setter;
-import com.vaadin.shared.util.SharedUtil;
-import com.vaadin.v7.data.Property;
-import com.vaadin.v7.util.SerializerHelper;
+import static com.vaadin.util.ReflectTools.convertPrimitiveType;
 
 /**
  * <p>
@@ -155,10 +155,8 @@ public class MethodProperty<T> extends AbstractProperty<T> {
             } else {
                 getMethod = null;
             }
-        } catch (SecurityException e) {
-            getLogger().log(Level.SEVERE, "Internal deserialization error", e);
-        } catch (NoSuchMethodException e) {
-            getLogger().log(Level.SEVERE, "Internal deserialization error", e);
+        } catch (SecurityException | NoSuchMethodException e) {
+            getLogger().error("Internal deserialization error", e);
         }
     }
 
@@ -810,8 +808,8 @@ public class MethodProperty<T> extends AbstractProperty<T> {
         fireValueChange();
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(MethodProperty.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(MethodProperty.class);
     }
 
 }

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/MethodPropertyDescriptor.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/MethodPropertyDescriptor.java
@@ -15,16 +15,16 @@
  */
 package com.vaadin.v7.data.util;
 
+import com.vaadin.util.ReflectTools;
+import com.vaadin.v7.data.Property;
+import com.vaadin.v7.util.SerializerHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Method;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.vaadin.util.ReflectTools;
-import com.vaadin.v7.data.Property;
-import com.vaadin.v7.util.SerializerHelper;
 
 /**
  * Property descriptor that is able to create simple {@link MethodProperty}
@@ -124,10 +124,8 @@ public class MethodPropertyDescriptor<BT>
             } else {
                 readMethod = null;
             }
-        } catch (SecurityException e) {
-            getLogger().log(Level.SEVERE, "Internal deserialization error", e);
-        } catch (NoSuchMethodException e) {
-            getLogger().log(Level.SEVERE, "Internal deserialization error", e);
+        } catch (SecurityException | NoSuchMethodException e) {
+            getLogger().error("Internal deserialization error", e);
         }
     }
 
@@ -147,7 +145,7 @@ public class MethodPropertyDescriptor<BT>
                 writeMethod);
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(MethodPropertyDescriptor.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(MethodPropertyDescriptor.class);
     }
 }

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/DefaultConverterFactory.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/converter/DefaultConverterFactory.java
@@ -16,12 +16,13 @@
 
 package com.vaadin.v7.data.util.converter;
 
+import com.vaadin.server.VaadinSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Date;
-import java.util.logging.Logger;
-
-import com.vaadin.server.VaadinSession;
 
 /**
  * Default implementation of {@link ConverterFactory}. Provides converters for
@@ -39,8 +40,8 @@ import com.vaadin.server.VaadinSession;
 @Deprecated
 public class DefaultConverterFactory implements ConverterFactory {
 
-    private static final Logger LOG = Logger
-            .getLogger(DefaultConverterFactory.class.getName());
+    private static final Logger LOG = LoggerFactory
+            .getLogger(DefaultConverterFactory.class);
 
     @Override
     public <PRESENTATION, MODEL> Converter<PRESENTATION, MODEL> createConverter(
@@ -48,8 +49,8 @@ public class DefaultConverterFactory implements ConverterFactory {
         Converter<PRESENTATION, MODEL> converter = findConverter(
                 presentationType, modelType);
         if (converter != null) {
-            LOG.finest(getClass().getName() + " created a "
-                    + converter.getClass());
+            LOG.trace("{} created a {}",
+                    getClass().getName(), converter.getClass());
             return converter;
         }
 
@@ -57,16 +58,15 @@ public class DefaultConverterFactory implements ConverterFactory {
         Converter<MODEL, PRESENTATION> reverseConverter = findConverter(
                 modelType, presentationType);
         if (reverseConverter != null) {
-            LOG.finest(getClass().getName() + " created a reverse "
-                    + reverseConverter.getClass());
+            LOG.trace("{} created a reverse {}",
+                    getClass().getName(), reverseConverter.getClass());
             return new ReverseConverter<PRESENTATION, MODEL>(reverseConverter);
         }
 
-        LOG.finest(getClass().getName() + " could not find a converter for "
-                + presentationType.getName() + " to " + modelType.getName()
-                + " conversion");
+        LOG.trace("{} could not find a converter for {} to {} conversion",
+                getClass().getName(), presentationType.getName(),
+                modelType.getName());
         return null;
-
     }
 
     protected <PRESENTATION, MODEL> Converter<PRESENTATION, MODEL> findConverter(

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/util/sqlcontainer/connection/J2EEConnectionPool.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/util/sqlcontainer/connection/J2EEConnectionPool.java
@@ -15,14 +15,13 @@
  */
 package com.vaadin.v7.data.util.sqlcontainer.connection;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 /**
  * @deprecated As of 8.0, no replacement available.
@@ -74,8 +73,8 @@ public class J2EEConnectionPool implements JDBCConnectionPool {
             try {
                 conn.close();
             } catch (SQLException e) {
-                Logger.getLogger(J2EEConnectionPool.class.getName())
-                        .log(Level.FINE, "Could not release SQL connection", e);
+                LoggerFactory.getLogger(J2EEConnectionPool.class)
+                        .debug("Could not release SQL connection", e);
             }
         }
     }

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Calendar.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Calendar.java
@@ -15,32 +15,6 @@
  */
 package com.vaadin.v7.ui;
 
-import java.lang.reflect.Method;
-import java.text.DateFormat;
-import java.text.DateFormatSymbols;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.EventListener;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.jsoup.nodes.Attributes;
-import org.jsoup.nodes.Element;
-
 import com.vaadin.event.Action;
 import com.vaadin.event.Action.Handler;
 import com.vaadin.event.dd.DropHandler;
@@ -60,39 +34,27 @@ import com.vaadin.v7.shared.ui.calendar.CalendarServerRpc;
 import com.vaadin.v7.shared.ui.calendar.CalendarState;
 import com.vaadin.v7.shared.ui.calendar.CalendarState.EventSortOrder;
 import com.vaadin.v7.shared.ui.calendar.DateConstants;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvent;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.BackwardEvent;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.BackwardHandler;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.DateClickEvent;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.DateClickHandler;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.EventClick;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.EventClickHandler;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.EventMoveHandler;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.EventResize;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.EventResizeHandler;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.ForwardEvent;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.ForwardHandler;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.MoveEvent;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.RangeSelectEvent;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.RangeSelectHandler;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.WeekClick;
-import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.WeekClickHandler;
-import com.vaadin.v7.ui.components.calendar.CalendarDateRange;
-import com.vaadin.v7.ui.components.calendar.CalendarTargetDetails;
-import com.vaadin.v7.ui.components.calendar.ContainerEventProvider;
+import com.vaadin.v7.ui.components.calendar.*;
+import com.vaadin.v7.ui.components.calendar.CalendarComponentEvents.*;
 import com.vaadin.v7.ui.components.calendar.event.BasicEventProvider;
 import com.vaadin.v7.ui.components.calendar.event.CalendarEditableEventProvider;
 import com.vaadin.v7.ui.components.calendar.event.CalendarEvent;
 import com.vaadin.v7.ui.components.calendar.event.CalendarEvent.EventChangeEvent;
 import com.vaadin.v7.ui.components.calendar.event.CalendarEvent.EventChangeListener;
 import com.vaadin.v7.ui.components.calendar.event.CalendarEventProvider;
-import com.vaadin.v7.ui.components.calendar.handler.BasicBackwardHandler;
-import com.vaadin.v7.ui.components.calendar.handler.BasicDateClickHandler;
-import com.vaadin.v7.ui.components.calendar.handler.BasicEventMoveHandler;
-import com.vaadin.v7.ui.components.calendar.handler.BasicEventResizeHandler;
-import com.vaadin.v7.ui.components.calendar.handler.BasicForwardHandler;
-import com.vaadin.v7.ui.components.calendar.handler.BasicWeekClickHandler;
+import com.vaadin.v7.ui.components.calendar.handler.*;
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.text.DateFormat;
+import java.text.DateFormatSymbols;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * <p>
@@ -242,7 +204,7 @@ public class Calendar extends AbstractLegacyComponent
      * Returns the logger for the calendar.
      */
     protected Logger getLogger() {
-        return Logger.getLogger(Calendar.class.getName());
+        return LoggerFactory.getLogger(Calendar.class);
     }
 
     /**
@@ -1755,7 +1717,7 @@ public class Calendar extends AbstractLegacyComponent
                         fireEventMove(eventIndex, d);
                     }
                 } catch (ParseException e) {
-                    getLogger().log(Level.WARNING, e.getMessage());
+                    getLogger().warn(e.getMessage());
                 }
             }
         }
@@ -1889,8 +1851,7 @@ public class Calendar extends AbstractLegacyComponent
                 }
 
             } catch (ParseException e) {
-                getLogger().log(Level.WARNING,
-                        "Could not parse action date string");
+                getLogger().warn("Could not parse action date string");
             }
 
         }

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/DateField.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/DateField.java
@@ -16,18 +16,6 @@
 
 package com.vaadin.v7.ui;
 
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.logging.Logger;
-
-import org.jsoup.nodes.Element;
-
 import com.vaadin.event.FieldEvents.BlurEvent;
 import com.vaadin.event.FieldEvents.BlurListener;
 import com.vaadin.event.FieldEvents.FocusEvent;
@@ -49,6 +37,12 @@ import com.vaadin.v7.event.FieldEvents;
 import com.vaadin.v7.shared.ui.datefield.DateFieldConstants;
 import com.vaadin.v7.shared.ui.datefield.Resolution;
 import com.vaadin.v7.shared.ui.datefield.TextualDateFieldState;
+import org.jsoup.nodes.Element;
+import org.slf4j.LoggerFactory;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.*;
 
 /**
  * <p>
@@ -1058,8 +1052,8 @@ public class DateField extends AbstractField<Date> implements
                     .parse(design.attr("value"), Date.class);
             // formatting will return null if it cannot parse the string
             if (date == null) {
-                Logger.getLogger(DateField.class.getName()).info(
-                        "cannot parse " + design.attr("value") + " as date");
+                LoggerFactory.getLogger(DateField.class).info(
+                        "cannot parse {} as date", design.attr("value"));
             }
             this.setValue(date, false, true);
         }

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Grid.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Grid.java
@@ -35,8 +35,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.Element;
@@ -4443,7 +4443,7 @@ public class Grid extends AbstractComponent
             try {
                 encodedValue = renderer.encode(presentationValue);
             } catch (Exception e) {
-                getLogger().log(Level.SEVERE, "Unable to encode data", e);
+                getLogger().error("Unable to encode data", e);
                 encodedValue = renderer.encode(null);
             }
 
@@ -4451,9 +4451,8 @@ public class Grid extends AbstractComponent
         }
 
         private static Logger getLogger() {
-            return Logger.getLogger(AbstractRenderer.class.getName());
+            return LoggerFactory.getLogger(AbstractRenderer.class);
         }
-
     }
 
     /**
@@ -6891,8 +6890,7 @@ public class Grid extends AbstractComponent
             try {
                 dataSource.removeItem(itemId);
             } catch (Exception e2) {
-                getLogger().log(Level.SEVERE,
-                        "Error recovering from exception in addRow", e);
+                getLogger().error("Error recovering from exception in addRow", e);
             }
             throw e;
         }
@@ -6926,7 +6924,7 @@ public class Grid extends AbstractComponent
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(Grid.class.getName());
+        return LoggerFactory.getLogger(Grid.class);
     }
 
     /**

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Table.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Table.java
@@ -16,27 +16,6 @@
 
 package com.vaadin.v7.ui;
 
-import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
-
 import com.vaadin.event.Action;
 import com.vaadin.event.Action.Handler;
 import com.vaadin.event.ContextClickEvent;
@@ -46,20 +25,12 @@ import com.vaadin.event.dd.DragSource;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
 import com.vaadin.event.dd.acceptcriteria.ServerSideCriterion;
-import com.vaadin.server.KeyMapper;
-import com.vaadin.server.LegacyCommunicationManager;
-import com.vaadin.server.LegacyPaint;
-import com.vaadin.server.PaintException;
-import com.vaadin.server.PaintTarget;
-import com.vaadin.server.Resource;
+import com.vaadin.server.*;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.MultiSelectMode;
 import com.vaadin.shared.util.SharedUtil;
-import com.vaadin.ui.Component;
+import com.vaadin.ui.*;
 import com.vaadin.ui.Grid;
-import com.vaadin.ui.HasChildMeasurementHint;
-import com.vaadin.ui.HasComponents;
-import com.vaadin.ui.UniqueSerializable;
 import com.vaadin.ui.declarative.DesignAttributeHandler;
 import com.vaadin.ui.declarative.DesignContext;
 import com.vaadin.ui.declarative.DesignException;
@@ -81,6 +52,14 @@ import com.vaadin.v7.shared.ui.table.TableConstants;
 import com.vaadin.v7.shared.ui.table.TableConstants.Section;
 import com.vaadin.v7.shared.ui.table.TableServerRpc;
 import com.vaadin.v7.shared.ui.table.TableState;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.*;
 
 /**
  * <p>
@@ -1968,9 +1947,9 @@ public class Table extends AbstractSelect implements Action.Container,
      */
     private Object[][] getVisibleCellsInsertIntoCache(int firstIndex,
             int rows) {
-        getLogger().log(Level.FINEST,
-                "Insert {0} rows at index {1} to existing page buffer requested",
-                new Object[] { rows, firstIndex });
+        getLogger().trace(
+                "Insert {} rows at index {} to existing page buffer requested",
+                rows, firstIndex);
 
         int minPageBufferIndex = getMinPageBufferIndex();
         int maxPageBufferIndex = getMaxPageBufferIndex();
@@ -2085,12 +2064,12 @@ public class Table extends AbstractSelect implements Action.Container,
         pageBuffer = newPageBuffer;
         pageBufferFirstIndex = Math.max(
                 pageBufferFirstIndex + rowsFromBeginning, minPageBufferIndex);
-        if (getLogger().isLoggable(Level.FINEST)) {
-            getLogger().log(Level.FINEST,
-                    "Page Buffer now contains {0} rows ({1}-{2})",
-                    new Object[] { pageBuffer[CELL_ITEMID].length,
-                            pageBufferFirstIndex, (pageBufferFirstIndex
-                                    + pageBuffer[CELL_ITEMID].length - 1) });
+        if (getLogger().isTraceEnabled()) {
+            getLogger().trace(
+                    "Page Buffer now contains {} rows ({}-{})",
+                    pageBuffer[CELL_ITEMID].length,
+                    pageBufferFirstIndex,
+                    (pageBufferFirstIndex + pageBuffer[CELL_ITEMID].length - 1));
         }
         return cells;
     }
@@ -2142,10 +2121,10 @@ public class Table extends AbstractSelect implements Action.Container,
      */
     private Object[][] getVisibleCellsNoCache(int firstIndex, int rows,
             boolean replaceListeners) {
-        if (getLogger().isLoggable(Level.FINEST)) {
-            getLogger().log(Level.FINEST,
-                    "Render visible cells for rows {0}-{1}",
-                    new Object[] { firstIndex, (firstIndex + rows - 1) });
+        if (getLogger().isTraceEnabled()) {
+            getLogger().trace(
+                    "Render visible cells for rows {}-{}",
+                    firstIndex, (firstIndex + rows - 1));
         }
         final Object[] colids = getVisibleColumns();
         final int cols = colids.length;
@@ -2156,8 +2135,8 @@ public class Table extends AbstractSelect implements Action.Container,
         if (replaceListeners) {
             // initialize the listener collections, this should only be done if
             // the entire cache is refreshed (through refreshRenderedCells)
-            listenedProperties = new HashSet<Property<?>>();
-            visibleComponents = new HashSet<Component>();
+            listenedProperties = new HashSet<>();
+            visibleComponents = new HashSet<>();
         }
 
         Object[][] cells = new Object[cols + CELL_FIRSTCOL][rows];
@@ -2394,8 +2373,9 @@ public class Table extends AbstractSelect implements Action.Container,
     }
 
     protected void registerComponent(Component component) {
-        getLogger().log(Level.FINEST, "Registered {0}: {1}", new Object[] {
-                component.getClass().getSimpleName(), component.getCaption() });
+        getLogger().trace("Registered {}: {}",
+                component.getClass().getSimpleName(), component.getCaption());
+
         if (!equals(component.getParent())) {
             component.setParent(this);
         }
@@ -2427,10 +2407,10 @@ public class Table extends AbstractSelect implements Action.Container,
      */
     private void unregisterComponentsAndPropertiesInRows(int firstIx,
             int count) {
-        if (getLogger().isLoggable(Level.FINEST)) {
-            getLogger().log(Level.FINEST,
-                    "Unregistering components in rows {0}-{1}",
-                    new Object[] { firstIx, (firstIx + count - 1) });
+        if (getLogger().isTraceEnabled()) {
+            getLogger().trace(
+                    "Unregistering components in rows {}-{}",
+                    firstIx, (firstIx + count - 1));
         }
         Object[] colids = getVisibleColumns();
         if (pageBuffer != null && pageBuffer[CELL_ITEMID].length > 0) {
@@ -2508,8 +2488,10 @@ public class Table extends AbstractSelect implements Action.Container,
      *            component that should be unregistered.
      */
     protected void unregisterComponent(Component component) {
-        getLogger().log(Level.FINEST, "Unregistered {0}: {1}", new Object[] {
-                component.getClass().getSimpleName(), component.getCaption() });
+        getLogger().trace(
+                "Unregistered {}: {}",
+                component.getClass().getSimpleName(), component.getCaption());
+
         component.setParent(null);
         /*
          * Also remove property data sources to unregister listeners keeping the
@@ -2962,8 +2944,7 @@ public class Table extends AbstractSelect implements Action.Container,
                         .get("lastToBeRendered")).intValue();
             } catch (Exception e) {
                 // FIXME: Handle exception
-                getLogger().log(Level.FINER,
-                        "Could not parse the first and/or last rows.", e);
+                getLogger().debug("Could not parse the first and/or last rows.", e);
             }
 
             // respect suggested rows only if table is not otherwise updated
@@ -2989,10 +2970,10 @@ public class Table extends AbstractSelect implements Action.Container,
                     }
                 }
             }
-            if (getLogger().isLoggable(Level.FINEST)) {
-                getLogger().log(Level.FINEST, "Client wants rows {0}-{1}",
-                        new Object[] { reqFirstRowToPaint,
-                                (reqFirstRowToPaint + reqRowsToPaint - 1) });
+            if (getLogger().isTraceEnabled()) {
+                getLogger().trace("Client wants rows {}-{}",
+                        reqFirstRowToPaint,
+                        (reqFirstRowToPaint + reqRowsToPaint - 1));
             }
             clientNeedsContentRefresh = true;
         }
@@ -3030,7 +3011,7 @@ public class Table extends AbstractSelect implements Action.Container,
                 try {
                     final Object[] ids = (Object[]) variables
                             .get("collapsedcolumns");
-                    Set<Object> idSet = new HashSet<Object>();
+                    Set<Object> idSet = new HashSet<>();
                     for (Object id : ids) {
                         idSet.add(columnIdMap.get(id.toString()));
                     }
@@ -3045,7 +3026,7 @@ public class Table extends AbstractSelect implements Action.Container,
                     }
                 } catch (final Exception e) {
                     // FIXME: Handle exception
-                    getLogger().log(Level.FINER,
+                    getLogger().debug(
                             "Could not determine column collapsing state", e);
                 }
                 clientNeedsContentRefresh = true;
@@ -3067,7 +3048,7 @@ public class Table extends AbstractSelect implements Action.Container,
                     }
                 } catch (final Exception e) {
                     // FIXME: Handle exception
-                    getLogger().log(Level.FINER,
+                    getLogger().debug(
                             "Could not determine column reordering state", e);
                 }
                 clientNeedsContentRefresh = true;
@@ -3375,9 +3356,9 @@ public class Table extends AbstractSelect implements Action.Container,
         target.startTag("prows");
 
         if (!shouldHideAddedRows()) {
-            getLogger().log(Level.FINEST,
-                    "Paint rows for add. Index: {0}, count: {1}.",
-                    new Object[] { firstIx, count });
+            getLogger().trace(
+                    "Paint rows for add. Index: {}, count: {}.",
+                    firstIx, count);
 
             // Partial row additions bypass the normal caching mechanism.
             Object[][] cells = getVisibleCellsInsertIntoCache(firstIx, count);
@@ -3400,9 +3381,10 @@ public class Table extends AbstractSelect implements Action.Container,
                         indexInRowbuffer, itemId);
             }
         } else {
-            getLogger().log(Level.FINEST,
-                    "Paint rows for remove. Index: {0}, count: {1}.",
-                    new Object[] { firstIx, count });
+            getLogger().trace(
+                    "Paint rows for remove. Index: {}, count: {}.",
+                    firstIx, count);
+
             removeRowsFromCacheAndFillBottom(firstIx, count);
             target.addAttribute("hide", true);
         }
@@ -5097,7 +5079,6 @@ public class Table extends AbstractSelect implements Action.Container,
         super.setEnabled(enabled);
         if (getParent() != null && !getParent().isEnabled()) {
             // some ancestor still disabled, don't update children
-            return;
         } else {
             markAsDirtyRecursive();
         }
@@ -6446,9 +6427,9 @@ public class Table extends AbstractSelect implements Action.Container,
         return (TableState) super.getState(markAsDirty);
     }
 
-    private final Logger getLogger() {
+    private Logger getLogger() {
         if (logger == null) {
-            logger = Logger.getLogger(Table.class.getName());
+            logger = LoggerFactory.getLogger(Table.class);
         }
         return logger;
     }

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/TreeTable.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/TreeTable.java
@@ -16,20 +16,6 @@
 
 package com.vaadin.v7.ui;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.jsoup.nodes.Element;
-
 import com.vaadin.server.PaintException;
 import com.vaadin.server.PaintTarget;
 import com.vaadin.server.Resource;
@@ -48,6 +34,12 @@ import com.vaadin.v7.ui.Tree.CollapseEvent;
 import com.vaadin.v7.ui.Tree.CollapseListener;
 import com.vaadin.v7.ui.Tree.ExpandEvent;
 import com.vaadin.v7.ui.Tree.ExpandListener;
+import org.jsoup.nodes.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.*;
 
 /**
  * TreeTable extends the {@link Table} component so that it can also visualize a
@@ -95,7 +87,7 @@ public class TreeTable extends Table implements Hierarchical {
 
         public Collection<?> getItemIds();
 
-        public void containerItemSetChange(ItemSetChangeEvent event);
+        public void containerItemSetChange(Container.ItemSetChangeEvent event);
     }
 
     private abstract class AbstractStrategy implements ContainerStrategy {
@@ -117,7 +109,7 @@ public class TreeTable extends Table implements Hierarchical {
         }
 
         @Override
-        public void containerItemSetChange(ItemSetChangeEvent event) {
+        public void containerItemSetChange(Container.ItemSetChangeEvent event) {
         }
 
     }
@@ -263,10 +255,10 @@ public class TreeTable extends Table implements Hierarchical {
             boolean removed = openItems.remove(itemId);
             if (!removed) {
                 openItems.add(itemId);
-                getLogger().log(Level.FINEST, "Item {0} is now expanded",
+                getLogger().trace("Item {} is now expanded",
                         itemId);
             } else {
-                getLogger().log(Level.FINEST, "Item {0} is now collapsed",
+                getLogger().trace("Item {} is now collapsed",
                         itemId);
             }
             clearPreorderCache();
@@ -321,7 +313,7 @@ public class TreeTable extends Table implements Hierarchical {
         }
 
         @Override
-        public void containerItemSetChange(ItemSetChangeEvent event) {
+        public void containerItemSetChange(Container.ItemSetChangeEvent event) {
             // preorder becomes invalid on sort, item additions etc.
             clearPreorderCache();
             super.containerItemSetChange(event);
@@ -889,8 +881,8 @@ public class TreeTable extends Table implements Hierarchical {
         markAsDirty();
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(TreeTable.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(TreeTable.class);
     }
 
     @Override

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/components/colorpicker/ColorPickerPopup.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/components/colorpicker/ColorPickerPopup.java
@@ -15,32 +15,21 @@
  */
 package com.vaadin.v7.ui.components.colorpicker;
 
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.shared.ui.MarginInfo;
-import com.vaadin.ui.Alignment;
-import com.vaadin.ui.Button;
+import com.vaadin.ui.*;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Button.ClickListener;
-import com.vaadin.ui.Component;
-import com.vaadin.ui.HorizontalLayout;
-import com.vaadin.ui.Layout;
-import com.vaadin.ui.TabSheet;
-import com.vaadin.ui.VerticalLayout;
-import com.vaadin.ui.Window;
 import com.vaadin.v7.data.Property.ValueChangeEvent;
 import com.vaadin.v7.data.Property.ValueChangeListener;
 import com.vaadin.v7.shared.ui.colorpicker.Color;
 import com.vaadin.v7.ui.AbstractColorPicker.Coordinates2Color;
 import com.vaadin.v7.ui.Slider;
 import com.vaadin.v7.ui.Slider.ValueOutOfBoundsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.*;
 
 /**
  * A component that represents color selection popup within a color picker.
@@ -562,10 +551,9 @@ public class ColorPickerPopup extends Window
             blueSlider.setValue(((Integer) color.getBlue()).doubleValue());
             greenSlider.setValue(((Integer) color.getGreen()).doubleValue());
         } catch (ValueOutOfBoundsException e) {
-            getLogger().log(Level.WARNING,
-                    "Unable to set RGB color value to " + color.getRed() + ","
-                            + color.getGreen() + "," + color.getBlue(),
-                    e);
+            getLogger().warn(
+                    "Unable to set RGB color value to {},{},{}",
+                    color.getRed(), color.getGreen(), color.getBlue(), e);
         }
     }
 
@@ -575,8 +563,8 @@ public class ColorPickerPopup extends Window
             saturationSlider.setValue(((Float) (hsv[1] * 100f)).doubleValue());
             valueSlider.setValue(((Float) (hsv[2] * 100f)).doubleValue());
         } catch (ValueOutOfBoundsException e) {
-            getLogger().log(Level.WARNING, "Unable to set HSV color value to "
-                    + hsv[0] + "," + hsv[1] + "," + hsv[2], e);
+            getLogger().warn("Unable to set HSV color value to {},{},{}",
+                    hsv[0], hsv[1], hsv[2], e);
         }
     }
 
@@ -763,6 +751,6 @@ public class ColorPickerPopup extends Window
     };
 
     private static Logger getLogger() {
-        return Logger.getLogger(ColorPickerPopup.class.getName());
+        return LoggerFactory.getLogger(ColorPickerPopup.class);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,12 @@
         <!-- Used in OSGi manifests -->
         <javax.validation.version>1.0.0.GA</javax.validation.version>
         <jsoup.version>1.8.3</jsoup.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j-gwt.version>1.7.7.1</slf4j-gwt.version>
         <javax.portlet.version>2.0</javax.portlet.version>
         <vaadin.sass.version>0.9.13</vaadin.sass.version>
         <!-- Note that this should be kept in sync with the class Constants -->
-        <atmosphere.runtime.version>2.4.11.vaadin2</atmosphere.runtime.version>
+        <atmosphere.runtime.version>2.4.11</atmosphere.runtime.version>
 
         <!-- OSGi -->
         <osgi.execution.environment>JavaSE-1.8</osgi.execution.environment>
@@ -162,7 +164,7 @@
                 <version>${vaadin.gwt.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.vaadin.external.atmosphere</groupId>
+                <groupId>org.atmosphere</groupId>
                 <artifactId>atmosphere-runtime</artifactId>
                 <version>${atmosphere.runtime.version}</version>
             </dependency>
@@ -217,6 +219,21 @@
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
                 <version>${jsoup.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ru.finam</groupId>
+                <artifactId>slf4j-gwt</artifactId>
+                <version>${slf4j-gwt.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/push/pom.xml
+++ b/push/pom.xml
@@ -20,7 +20,7 @@
     <dependencies>
         <!-- Atmosphere -->
         <dependency>
-            <groupId>com.vaadin.external.atmosphere</groupId>
+            <groupId>org.atmosphere</groupId>
             <artifactId>atmosphere-runtime</artifactId>
         </dependency>
         <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -80,6 +80,16 @@
             <artifactId>vaadin-icons</artifactId>
         </dependency>
 
+        <!-- Logging Facade -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+        </dependency>
+
         <!-- Jsoup for BootstrapHandler -->
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/server/src/main/java/com/vaadin/data/util/BeanUtil.java
+++ b/server/src/main/java/com/vaadin/data/util/BeanUtil.java
@@ -15,6 +15,9 @@
  */
 package com.vaadin.data.util;
 
+import com.vaadin.data.validator.BeanValidator;
+import org.slf4j.LoggerFactory;
+
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
@@ -24,10 +27,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.vaadin.data.validator.BeanValidator;
 
 /**
  * Utility class for Java Beans information access.
@@ -237,10 +236,11 @@ public final class BeanUtil implements Serializable {
                 return true;
             } catch (ClassNotFoundException | NoSuchMethodException
                     | InvocationTargetException e) {
-                Logger.getLogger(BeanValidator.class.getName()).log(Level.INFO,
+                LoggerFactory.getLogger(BeanValidator.class)
+                        .info(
                         "A JSR-303 bean validation implementation not found on the classpath or could not be initialized. "
-                                + BeanValidator.class.getSimpleName()
-                                + " cannot be used.",
+                        + "{} cannot be used.",
+                        BeanValidator.class.getSimpleName(),
                         e);
                 return false;
             } catch (IllegalAccessException | IllegalArgumentException e) {

--- a/server/src/main/java/com/vaadin/event/ListenerMethod.java
+++ b/server/src/main/java/com/vaadin/event/ListenerMethod.java
@@ -16,18 +16,15 @@
 
 package com.vaadin.event;
 
-import java.io.IOException;
-import java.io.NotSerializableException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.EventListener;
 import java.util.EventObject;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * <p>
@@ -94,8 +91,8 @@ public class ListenerMethod implements EventListener, Serializable {
             out.writeObject(name);
             out.writeObject(paramTypes);
         } catch (NotSerializableException e) {
-            getLogger().log(Level.WARNING,
-                    "Error in serialization of the application: Class {0} must implement serialization.",
+            getLogger().warn(
+                    "Error in serialization of the application: Class {} must implement serialization.",
                     target.getClass().getName());
             throw e;
         }
@@ -113,7 +110,7 @@ public class ListenerMethod implements EventListener, Serializable {
             // inner classes
             method = findHighestMethod(target.getClass(), name, paramTypes);
         } catch (SecurityException e) {
-            getLogger().log(Level.SEVERE, "Internal deserialization error", e);
+            getLogger().error("Internal deserialization error", e);
         }
     }
 
@@ -651,8 +648,7 @@ public class ListenerMethod implements EventListener, Serializable {
         return target;
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(ListenerMethod.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(ListenerMethod.class);
     }
-
 }

--- a/server/src/main/java/com/vaadin/event/dd/acceptcriteria/SourceIs.java
+++ b/server/src/main/java/com/vaadin/event/dd/acceptcriteria/SourceIs.java
@@ -15,14 +15,12 @@
  */
 package com.vaadin.event.dd.acceptcriteria;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.event.TransferableImpl;
 import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.server.PaintException;
 import com.vaadin.server.PaintTarget;
 import com.vaadin.ui.Component;
+import org.slf4j.LoggerFactory;
 
 /**
  * Client side criteria that checks if the drag source is one of the given
@@ -48,10 +46,9 @@ public class SourceIs extends ClientSideCriterion {
             if (c.isAttached()) {
                 target.addAttribute("component" + paintedComponents++, c);
             } else {
-                Logger.getLogger(SourceIs.class.getName()).log(Level.WARNING,
-                        "SourceIs component {0} at index {1} is not attached to the component hierachy and will thus be ignored",
-                        new Object[] { c.getClass().getName(),
-                                Integer.valueOf(i) });
+                LoggerFactory.getLogger(SourceIs.class).warn(
+                        "SourceIs component {} at index {} is not attached to the component hierachy and will thus be ignored",
+                        c.getClass().getName(), i);
             }
         }
         target.addAttribute("c", paintedComponents);

--- a/server/src/main/java/com/vaadin/server/BootstrapHandler.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapHandler.java
@@ -16,34 +16,6 @@
 
 package com.vaadin.server;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.logging.Logger;
-
-import javax.servlet.http.HttpServletResponse;
-
-import org.jsoup.nodes.DataNode;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.DocumentType;
-import org.jsoup.nodes.Element;
-import org.jsoup.nodes.Node;
-import org.jsoup.parser.Tag;
-
 import com.vaadin.annotations.Viewport;
 import com.vaadin.annotations.ViewportGeneratorClass;
 import com.vaadin.server.DependencyFilter.FilterContext;
@@ -56,11 +28,22 @@ import com.vaadin.ui.Dependency;
 import com.vaadin.ui.Dependency.Type;
 import com.vaadin.ui.UI;
 import com.vaadin.util.ReflectTools;
-
 import elemental.json.Json;
 import elemental.json.JsonException;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
+import org.jsoup.nodes.*;
+import org.jsoup.parser.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.*;
+import java.net.URLEncoder;
+import java.util.*;
+import java.util.Map.Entry;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Handles the initial request to start the application.
@@ -598,7 +581,7 @@ public abstract class BootstrapHandler extends SynchronizedRequestHandler {
                 head.appendElement("link").attr("rel", "stylesheet")
                         .attr("type", "text/css").attr("href", url);
             } else {
-                getLogger().severe("Ignoring unknown dependency type "
+                getLogger().error("Ignoring unknown dependency type "
                         + dependency.getType());
             }
         }
@@ -609,7 +592,7 @@ public abstract class BootstrapHandler extends SynchronizedRequestHandler {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(BootstrapHandler.class.getName());
+        return LoggerFactory.getLogger(BootstrapHandler.class);
     }
 
     protected String getMainDivStyle(BootstrapContext context) {
@@ -704,11 +687,13 @@ public abstract class BootstrapHandler extends SynchronizedRequestHandler {
         Element mainScriptTag = new Element(Tag.valueOf("script"), "")
                 .attr("type", "text/javascript");
 
-        StringBuilder builder = new StringBuilder();
-        builder.append("//<![CDATA[\n");
-        builder.append("if (!window.vaadin) alert(" + JsonUtil.quote(
-                "Failed to load the bootstrap javascript: " + bootstrapLocation)
-                + ");\n");
+        StringBuilder builder = new StringBuilder()
+                .append("//<![CDATA[\n")
+                .append("if (!window.vaadin) alert(")
+                .append(
+                        JsonUtil.quote("Failed to load the bootstrap javascript: "
+                                + bootstrapLocation))
+                .append(");\n");
 
         appendMainScriptTagContents(context, builder);
 
@@ -716,7 +701,6 @@ public abstract class BootstrapHandler extends SynchronizedRequestHandler {
         mainScriptTag.appendChild(
                 new DataNode(builder.toString(), mainScriptTag.baseUri()));
         fragmentNodes.add(mainScriptTag);
-
     }
 
     protected void appendMainScriptTagContents(BootstrapContext context,

--- a/server/src/main/java/com/vaadin/server/ComponentSizeValidator.java
+++ b/server/src/main/java/com/vaadin/server/ComponentSizeValidator.java
@@ -15,33 +15,15 @@
  */
 package com.vaadin.server;
 
+import com.vaadin.server.Sizeable.Unit;
+import com.vaadin.ui.*;
+import com.vaadin.ui.GridLayout.Area;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.PrintStream;
 import java.io.Serializable;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.vaadin.server.Sizeable.Unit;
-import com.vaadin.ui.AbstractOrderedLayout;
-import com.vaadin.ui.AbstractSplitPanel;
-import com.vaadin.ui.Component;
-import com.vaadin.ui.ComponentContainer;
-import com.vaadin.ui.CustomComponent;
-import com.vaadin.ui.GridLayout;
-import com.vaadin.ui.GridLayout.Area;
-import com.vaadin.ui.HasComponents;
-import com.vaadin.ui.Panel;
-import com.vaadin.ui.TabSheet;
-import com.vaadin.ui.UI;
-import com.vaadin.ui.VerticalLayout;
-import com.vaadin.ui.Window;
+import java.util.*;
 
 @SuppressWarnings({ "serial", "deprecation" })
 public class ComponentSizeValidator implements Serializable {
@@ -162,8 +144,7 @@ public class ComponentSizeValidator implements Serializable {
 
             return parentCanDefineHeight(component);
         } catch (Exception e) {
-            getLogger().log(Level.FINER,
-                    "An exception occurred while validating sizes.", e);
+            getLogger().debug("An exception occurred while validating sizes.", e);
             return true;
         }
     }
@@ -182,8 +163,7 @@ public class ComponentSizeValidator implements Serializable {
 
             return parentCanDefineWidth(component);
         } catch (Exception e) {
-            getLogger().log(Level.FINER,
-                    "An exception occurred while validating sizes.", e);
+            getLogger().debug("An exception occurred while validating sizes.", e);
             return true;
         }
     }
@@ -659,15 +639,14 @@ public class ComponentSizeValidator implements Serializable {
                 map.put(object, cl);
                 return;
             } catch (Exception e) {
-                getLogger().log(Level.FINER,
-                        "An exception occurred while validating sizes.", e);
+                getLogger().debug("An exception occurred while validating sizes.", e);
             }
 
         }
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(ComponentSizeValidator.class.getName());
+        return LoggerFactory.getLogger(ComponentSizeValidator.class);
     }
 
     /**

--- a/server/src/main/java/com/vaadin/server/ConnectorResourceHandler.java
+++ b/server/src/main/java/com/vaadin/server/ConnectorResourceHandler.java
@@ -15,18 +15,16 @@
  */
 package com.vaadin.server;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.servlet.http.HttpServletResponse;
-
 import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.ui.UI;
 import com.vaadin.util.CurrentInstance;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ConnectorResourceHandler implements RequestHandler {
     // APP/connector/[uiid]/[cid]/[filename.xyz]
@@ -36,8 +34,8 @@ public class ConnectorResourceHandler implements RequestHandler {
     private static final Pattern CONNECTOR_RESOURCE_PATTERN = Pattern
             .compile("^" + CONNECTOR_RESOURCE_PREFIX + "(\\d+)/(\\d+)/(.*)");
 
-    private static Logger getLogger() {
-        return Logger.getLogger(ConnectorResourceHandler.class.getName());
+    private static org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(ConnectorResourceHandler.class);
 
     }
 
@@ -120,7 +118,7 @@ public class ConnectorResourceHandler implements RequestHandler {
 
             if (!loggedDecodingWarning) {
                 loggedDecodingWarning = true;
-                getLogger().warning(
+                getLogger().warn(
                         "Request path contains a new line character. This typically means that the server is incorrectly configured to use something else than UTF-8 for URL decoding (requestPath: "
                                 + requestPath + ")");
             }
@@ -129,7 +127,8 @@ public class ConnectorResourceHandler implements RequestHandler {
 
     private static boolean error(VaadinRequest request, VaadinResponse response,
             String logMessage) throws IOException {
-        getLogger().log(Level.WARNING, logMessage);
+        getLogger().warn(logMessage);
+
         response.sendError(HttpServletResponse.SC_NOT_FOUND,
                 request.getPathInfo() + " can not be found");
 

--- a/server/src/main/java/com/vaadin/server/Constants.java
+++ b/server/src/main/java/com/vaadin/server/Constants.java
@@ -66,11 +66,11 @@ public interface Constants {
             + "=================================================================";
 
     // Keep the version number in sync with pom.xml
-    static final String REQUIRED_ATMOSPHERE_RUNTIME_VERSION = "2.4.11.vaadin2";
+    static final String REQUIRED_ATMOSPHERE_RUNTIME_VERSION = "2.4.11";
 
     static final String INVALID_ATMOSPHERE_VERSION_WARNING = "\n"
             + "=================================================================\n"
-            + "Vaadin depends on Atmosphere {0} but version {1} was found.\n"
+            + "Vaadin depends on Atmosphere {} but version {} was found.\n"
             + "This might cause compatibility problems if push is used.\n"
             + "=================================================================";
 
@@ -89,7 +89,7 @@ public interface Constants {
 
     static final String PUSH_NOT_SUPPORTED_ERROR = "\n"
             + "=================================================================\n"
-            + "Push is not supported for {0}\n" + "Will fall back to using "
+            + "Push is not supported for {}\n" + "Will fall back to using "
             + PushMode.class.getSimpleName() + "." + PushMode.DISABLED.name()
             + ".\n"
             + "=================================================================";

--- a/server/src/main/java/com/vaadin/server/DefaultDeploymentConfiguration.java
+++ b/server/src/main/java/com/vaadin/server/DefaultDeploymentConfiguration.java
@@ -16,11 +16,12 @@
 
 package com.vaadin.server;
 
+import com.vaadin.shared.communication.PushMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Locale;
 import java.util.Properties;
-import java.util.logging.Logger;
-
-import com.vaadin.shared.communication.PushMode;
 
 /**
  * The default implementation of {@link DeploymentConfiguration} based on a base
@@ -271,7 +272,7 @@ public class DefaultDeploymentConfiguration
                 Constants.SERVLET_PARAMETER_PRODUCTION_MODE, "false")
                         .equals("true");
         if (!productionMode) {
-            getLogger().warning(Constants.NOT_PRODUCTION_MODE_INFO);
+            getLogger().warn(Constants.NOT_PRODUCTION_MODE_INFO);
         }
     }
 
@@ -283,7 +284,7 @@ public class DefaultDeploymentConfiguration
                 Constants.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION, "false")
                         .equals("true");
         if (!xsrfProtectionEnabled) {
-            getLogger().warning(Constants.WARNING_XSRF_PROTECTION_DISABLED);
+            getLogger().warn(Constants.WARNING_XSRF_PROTECTION_DISABLED);
         }
     }
 
@@ -296,8 +297,7 @@ public class DefaultDeploymentConfiguration
                     Constants.SERVLET_PARAMETER_RESOURCE_CACHE_TIME,
                     Integer.toString(DEFAULT_RESOURCE_CACHE_TIME)));
         } catch (NumberFormatException e) {
-            getLogger().warning(
-                    Constants.WARNING_RESOURCE_CACHING_TIME_NOT_NUMERIC);
+            getLogger().warn(Constants.WARNING_RESOURCE_CACHING_TIME_NOT_NUMERIC);
             resourceCacheTime = DEFAULT_RESOURCE_CACHE_TIME;
         }
     }
@@ -308,8 +308,7 @@ public class DefaultDeploymentConfiguration
                     Constants.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
                     Integer.toString(DEFAULT_HEARTBEAT_INTERVAL)));
         } catch (NumberFormatException e) {
-            getLogger()
-                    .warning(Constants.WARNING_HEARTBEAT_INTERVAL_NOT_NUMERIC);
+            getLogger().warn(Constants.WARNING_HEARTBEAT_INTERVAL_NOT_NUMERIC);
             heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
         }
     }
@@ -328,7 +327,7 @@ public class DefaultDeploymentConfiguration
             pushMode = Enum.valueOf(PushMode.class,
                     mode.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
-            getLogger().warning(Constants.WARNING_PUSH_MODE_NOT_RECOGNIZED);
+            getLogger().warn(Constants.WARNING_PUSH_MODE_NOT_RECOGNIZED);
             pushMode = PushMode.DISABLED;
         }
     }
@@ -347,7 +346,6 @@ public class DefaultDeploymentConfiguration
     }
 
     private Logger getLogger() {
-        return Logger.getLogger(getClass().getName());
+        return LoggerFactory.getLogger(getClass());
     }
-
 }

--- a/server/src/main/java/com/vaadin/server/DefaultErrorHandler.java
+++ b/server/src/main/java/com/vaadin/server/DefaultErrorHandler.java
@@ -16,17 +16,17 @@
 
 package com.vaadin.server;
 
-import java.lang.reflect.InvocationTargetException;
-import java.net.SocketException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.event.ListenerMethod.MethodException;
 import com.vaadin.server.ClientConnector.ConnectorErrorEvent;
 import com.vaadin.server.ServerRpcManager.RpcInvocationException;
 import com.vaadin.shared.Connector;
 import com.vaadin.ui.AbstractComponent;
 import com.vaadin.ui.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.net.SocketException;
 
 public class DefaultErrorHandler implements ErrorHandler {
     @Override
@@ -55,7 +55,7 @@ public class DefaultErrorHandler implements ErrorHandler {
         }
 
         // also print the error on console
-        getLogger().log(Level.SEVERE, "", t);
+        getLogger().error("", t);
     }
 
     /**
@@ -93,7 +93,7 @@ public class DefaultErrorHandler implements ErrorHandler {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(DefaultErrorHandler.class.getName());
+        return LoggerFactory.getLogger(DefaultErrorHandler.class);
     }
 
     /**

--- a/server/src/main/java/com/vaadin/server/DragAndDropService.java
+++ b/server/src/main/java/com/vaadin/server/DragAndDropService.java
@@ -15,23 +15,9 @@
  */
 package com.vaadin.server;
 
-import java.io.IOException;
-import java.io.Writer;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.TransferableImpl;
-import com.vaadin.event.dd.DragAndDropEvent;
-import com.vaadin.event.dd.DragSource;
-import com.vaadin.event.dd.DropHandler;
-import com.vaadin.event.dd.DropTarget;
-import com.vaadin.event.dd.TargetDetails;
-import com.vaadin.event.dd.TargetDetailsImpl;
+import com.vaadin.event.dd.*;
 import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
 import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.shared.Registration;
@@ -41,8 +27,16 @@ import com.vaadin.ui.Component;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.dnd.DragSourceExtension;
 import com.vaadin.ui.dnd.DropTargetExtension;
-
 import elemental.json.JsonObject;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
 
 /**
  *
@@ -77,14 +71,14 @@ public class DragAndDropService implements VariableOwner, ClientConnector {
                 .get("component");
         if (sourceComponent != null && !sourceComponent.isConnectorEnabled()) {
             // source component not supposed to be enabled
-            getLogger().warning("Client dropped from " + sourceComponent
+            getLogger().warn("Client dropped from " + sourceComponent
                     + " even though it's disabled");
             return;
         }
 
         // Validate drop handler owner
         if (!(owner instanceof DropTarget)) {
-            getLogger().severe("DropHandler owner " + owner
+            getLogger().error("DropHandler owner " + owner
                     + " must implement DropTarget");
             return;
         }
@@ -93,7 +87,7 @@ public class DragAndDropService implements VariableOwner, ClientConnector {
         DropTarget dropTarget = (DropTarget) owner;
 
         if (!dropTarget.isConnectorEnabled()) {
-            getLogger().warning("Client dropped on " + owner
+            getLogger().warn("Client dropped on " + owner
                     + " even though it's disabled");
             return;
         }
@@ -122,8 +116,8 @@ public class DragAndDropService implements VariableOwner, ClientConnector {
         DropHandler dropHandler = dropTarget.getDropHandler();
         if (dropHandler == null) {
             // No dropHandler returned so no drop can be performed.
-            getLogger().log(Level.FINE,
-                    "DropTarget.getDropHandler() returned null for owner: {0}",
+            getLogger().debug(
+                    "DropTarget.getDropHandler() returned null for owner: {}",
                     dropTarget);
             return;
         }
@@ -340,8 +334,8 @@ public class DragAndDropService implements VariableOwner, ClientConnector {
     public void removeExtension(Extension extension) {
     }
 
-    private Logger getLogger() {
-        return Logger.getLogger(DragAndDropService.class.getName());
+    private org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(DragAndDropService.class);
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/server/GlobalResourceHandler.java
+++ b/server/src/main/java/com/vaadin/server/GlobalResourceHandler.java
@@ -16,22 +16,21 @@
 
 package com.vaadin.server;
 
+import com.vaadin.shared.ApplicationConstants;
+import com.vaadin.ui.LegacyComponent;
+import com.vaadin.ui.UI;
+import com.vaadin.util.CurrentInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.servlet.http.HttpServletResponse;
-
-import com.vaadin.shared.ApplicationConstants;
-import com.vaadin.ui.LegacyComponent;
-import com.vaadin.ui.UI;
-import com.vaadin.util.CurrentInstance;
 
 /**
  * A {@link RequestHandler} that takes care of {@link ConnectorResource}s that
@@ -227,12 +226,12 @@ public class GlobalResourceHandler implements RequestHandler {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(GlobalResourceHandler.class.getName());
+        return LoggerFactory.getLogger(GlobalResourceHandler.class);
     }
 
     private static boolean error(VaadinRequest request, VaadinResponse response,
             String logMessage) throws IOException {
-        getLogger().log(Level.WARNING, logMessage);
+        getLogger().warn(logMessage);
         response.sendError(HttpServletResponse.SC_NOT_FOUND,
                 request.getPathInfo() + " can not be found");
 

--- a/server/src/main/java/com/vaadin/server/JsonPaintTarget.java
+++ b/server/src/main/java/com/vaadin/server/JsonPaintTarget.java
@@ -16,25 +16,16 @@
 
 package com.vaadin.server;
 
-import java.io.PrintWriter;
-import java.io.Serializable;
-import java.io.Writer;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Deque;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CustomLayout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.io.Writer;
+import java.util.*;
 
 /**
  * User Interface Description Language Target.
@@ -664,10 +655,10 @@ public class JsonPaintTarget implements PaintTarget {
             throws PaintException {
         boolean topLevelPaintable = openPaintables.isEmpty();
 
-        if (getLogger().isLoggable(Level.FINE)) {
-            getLogger().log(Level.FINE, "startPaintable for {0}@{1}",
-                    new Object[] { connector.getClass().getName(),
-                            Integer.toHexString(connector.hashCode()) });
+        if (getLogger().isDebugEnabled()) {
+            getLogger().debug("startPaintable for {}@{}",
+                    connector.getClass().getName(),
+                    Integer.toHexString(connector.hashCode()));
         }
         startTag(tagName, true);
 
@@ -690,10 +681,10 @@ public class JsonPaintTarget implements PaintTarget {
 
     @Override
     public void endPaintable(Component paintable) throws PaintException {
-        if (getLogger().isLoggable(Level.FINE)) {
-            getLogger().log(Level.FINE, "endPaintable for {0}@{1}",
-                    new Object[] { paintable.getClass().getName(),
-                            Integer.toHexString(paintable.hashCode()) });
+        if (getLogger().isDebugEnabled()) {
+            getLogger().debug("endPaintable for {}@{}",
+                    paintable.getClass().getName(),
+                    Integer.toHexString(paintable.hashCode()));
         }
 
         ClientConnector openPaintable = openPaintables.peek();
@@ -1030,8 +1021,7 @@ public class JsonPaintTarget implements PaintTarget {
         return !cacheEnabled;
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(JsonPaintTarget.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(JsonPaintTarget.class);
     }
-
 }

--- a/server/src/main/java/com/vaadin/server/LegacyCommunicationManager.java
+++ b/server/src/main/java/com/vaadin/server/LegacyCommunicationManager.java
@@ -16,6 +16,19 @@
 
 package com.vaadin.server;
 
+import com.vaadin.server.ClientConnector.ConnectorErrorEvent;
+import com.vaadin.shared.ApplicationConstants;
+import com.vaadin.shared.JavaScriptConnectorState;
+import com.vaadin.shared.JavaScriptExtensionState;
+import com.vaadin.shared.communication.SharedState;
+import com.vaadin.shared.ui.JavaScriptComponentState;
+import com.vaadin.ui.*;
+import com.vaadin.util.ReflectTools;
+import elemental.json.JsonObject;
+import elemental.json.JsonValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -26,23 +39,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.vaadin.server.ClientConnector.ConnectorErrorEvent;
-import com.vaadin.shared.ApplicationConstants;
-import com.vaadin.shared.JavaScriptConnectorState;
-import com.vaadin.shared.JavaScriptExtensionState;
-import com.vaadin.shared.communication.SharedState;
-import com.vaadin.shared.ui.JavaScriptComponentState;
-import com.vaadin.ui.Component;
-import com.vaadin.ui.ConnectorTracker;
-import com.vaadin.ui.HasComponents;
-import com.vaadin.ui.SelectiveRenderer;
-import com.vaadin.ui.UI;
-import com.vaadin.util.ReflectTools;
-
-import elemental.json.JsonObject;
-import elemental.json.JsonValue;
 
 /**
  * This is a common base class for the server-side implementations of the
@@ -130,8 +126,8 @@ public class LegacyCommunicationManager implements Serializable {
                     stateType, null);
             return encodeResult.getEncodedValue();
         } catch (Exception e) {
-            getLogger().log(Level.WARNING,
-                    "Error creating reference object for state of type {0}",
+            getLogger().warn(
+                    "Error creating reference object for state of type {}",
                     stateType.getName());
             return null;
         }
@@ -192,8 +188,7 @@ public class LegacyCommunicationManager implements Serializable {
             // Bare path interpreted as published file
             return registerPublishedFile(resourceUri, context);
         } catch (URISyntaxException e) {
-            getLogger().log(Level.WARNING,
-                    "Could not parse resource url " + resourceUri, e);
+            getLogger().warn("Could not parse resource url {}", resourceUri, e);
             return resourceUri;
         }
     }
@@ -211,9 +206,9 @@ public class LegacyCommunicationManager implements Serializable {
         if (publishedFileContexts.containsKey(name)) {
             Class<?> oldContext = publishedFileContexts.get(name);
             if (oldContext != context) {
-                getLogger().log(Level.WARNING,
-                        "{0} published by both {1} and {2}. File from {2} will be used.",
-                        new Object[] { name, context, oldContext });
+                getLogger().warn(
+                        "{} published by both {} and {}. File from {} will be used.",
+                        name, context, oldContext, oldContext);
             }
         } else {
             publishedFileContexts.put(name, context);
@@ -335,10 +330,8 @@ public class LegacyCommunicationManager implements Serializable {
         if (id == null) {
             id = nextTypeKey++;
             typeToKey.put(class1, id);
-            if (getLogger().isLoggable(Level.FINE)) {
-                getLogger().log(Level.FINE, "Mapping {0} to {1}",
-                        new Object[] { class1.getName(), id });
-            }
+
+            getLogger().debug("Mapping {} to {}", class1.getName(), id);
         }
         return id.toString();
     }
@@ -440,7 +433,7 @@ public class LegacyCommunicationManager implements Serializable {
         ui.getConnectorTracker().markAllClientSidesUninitialized();
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(LegacyCommunicationManager.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(LegacyCommunicationManager.class);
     }
 }

--- a/server/src/main/java/com/vaadin/server/LocaleService.java
+++ b/server/src/main/java/com/vaadin/server/LocaleService.java
@@ -14,10 +14,13 @@
  * the License.
  */
 
-/**
- *
- */
 package com.vaadin.server;
+
+import com.vaadin.shared.ui.ui.UIState.LocaleData;
+import com.vaadin.shared.ui.ui.UIState.LocaleServiceState;
+import com.vaadin.ui.UI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.text.DateFormat;
@@ -26,11 +29,6 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Locale;
-import java.util.logging.Logger;
-
-import com.vaadin.shared.ui.ui.UIState.LocaleData;
-import com.vaadin.shared.ui.ui.UIState.LocaleServiceState;
-import com.vaadin.ui.UI;
 
 /**
  * Server side service which handles locale and the transmission of locale date
@@ -163,12 +161,12 @@ public class LocaleService implements Serializable {
         DateFormat timeFormat = DateFormat.getTimeInstance(DateFormat.SHORT,
                 locale);
         if (!(dateFormat instanceof SimpleDateFormat)) {
-            getLogger().warning("Unable to get default date pattern for locale "
+            getLogger().warn("Unable to get default date pattern for locale "
                     + locale.toString());
             dateFormat = new SimpleDateFormat();
         }
         if (!(timeFormat instanceof SimpleDateFormat)) {
-            getLogger().warning("Unable to get default time pattern for locale "
+            getLogger().warn("Unable to get default time pattern for locale "
                     + locale.toString());
             timeFormat = new SimpleDateFormat();
         }
@@ -195,7 +193,6 @@ public class LocaleService implements Serializable {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(LocaleService.class.getName());
+        return LoggerFactory.getLogger(LocaleService.class);
     }
-
 }

--- a/server/src/main/java/com/vaadin/server/ServerRpcManager.java
+++ b/server/src/main/java/com/vaadin/server/ServerRpcManager.java
@@ -16,15 +16,14 @@
 
 package com.vaadin.server;
 
+import com.vaadin.shared.communication.ServerRpc;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.vaadin.shared.communication.ServerRpc;
 
 /**
  * Server side RPC manager that handles RPC calls coming from the client.
@@ -115,10 +114,10 @@ public class ServerRpcManager<T extends ServerRpc> implements Serializable {
         if (manager != null) {
             manager.applyInvocation(invocation);
         } else {
-            getLogger().log(Level.WARNING,
-                    "RPC call received for RpcTarget {0} ({1}) but the target has not registered any RPC interfaces",
-                    new Object[] { target.getClass().getName(),
-                            invocation.getConnectorId() });
+            getLogger().warn(
+                    "RPC call received for RpcTarget {} ({}) but the target has not registered any RPC interfaces",
+                    target.getClass().getName(),
+                    invocation.getConnectorId());
         }
     }
 
@@ -161,8 +160,8 @@ public class ServerRpcManager<T extends ServerRpc> implements Serializable {
         }
     }
 
-    private static Logger getLogger() {
-        return Logger.getLogger(ServerRpcManager.class.getName());
+    private static org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(ServerRpcManager.class);
     }
 
     /**

--- a/server/src/main/java/com/vaadin/server/UIProvider.java
+++ b/server/src/main/java/com/vaadin/server/UIProvider.java
@@ -16,22 +16,18 @@
 
 package com.vaadin.server;
 
-import java.io.InputStream;
-import java.io.Serializable;
-import java.lang.annotation.Annotation;
-import java.lang.annotation.Inherited;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.vaadin.annotations.PreserveOnRefresh;
-import com.vaadin.annotations.Push;
-import com.vaadin.annotations.Theme;
-import com.vaadin.annotations.Title;
-import com.vaadin.annotations.Widgetset;
+import com.vaadin.annotations.*;
 import com.vaadin.shared.communication.PushMode;
 import com.vaadin.shared.ui.ui.Transport;
 import com.vaadin.ui.UI;
 import com.vaadin.util.ReflectTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Inherited;
 
 public abstract class UIProvider implements Serializable {
 
@@ -224,13 +220,13 @@ public abstract class UIProvider implements Serializable {
             try {
                 return cls.newInstance();
             } catch (InstantiationException e) {
-                getLogger().log(Level.INFO,
-                        "Unexpected trying to instantiate class "
-                                + cls.getName(),
+                getLogger().info(
+                        "Unexpected trying to instantiate class {}",
+                        cls.getName(),
                         e);
             } catch (IllegalAccessException e) {
-                getLogger().log(Level.INFO,
-                        "Unexpected trying to access class " + cls.getName(),
+                getLogger().info(
+                        "Unexpected trying to access class {}", cls.getName(),
                         e);
             }
         }
@@ -316,8 +312,7 @@ public abstract class UIProvider implements Serializable {
         }
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(UIProvider.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(UIProvider.class);
     }
-
 }

--- a/server/src/main/java/com/vaadin/server/VaadinPortlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinPortlet.java
@@ -15,6 +15,18 @@
  */
 package com.vaadin.server;
 
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.vaadin.server.communication.PortletDummyRequestHandler;
+import com.vaadin.server.communication.PortletUIInitHandler;
+import com.vaadin.ui.UI;
+import com.vaadin.util.CurrentInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.portlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
@@ -23,33 +35,6 @@ import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.portlet.ActionRequest;
-import javax.portlet.ActionResponse;
-import javax.portlet.EventRequest;
-import javax.portlet.EventResponse;
-import javax.portlet.GenericPortlet;
-import javax.portlet.PortalContext;
-import javax.portlet.PortletConfig;
-import javax.portlet.PortletContext;
-import javax.portlet.PortletException;
-import javax.portlet.PortletRequest;
-import javax.portlet.PortletResponse;
-import javax.portlet.RenderRequest;
-import javax.portlet.RenderResponse;
-import javax.portlet.ResourceRequest;
-import javax.portlet.ResourceResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-
-import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
-import com.liferay.portal.kernel.util.PropsUtil;
-import com.vaadin.server.communication.PortletDummyRequestHandler;
-import com.vaadin.server.communication.PortletUIInitHandler;
-import com.vaadin.ui.UI;
-import com.vaadin.util.CurrentInstance;
 
 /**
  * Portlet 2.0 base class. This replaces the servlet in servlet/portlet 1.0
@@ -370,7 +355,7 @@ public class VaadinPortlet extends GenericPortlet
             } catch (Exception e) {
                 if (!warningLogged) {
                     warningLogged = true;
-                    getLogger().log(Level.WARNING,
+                    getLogger().warn(
                             "Could not determine underlying servlet request for WebLogic Portal portlet request",
                             e);
                 }
@@ -639,8 +624,8 @@ public class VaadinPortlet extends GenericPortlet
         getService().destroy();
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(VaadinPortlet.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(VaadinPortlet.class);
     }
 
     /**

--- a/server/src/main/java/com/vaadin/server/VaadinPortletService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinPortletService.java
@@ -16,28 +16,19 @@
 
 package com.vaadin.server;
 
-import static com.vaadin.shared.util.SharedUtil.trimTrailingSlashes;
+import com.vaadin.server.VaadinPortlet.RequestType;
+import com.vaadin.server.communication.*;
+import com.vaadin.ui.UI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.portlet.*;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
-import javax.portlet.EventRequest;
-import javax.portlet.PortletContext;
-import javax.portlet.PortletRequest;
-import javax.portlet.PortletSession;
-import javax.portlet.RenderRequest;
-
-import com.vaadin.server.VaadinPortlet.RequestType;
-import com.vaadin.server.communication.PortletBootstrapHandler;
-import com.vaadin.server.communication.PortletDummyRequestHandler;
-import com.vaadin.server.communication.PortletListenerNotifier;
-import com.vaadin.server.communication.PortletStateAwareRequestHandler;
-import com.vaadin.server.communication.PortletUIInitHandler;
-import com.vaadin.ui.UI;
+import static com.vaadin.shared.util.SharedUtil.trimTrailingSlashes;
 
 public class VaadinPortletService extends VaadinService {
     private final VaadinPortlet portlet;
@@ -175,7 +166,7 @@ public class VaadinPortletService extends VaadinService {
                 return new File(url.getFile());
             } catch (final Exception e) {
                 // FIXME: Handle exception
-                getLogger().log(Level.INFO,
+                getLogger().info(
                         "Cannot access base directory, possible security issue "
                                 + "with Application Server or Servlet Container",
                         e);
@@ -184,8 +175,8 @@ public class VaadinPortletService extends VaadinService {
         return null;
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(VaadinPortletService.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(VaadinPortletService.class);
     }
 
     @Override
@@ -338,7 +329,7 @@ public class VaadinPortletService extends VaadinService {
             VaadinResponse response) {
         // TODO Figure out a better way to deal with
         // SessionExpiredExceptions
-        getLogger().finest("A user session has expired");
+        getLogger().trace("A user session has expired");
     }
 
     private WrappedPortletSession getWrappedPortletSession(

--- a/server/src/main/java/com/vaadin/server/VaadinServletService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServletService.java
@@ -16,6 +16,14 @@
 
 package com.vaadin.server;
 
+import com.vaadin.server.communication.PushRequestHandler;
+import com.vaadin.server.communication.ServletBootstrapHandler;
+import com.vaadin.server.communication.ServletUIInitHandler;
+import com.vaadin.ui.UI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,14 +31,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.servlet.http.HttpServletRequest;
-
-import com.vaadin.server.communication.PushRequestHandler;
-import com.vaadin.server.communication.ServletBootstrapHandler;
-import com.vaadin.server.communication.ServletUIInitHandler;
-import com.vaadin.ui.UI;
 
 public class VaadinServletService extends VaadinService {
 
@@ -70,7 +70,7 @@ public class VaadinServletService extends VaadinService {
                 // Atmosphere init failed. Push won't work but we don't throw a
                 // service exception as we don't want to prevent non-push
                 // applications from working
-                getLogger().log(Level.WARNING,
+                getLogger().warn(
                         "Error initializing Atmosphere. Push will not work.",
                         e);
             }
@@ -288,8 +288,7 @@ public class VaadinServletService extends VaadinService {
         return appId;
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(VaadinServletService.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(VaadinServletService.class);
     }
-
 }

--- a/server/src/main/java/com/vaadin/server/VaadinSession.java
+++ b/server/src/main/java/com/vaadin/server/VaadinSession.java
@@ -16,42 +16,30 @@
 
 package com.vaadin.server;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpSessionBindingEvent;
-import javax.servlet.http.HttpSessionBindingListener;
-
 import com.vaadin.event.EventRouter;
 import com.vaadin.shared.Registration;
 import com.vaadin.shared.communication.PushMode;
 import com.vaadin.ui.UI;
 import com.vaadin.util.CurrentInstance;
 import com.vaadin.util.ReflectTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionBindingEvent;
+import javax.servlet.http.HttpSessionBindingListener;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Contains everything that Vaadin needs to store for a specific user. This is
@@ -140,7 +128,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
                     errorHandler.error(errorEvent);
                 }
             } catch (Exception e) {
-                getLogger().log(Level.SEVERE, e.getMessage(), e);
+                getLogger().error(e.getMessage(), e);
             }
         }
     }
@@ -289,7 +277,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
         // closing
         // Notify the service
         if (service == null) {
-            getLogger().warning(
+            getLogger().warn(
                     "A VaadinSession instance not associated to any service is getting unbound. "
                             + "Session destroy events will not be fired and UIs in the session will not get detached. "
                             + "This might happen if a session is deserialized but never used before it expires.");
@@ -1030,7 +1018,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
                     try {
                         ui.getConnectorTracker().cleanConnectorMap(false);
                     } catch (AssertionError | Exception e) {
-                        getLogger().log(Level.SEVERE,
+                        getLogger().error(
                                 "Exception while cleaning connector map for ui "
                                         + ui.getUIId(),
                                 e);
@@ -1312,8 +1300,8 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
         this.state = state;
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(VaadinSession.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(VaadinSession.class);
     }
 
     /**

--- a/server/src/main/java/com/vaadin/server/communication/AtmospherePushConnection.java
+++ b/server/src/main/java/com/vaadin/server/communication/AtmospherePushConnection.java
@@ -16,27 +16,17 @@
 
 package com.vaadin.server.communication;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.Reader;
-import java.io.Serializable;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
-
+import com.vaadin.shared.communication.PushConstants;
+import com.vaadin.ui.UI;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.AtmosphereResource.TRANSPORT;
 import org.atmosphere.util.Version;
+import org.slf4j.LoggerFactory;
 
-import com.vaadin.shared.communication.PushConstants;
-import com.vaadin.ui.UI;
+import java.io.*;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * A {@link PushConnection} implementation using the Atmosphere push support
@@ -283,8 +273,7 @@ public class AtmospherePushConnection implements PushConnection {
         if (resource == null) {
             // Already disconnected. Should not happen but if it does, we don't
             // want to cause NPEs
-            getLogger().fine(
-                    "AtmospherePushConnection.disconnect() called twice, this should not happen");
+            getLogger().debug("AtmospherePushConnection.disconnect() called twice, this should not happen");
             return;
         }
         if (resource.isResumed()) {
@@ -301,11 +290,9 @@ public class AtmospherePushConnection implements PushConnection {
             try {
                 outgoingMessage.get(1000, TimeUnit.MILLISECONDS);
             } catch (TimeoutException e) {
-                getLogger().log(Level.INFO,
-                        "Timeout waiting for messages to be sent to client before disconnect");
+                getLogger().info("Timeout waiting for messages to be sent to client before disconnect");
             } catch (Exception e) {
-                getLogger().log(Level.INFO,
-                        "Error waiting for messages to be sent to client before disconnect");
+                getLogger().info("Error waiting for messages to be sent to client before disconnect");
             }
             outgoingMessage = null;
         }
@@ -313,8 +300,7 @@ public class AtmospherePushConnection implements PushConnection {
         try {
             resource.close();
         } catch (IOException e) {
-            getLogger().log(Level.INFO, "Error when closing push connection",
-                    e);
+            getLogger().info("Error when closing push connection", e);
         }
         connectionLost();
     }
@@ -353,8 +339,8 @@ public class AtmospherePushConnection implements PushConnection {
         state = State.DISCONNECTED;
     }
 
-    private static Logger getLogger() {
-        return Logger.getLogger(AtmospherePushConnection.class.getName());
+    private static org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(AtmospherePushConnection.class);
     }
 
     /**
@@ -364,24 +350,6 @@ public class AtmospherePushConnection implements PushConnection {
      * @since 7.6
      */
     public static void enableAtmosphereDebugLogging() {
-        Level level = Level.FINEST;
-
-        Logger atmosphereLogger = Logger.getLogger("org.atmosphere");
-        if (atmosphereLogger.getLevel() == level) {
-            // Already enabled
-            return;
-        }
-
-        atmosphereLogger.setLevel(level);
-
-        // Without this logging, we will have a ClassCircularityError
-        LogRecord record = new LogRecord(Level.INFO,
-                "Enabling Atmosphere debug logging");
-        atmosphereLogger.log(record);
-
-        ConsoleHandler ch = new ConsoleHandler();
-        ch.setLevel(Level.ALL);
-        atmosphereLogger.addHandler(ch);
+        // it is not required any more, since SLF4J is enabled by default
     }
-
 }

--- a/server/src/main/java/com/vaadin/server/communication/JSR356WebsocketInitializer.java
+++ b/server/src/main/java/com/vaadin/server/communication/JSR356WebsocketInitializer.java
@@ -15,22 +15,16 @@
  */
 package com.vaadin.server.communication;
 
+import com.vaadin.server.VaadinServlet;
+import org.atmosphere.cpr.AtmosphereFramework;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.annotation.WebListener;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-import javax.servlet.ServletRegistration;
-import javax.servlet.annotation.WebListener;
-
-import org.atmosphere.cpr.AtmosphereFramework;
-
-import com.vaadin.server.VaadinServlet;
 
 /**
  * Initializer class for JSR 356 websockets.
@@ -118,7 +112,7 @@ public class JSR356WebsocketInitializer implements ServletContextListener {
                     initAtmosphereForVaadinServlet(servletRegistration,
                             servletContext);
                 } catch (Exception e) {
-                    getLogger().log(Level.WARNING,
+                    getLogger().warn(
                             "Failed to initialize Atmosphere for "
                                     + servletName,
                             e);
@@ -145,14 +139,16 @@ public class JSR356WebsocketInitializer implements ServletContextListener {
 
         if (servletContext.getAttribute(attributeName) != null) {
             // Already initialized
-            getLogger().warning("Atmosphere already initialized");
+            getLogger().warn("Atmosphere already initialized");
             return;
         }
-        getLogger().finer("Creating AtmosphereFramework for " + servletName);
+        getLogger().trace("Creating AtmosphereFramework for {}", servletName);
+
         AtmosphereFramework framework = PushRequestHandler.initAtmosphere(
                 new FakeServletConfig(servletRegistration, servletContext));
         servletContext.setAttribute(attributeName, framework);
-        getLogger().finer("Created AtmosphereFramework for " + servletName);
+
+        getLogger().trace("Created AtmosphereFramework for {}", servletName);
 
     }
 
@@ -214,8 +210,8 @@ public class JSR356WebsocketInitializer implements ServletContextListener {
         }
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(JSR356WebsocketInitializer.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(JSR356WebsocketInitializer.class);
     }
 
     @Override
@@ -238,5 +234,4 @@ public class JSR356WebsocketInitializer implements ServletContextListener {
             }
         }
     }
-
 }

--- a/server/src/main/java/com/vaadin/server/communication/LegacyUidlWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/LegacyUidlWriter.java
@@ -16,6 +16,15 @@
 
 package com.vaadin.server.communication;
 
+import com.vaadin.server.ClientConnector;
+import com.vaadin.server.LegacyPaint;
+import com.vaadin.server.PaintTarget;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.LegacyComponent;
+import com.vaadin.ui.UI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.Writer;
@@ -23,14 +32,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Logger;
-
-import com.vaadin.server.ClientConnector;
-import com.vaadin.server.LegacyPaint;
-import com.vaadin.server.PaintTarget;
-import com.vaadin.ui.Component;
-import com.vaadin.ui.LegacyComponent;
-import com.vaadin.ui.UI;
 
 /**
  * Serializes legacy UIDL changes to JSON.
@@ -72,8 +73,7 @@ public class LegacyUidlWriter implements Serializable {
 
         writer.write("[");
         for (Component c : legacyComponents) {
-            getLogger()
-                    .fine("Painting LegacyComponent " + c.getClass().getName()
+            getLogger().trace("Painting LegacyComponent " + c.getClass().getName()
                             + "@" + Integer.toHexString(c.hashCode()));
             target.startTag("change");
             final String pid = c.getConnectorId();
@@ -109,7 +109,7 @@ public class LegacyUidlWriter implements Serializable {
         });
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(LegacyUidlWriter.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(LegacyUidlWriter.class);
     }
 }

--- a/server/src/main/java/com/vaadin/server/communication/PublishedFileHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PublishedFileHandler.java
@@ -16,23 +16,17 @@
 
 package com.vaadin.server.communication;
 
+import com.vaadin.annotations.JavaScript;
+import com.vaadin.annotations.StyleSheet;
+import com.vaadin.server.*;
+import com.vaadin.shared.ApplicationConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.logging.Logger;
-
-import javax.servlet.http.HttpServletResponse;
-
-import com.vaadin.annotations.JavaScript;
-import com.vaadin.annotations.StyleSheet;
-import com.vaadin.server.Constants;
-import com.vaadin.server.LegacyCommunicationManager;
-import com.vaadin.server.RequestHandler;
-import com.vaadin.server.ServletPortletHelper;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinResponse;
-import com.vaadin.server.VaadinSession;
-import com.vaadin.shared.ApplicationConstants;
 
 /**
  * Serves a connector resource from the classpath if the resource has previously
@@ -70,8 +64,7 @@ public class PublishedFileHandler implements RequestHandler {
         // Security check: avoid accidentally serving from the UI of the
         // classpath instead of relative to the context class
         if (fileName.startsWith("/")) {
-            getLogger()
-                    .warning("Published file request starting with / rejected: "
+            getLogger().warn("Published file request starting with / rejected: "
                             + fileName);
             response.sendError(HttpServletResponse.SC_NOT_FOUND, fileName);
             return true;
@@ -90,7 +83,7 @@ public class PublishedFileHandler implements RequestHandler {
         // Security check: don't serve resource if the name hasn't been
         // registered in the map
         if (context == null) {
-            getLogger().warning(
+            getLogger().warn(
                     "Rejecting published file request for file that has not been published: "
                             + fileName);
             response.sendError(HttpServletResponse.SC_NOT_FOUND, fileName);
@@ -100,7 +93,7 @@ public class PublishedFileHandler implements RequestHandler {
         // Resolve file relative to the location of the context class
         InputStream in = context.getResourceAsStream(fileName);
         if (in == null) {
-            getLogger().warning(fileName + " published by " + context.getName()
+            getLogger().warn(fileName + " published by " + context.getName()
                     + " not found. Verify that the file "
                     + context.getPackage().getName().replace('.', '/') + '/'
                     + fileName + " is available on the classpath.");
@@ -150,7 +143,7 @@ public class PublishedFileHandler implements RequestHandler {
         return true;
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(PublishedFileHandler.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(PublishedFileHandler.class);
     }
 }

--- a/server/src/main/java/com/vaadin/server/communication/PushAtmosphereHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushAtmosphereHandler.java
@@ -15,16 +15,17 @@
  */
 package com.vaadin.server.communication;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.atmosphere.cpr.AtmosphereRequest;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.AtmosphereResourceEvent;
 import org.atmosphere.cpr.AtmosphereResourceEventListenerAdapter;
 import org.atmosphere.handler.AbstractReflectorAtmosphereHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.logging.Level;
 
 /**
  * Handles Atmosphere requests and forwards them to logical methods in
@@ -42,8 +43,8 @@ public class PushAtmosphereHandler extends AbstractReflectorAtmosphereHandler
         this.pushHandler = pushHandler;
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(PushAtmosphereHandler.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(PushAtmosphereHandler.class);
     }
 
     @Override
@@ -51,7 +52,7 @@ public class PushAtmosphereHandler extends AbstractReflectorAtmosphereHandler
             throws IOException {
         super.onStateChange(event);
         if (pushHandler == null) {
-            getLogger().warning(
+            getLogger().warn(
                     "AtmosphereHandler.onStateChange called before PushHandler has been set. This should really not happen");
             return;
         }
@@ -64,7 +65,7 @@ public class PushAtmosphereHandler extends AbstractReflectorAtmosphereHandler
     @Override
     public void onRequest(AtmosphereResource resource) {
         if (pushHandler == null) {
-            getLogger().warning(
+            getLogger().warn(
                     "AtmosphereHandler.onRequest called before PushHandler has been set. This should really not happen");
             return;
         }
@@ -111,7 +112,8 @@ public class PushAtmosphereHandler extends AbstractReflectorAtmosphereHandler
 
         @Override
         public void onThrowable(AtmosphereResourceEvent event) {
-            getLogger().log(Level.SEVERE, "Exception in push connection",
+            getLogger().error(
+                    "Exception in push connection",
                     event.throwable());
             pushHandler.connectionLost(event);
         }

--- a/server/src/main/java/com/vaadin/server/communication/PushRequestHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushRequestHandler.java
@@ -16,36 +16,20 @@
 
 package com.vaadin.server.communication;
 
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import com.vaadin.server.*;
+import com.vaadin.shared.communication.PushConstants;
+import org.atmosphere.cache.UUIDBroadcasterCache;
+import org.atmosphere.client.TrackMessageSizeInterceptor;
+import org.atmosphere.cpr.*;
+import org.atmosphere.cpr.AtmosphereFramework.AtmosphereHandlerWrapper;
+import org.atmosphere.interceptor.HeartbeatInterceptor;
+import org.atmosphere.util.VoidAnnotationProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
-
-import org.atmosphere.cache.UUIDBroadcasterCache;
-import org.atmosphere.client.TrackMessageSizeInterceptor;
-import org.atmosphere.cpr.ApplicationConfig;
-import org.atmosphere.cpr.AtmosphereFramework;
-import org.atmosphere.cpr.AtmosphereFramework.AtmosphereHandlerWrapper;
-import org.atmosphere.cpr.AtmosphereHandler;
-import org.atmosphere.cpr.AtmosphereInterceptor;
-import org.atmosphere.cpr.AtmosphereRequestImpl;
-import org.atmosphere.cpr.AtmosphereResponseImpl;
-import org.atmosphere.interceptor.HeartbeatInterceptor;
-import org.atmosphere.util.VoidAnnotationProcessor;
-
-import com.vaadin.server.RequestHandler;
-import com.vaadin.server.ServiceException;
-import com.vaadin.server.ServletPortletHelper;
-import com.vaadin.server.SessionExpiredHandler;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinResponse;
-import com.vaadin.server.VaadinServletRequest;
-import com.vaadin.server.VaadinServletResponse;
-import com.vaadin.server.VaadinServletService;
-import com.vaadin.server.VaadinSession;
-import com.vaadin.shared.communication.PushConstants;
+import java.io.IOException;
 
 /**
  * Handles requests to open a push (bidirectional) communication channel between
@@ -75,12 +59,12 @@ public class PushRequestHandler
         atmosphere = getPreInitializedAtmosphere(vaadinServletConfig);
         if (atmosphere == null) {
             // Not initialized by JSR356WebsocketInitializer
-            getLogger().fine("Initializing Atmosphere for servlet "
+            getLogger().debug("Initializing Atmosphere for servlet "
                     + vaadinServletConfig.getServletName());
             try {
                 atmosphere = initAtmosphere(vaadinServletConfig);
             } catch (Exception e) {
-                getLogger().log(Level.WARNING,
+                getLogger().warn(
                         "Failed to initialize Atmosphere for "
                                 + service.getServlet().getServletName()
                                 + ". Push will not work.",
@@ -88,7 +72,7 @@ public class PushRequestHandler
                 return;
             }
         } else {
-            getLogger().fine("Using pre-initialized Atmosphere for servlet "
+            getLogger().debug("Using pre-initialized Atmosphere for servlet "
                     + vaadinServletConfig.getServletName());
         }
         pushHandler.setLongPollingSuspendTimeout(
@@ -123,8 +107,8 @@ public class PushRequestHandler
         return new PushHandler(service);
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(PushRequestHandler.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(PushRequestHandler.class);
     }
 
     /**

--- a/server/src/main/java/com/vaadin/server/communication/ResourceWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/ResourceWriter.java
@@ -16,19 +16,15 @@
 
 package com.vaadin.server.communication;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Serializable;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.server.JsonPaintTarget;
 import com.vaadin.server.LegacyCommunicationManager;
 import com.vaadin.ui.CustomLayout;
 import com.vaadin.ui.UI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Serializes resources to JSON. Currently only used for {@link CustomLayout}
@@ -72,8 +68,7 @@ public class ResourceWriter implements Serializable {
                         ui.getTheme(), resource);
             } catch (final Exception e) {
                 // FIXME: Handle exception
-                getLogger().log(Level.FINER,
-                        "Failed to get theme resource stream.", e);
+                getLogger().debug("Failed to get theme resource stream.", e);
             }
             if (is != null) {
 
@@ -84,25 +79,25 @@ public class ResourceWriter implements Serializable {
                 try (InputStreamReader r = new InputStreamReader(is,
                         StandardCharsets.UTF_8)) {
                     final char[] buffer = new char[20000];
-                    int charsRead = 0;
+                    int charsRead;
                     while ((charsRead = r.read(buffer)) > 0) {
                         layout.append(buffer, 0, charsRead);
                     }
                 } catch (final IOException e) {
                     // FIXME: Handle exception
-                    getLogger().log(Level.INFO, "Resource transfer failed", e);
+                    getLogger().info("Resource transfer failed", e);
                 }
                 writer.write("\""
                         + JsonPaintTarget.escapeJSON(layout.toString()) + "\"");
             } else {
                 // FIXME: Handle exception
-                getLogger().severe("CustomLayout not found: " + resource);
+                getLogger().error("CustomLayout not found: " + resource);
             }
         }
         writer.write("}");
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(ResourceWriter.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(ResourceWriter.class);
     }
 }

--- a/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
@@ -16,36 +16,27 @@
 
 package com.vaadin.server.communication;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.StringWriter;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.annotations.PreserveOnRefresh;
-import com.vaadin.server.LegacyApplicationUIProvider;
-import com.vaadin.server.SynchronizedRequestHandler;
-import com.vaadin.server.UIClassSelectionEvent;
-import com.vaadin.server.UICreateEvent;
-import com.vaadin.server.UIProvider;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinResponse;
-import com.vaadin.server.VaadinService;
-import com.vaadin.server.VaadinSession;
+import com.vaadin.server.*;
 import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.shared.JsonConstants;
 import com.vaadin.shared.communication.PushMode;
 import com.vaadin.shared.ui.ui.Transport;
 import com.vaadin.shared.ui.ui.UIConstants;
 import com.vaadin.ui.UI;
-
 import elemental.json.Json;
 import elemental.json.JsonException;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Handles an initial request from the client to initialize a {@link UI}.
@@ -227,7 +218,7 @@ public abstract class UIInitHandler extends SynchronizedRequestHandler {
         // Warn if the window can't be preserved
         if (embedId == null
                 && vaadinService.preserveUIOnRefresh(provider, event)) {
-            getLogger().warning("There is no embed id available for UI "
+            getLogger().warn("There is no embed id available for UI "
                     + uiClass + " that should be preserved.");
         }
 
@@ -294,7 +285,7 @@ public abstract class UIInitHandler extends SynchronizedRequestHandler {
             writer.write("}");
 
             String initialUIDL = writer.toString();
-            getLogger().log(Level.FINE, "Initial UIDL:" + initialUIDL);
+            getLogger().trace("Initial UIDL:" + initialUIDL);
             return initialUIDL;
         }
     }
@@ -325,7 +316,7 @@ public abstract class UIInitHandler extends SynchronizedRequestHandler {
                 + session.getPushId() + "\",";
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(UIInitHandler.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(UIInitHandler.class);
     }
 }

--- a/server/src/main/java/com/vaadin/server/communication/UidlRequestHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/UidlRequestHandler.java
@@ -16,25 +16,17 @@
 
 package com.vaadin.server.communication;
 
+import com.vaadin.server.LegacyCommunicationManager.InvalidUIDLSecurityKeyException;
+import com.vaadin.server.*;
+import com.vaadin.shared.JsonConstants;
+import com.vaadin.ui.UI;
+import elemental.json.JsonException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.vaadin.server.LegacyCommunicationManager.InvalidUIDLSecurityKeyException;
-import com.vaadin.server.ServletPortletHelper;
-import com.vaadin.server.SessionExpiredHandler;
-import com.vaadin.server.SynchronizedRequestHandler;
-import com.vaadin.server.SystemMessages;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinResponse;
-import com.vaadin.server.VaadinService;
-import com.vaadin.server.VaadinSession;
-import com.vaadin.shared.JsonConstants;
-import com.vaadin.ui.UI;
-
-import elemental.json.JsonException;
 
 /**
  * Processes a UIDL request from the client.
@@ -91,13 +83,13 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
 
             writeUidl(request, response, uI, stringWriter);
         } catch (JsonException e) {
-            getLogger().log(Level.SEVERE, "Error writing JSON to response", e);
+            getLogger().error("Error writing JSON to response", e);
             // Refresh on client side
             writeRefresh(request, response);
             return true;
         } catch (InvalidUIDLSecurityKeyException e) {
-            getLogger().log(Level.WARNING,
-                    "Invalid security key received from {0}",
+            getLogger().warn(
+                    "Invalid security key received from {}",
                     request.getRemoteHost());
             // Refresh on client side
             writeRefresh(request, response);
@@ -143,8 +135,8 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
         outWriter.write("for(;;);[{");
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(UidlRequestHandler.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(UidlRequestHandler.class);
     }
 
     /*
@@ -198,5 +190,4 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
 
         return json;
     }
-
 }

--- a/server/src/main/java/com/vaadin/server/communication/UidlWriter.java
+++ b/server/src/main/java/com/vaadin/server/communication/UidlWriter.java
@@ -16,36 +16,24 @@
 
 package com.vaadin.server.communication;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.vaadin.server.ClientConnector;
+import com.vaadin.server.*;
 import com.vaadin.server.DependencyFilter.FilterContext;
-import com.vaadin.server.JsonPaintTarget;
-import com.vaadin.server.LegacyCommunicationManager;
 import com.vaadin.server.LegacyCommunicationManager.ClientCache;
-import com.vaadin.server.SystemMessages;
-import com.vaadin.server.VaadinService;
-import com.vaadin.server.VaadinSession;
 import com.vaadin.shared.ApplicationConstants;
 import com.vaadin.ui.ConnectorTracker;
 import com.vaadin.ui.Dependency;
 import com.vaadin.ui.UI;
-
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.Writer;
+import java.util.*;
 
 /**
  * Serializes pending server-side changes to UI state to JSON. This includes
@@ -86,7 +74,7 @@ public class UidlWriter implements Serializable {
         boolean repaintAll = clientCache.isEmpty();
         // Paints components
         ConnectorTracker uiConnectorTracker = ui.getConnectorTracker();
-        getLogger().log(Level.FINE, "* Creating response to client");
+        getLogger().debug("* Creating response to client");
 
         while (true) {
             List<ClientConnector> connectorsToProcess = new ArrayList<>();
@@ -130,8 +118,8 @@ public class UidlWriter implements Serializable {
             }
         }
 
-        getLogger().log(Level.FINE, "Found " + processedConnectors.size()
-                + " dirty connectors to paint");
+        getLogger().debug("Found {} dirty connectors to paint",
+                processedConnectors.size());
 
         uiConnectorTracker.setWritingResponse(true);
         try {
@@ -354,7 +342,7 @@ public class UidlWriter implements Serializable {
         }
     }
 
-    private static final Logger getLogger() {
-        return Logger.getLogger(UidlWriter.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(UidlWriter.class);
     }
 }

--- a/server/src/main/java/com/vaadin/server/themeutils/SASSAddonImportFileCreator.java
+++ b/server/src/main/java/com/vaadin/server/themeutils/SASSAddonImportFileCreator.java
@@ -15,22 +15,14 @@
  */
 package com.vaadin.server.themeutils;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.server.widgetsetutils.ClassPathExplorer;
 import com.vaadin.server.widgetsetutils.ClassPathExplorer.LocationInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.net.URL;
+import java.util.*;
 
 /**
  * Helper class for managing the addon imports and creating an a SCSS file for
@@ -124,12 +116,12 @@ public class SASSAddonImportFileCreator {
 
         } catch (FileNotFoundException e) {
             // Should not happen since file is checked before this
-            getLogger().log(Level.WARNING, "Error updating addons.scss", e);
+            getLogger().warn("Error updating addons.scss", e);
         }
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(SASSAddonImportFileCreator.class.getName());
+        return LoggerFactory.getLogger(SASSAddonImportFileCreator.class);
     }
 
     private static List<String> addImport(PrintStream stream, String file,

--- a/server/src/main/java/com/vaadin/ui/AbstractDateField.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractDateField.java
@@ -15,39 +15,13 @@
  */
 package com.vaadin.ui;
 
-import java.io.Serializable;
-import java.lang.reflect.Type;
-import java.text.SimpleDateFormat;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.temporal.Temporal;
-import java.time.temporal.TemporalAdjuster;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.jsoup.nodes.Element;
-
 import com.googlecode.gentyref.GenericTypeReflector;
 import com.vaadin.data.Result;
 import com.vaadin.data.ValidationResult;
 import com.vaadin.data.Validator;
 import com.vaadin.data.ValueContext;
 import com.vaadin.data.validator.RangeValidator;
-import com.vaadin.event.FieldEvents.BlurEvent;
-import com.vaadin.event.FieldEvents.BlurListener;
-import com.vaadin.event.FieldEvents.BlurNotifier;
-import com.vaadin.event.FieldEvents.FocusEvent;
-import com.vaadin.event.FieldEvents.FocusListener;
-import com.vaadin.event.FieldEvents.FocusNotifier;
+import com.vaadin.event.FieldEvents.*;
 import com.vaadin.server.ErrorMessage;
 import com.vaadin.server.UserError;
 import com.vaadin.shared.Registration;
@@ -57,6 +31,19 @@ import com.vaadin.shared.ui.datefield.DateResolution;
 import com.vaadin.ui.declarative.DesignAttributeHandler;
 import com.vaadin.ui.declarative.DesignContext;
 import com.vaadin.util.TimeZoneUtil;
+import org.jsoup.nodes.Element;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.lang.reflect.Type;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAdjuster;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A date editor component with {@link LocalDate} as an input value.
@@ -624,9 +611,9 @@ public abstract class AbstractDateField<T extends Temporal & TemporalAdjuster & 
                         .parse(design.attr("value"), clazz);
                 // formatting will return null if it cannot parse the string
                 if (date == null) {
-                    Logger.getLogger(AbstractDateField.class.getName())
-                            .info("cannot parse " + design.attr("value")
-                                    + " as date");
+                    LoggerFactory.getLogger(AbstractDateField.class)
+                            .info("cannot parse {} as date",
+                                    design.attr("value"));
                 }
                 doSetValue(date);
             } else {

--- a/server/src/main/java/com/vaadin/ui/AbstractMedia.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractMedia.java
@@ -16,32 +16,25 @@
 
 package com.vaadin.ui;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.jsoup.nodes.Attributes;
-import org.jsoup.nodes.Element;
-import org.jsoup.nodes.Node;
-
-import com.vaadin.server.ConnectorResource;
-import com.vaadin.server.DownloadStream;
-import com.vaadin.server.Resource;
-import com.vaadin.server.ResourceReference;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinResponse;
-import com.vaadin.server.VaadinSession;
+import com.vaadin.server.*;
 import com.vaadin.shared.communication.URLReference;
 import com.vaadin.shared.ui.AbstractMediaState;
 import com.vaadin.shared.ui.MediaControl;
 import com.vaadin.shared.ui.PreloadMode;
 import com.vaadin.ui.declarative.DesignAttributeHandler;
 import com.vaadin.ui.declarative.DesignContext;
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Abstract base class for the HTML5 media components.
@@ -112,8 +105,7 @@ public abstract class AbstractMedia extends AbstractComponent {
             int sourceIndex = Integer.parseInt(matcher.group(1));
 
             if (sourceIndex < 0 || sourceIndex >= sources.size()) {
-                getLogger().log(Level.WARNING,
-                        "Requested source index {0} is out of bounds",
+                getLogger().warn("Requested source index {} is out of bounds",
                         sourceIndex);
                 return false;
             }
@@ -131,7 +123,7 @@ public abstract class AbstractMedia extends AbstractComponent {
     }
 
     private Logger getLogger() {
-        return Logger.getLogger(AbstractMedia.class.getName());
+        return LoggerFactory.getLogger(AbstractMedia.class);
     }
 
     /**

--- a/server/src/main/java/com/vaadin/ui/AbstractOrderedLayout.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractOrderedLayout.java
@@ -16,15 +16,6 @@
 
 package com.vaadin.ui;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.logging.Logger;
-
-import org.jsoup.nodes.Attributes;
-import org.jsoup.nodes.Element;
-
 import com.vaadin.event.LayoutEvents.LayoutClickEvent;
 import com.vaadin.event.LayoutEvents.LayoutClickListener;
 import com.vaadin.event.LayoutEvents.LayoutClickNotifier;
@@ -39,6 +30,15 @@ import com.vaadin.shared.ui.orderedlayout.AbstractOrderedLayoutState;
 import com.vaadin.shared.ui.orderedlayout.AbstractOrderedLayoutState.ChildComponentData;
 import com.vaadin.ui.declarative.DesignAttributeHandler;
 import com.vaadin.ui.declarative.DesignContext;
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
 
 @SuppressWarnings("serial")
 public abstract class AbstractOrderedLayout extends AbstractLayout
@@ -554,6 +554,6 @@ public abstract class AbstractOrderedLayout extends AbstractLayout
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(AbstractOrderedLayout.class.getName());
+        return LoggerFactory.getLogger(AbstractOrderedLayout.class);
     }
 }

--- a/server/src/main/java/com/vaadin/ui/UI.java
+++ b/server/src/main/java/com/vaadin/ui/UI.java
@@ -16,25 +16,6 @@
 
 package com.vaadin.ui;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.lang.reflect.Method;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.Future;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.annotations.PreserveOnRefresh;
 import com.vaadin.event.Action;
 import com.vaadin.event.Action.Handler;
@@ -47,38 +28,14 @@ import com.vaadin.event.UIEvents.PollListener;
 import com.vaadin.event.UIEvents.PollNotifier;
 import com.vaadin.navigator.Navigator;
 import com.vaadin.navigator.PushStateNavigation;
-import com.vaadin.server.ClientConnector;
-import com.vaadin.server.ComponentSizeValidator;
+import com.vaadin.server.*;
 import com.vaadin.server.ComponentSizeValidator.InvalidLayout;
-import com.vaadin.server.DefaultErrorHandler;
-import com.vaadin.server.ErrorHandler;
-import com.vaadin.server.ErrorHandlingRunnable;
-import com.vaadin.server.LocaleService;
-import com.vaadin.server.Page;
-import com.vaadin.server.PaintException;
-import com.vaadin.server.PaintTarget;
-import com.vaadin.server.UIProvider;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinService;
-import com.vaadin.server.VaadinServlet;
-import com.vaadin.server.VaadinSession;
 import com.vaadin.server.VaadinSession.State;
 import com.vaadin.server.communication.PushConnection;
-import com.vaadin.shared.ApplicationConstants;
-import com.vaadin.shared.Connector;
-import com.vaadin.shared.EventId;
-import com.vaadin.shared.MouseEventDetails;
-import com.vaadin.shared.Registration;
+import com.vaadin.shared.*;
 import com.vaadin.shared.communication.PushMode;
 import com.vaadin.shared.ui.WindowOrderRpc;
-import com.vaadin.shared.ui.ui.DebugWindowClientRpc;
-import com.vaadin.shared.ui.ui.DebugWindowServerRpc;
-import com.vaadin.shared.ui.ui.PageClientRpc;
-import com.vaadin.shared.ui.ui.ScrollClientRpc;
-import com.vaadin.shared.ui.ui.UIClientRpc;
-import com.vaadin.shared.ui.ui.UIConstants;
-import com.vaadin.shared.ui.ui.UIServerRpc;
-import com.vaadin.shared.ui.ui.UIState;
+import com.vaadin.shared.ui.ui.*;
 import com.vaadin.ui.Component.Focusable;
 import com.vaadin.ui.Dependency.Type;
 import com.vaadin.ui.Window.WindowOrderChangeListener;
@@ -88,6 +45,18 @@ import com.vaadin.ui.dnd.DropTargetExtension;
 import com.vaadin.util.ConnectorHelper;
 import com.vaadin.util.CurrentInstance;
 import com.vaadin.util.ReflectTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.Future;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * The topmost component in any component hierarchy. There is one UI for every
@@ -237,8 +206,9 @@ public abstract class UI extends AbstractSingleComponentContainer
         @Override
         public void showServerDesign(Connector connector) {
             if (!(connector instanceof Component)) {
-                getLogger().severe("Tried to output declarative design for "
-                        + connector + ", which is not a component");
+                getLogger().error(
+                        "Tried to output declarative design for {}" +
+                                " which is not a component", connector);
                 return;
             }
             if (connector instanceof UI) {
@@ -253,8 +223,7 @@ public abstract class UI extends AbstractSingleComponentContainer
                         + " requested from debug window:\n"
                         + baos.toString(UTF_8.name()));
             } catch (IOException e) {
-                getLogger().log(Level.WARNING,
-                        "Error producing design for " + connector, e);
+                getLogger().warn("Error producing design for {}", connector, e);
             }
 
         }
@@ -510,8 +479,7 @@ public abstract class UI extends AbstractSingleComponentContainer
                 try {
                     detach();
                 } catch (Exception e) {
-                    getLogger().log(Level.WARNING,
-                            "Error while detaching UI from session", e);
+                    getLogger().warn("Error while detaching UI from session", e);
                 }
                 // Disable push when the UI is detached. Otherwise the
                 // push connection and possibly VaadinSession will live
@@ -1593,7 +1561,7 @@ public abstract class UI extends AbstractSingleComponentContainer
                         errorHandler.error(errorEvent);
                     }
                 } catch (Exception e) {
-                    getLogger().log(Level.SEVERE, e.getMessage(), e);
+                    getLogger().error(e.getMessage(), e);
                 }
             }
         });
@@ -1820,7 +1788,7 @@ public abstract class UI extends AbstractSingleComponentContainer
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(UI.class.getName());
+        return LoggerFactory.getLogger(UI.class);
     }
 
     /**

--- a/server/src/main/java/com/vaadin/ui/components/colorpicker/ColorPickerPopup.java
+++ b/server/src/main/java/com/vaadin/ui/components/colorpicker/ColorPickerPopup.java
@@ -15,32 +15,18 @@
  */
 package com.vaadin.ui.components.colorpicker;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.vaadin.data.HasValue;
 import com.vaadin.shared.Registration;
 import com.vaadin.shared.ui.MarginInfo;
 import com.vaadin.shared.ui.colorpicker.Color;
 import com.vaadin.ui.AbstractColorPicker.Coordinates2Color;
-import com.vaadin.ui.Alignment;
-import com.vaadin.ui.Button;
+import com.vaadin.ui.*;
 import com.vaadin.ui.Button.ClickEvent;
-import com.vaadin.ui.Component;
-import com.vaadin.ui.HasComponents;
-import com.vaadin.ui.HorizontalLayout;
-import com.vaadin.ui.Layout;
-import com.vaadin.ui.Slider;
 import com.vaadin.ui.Slider.ValueOutOfBoundsException;
-import com.vaadin.ui.TabSheet;
-import com.vaadin.ui.VerticalLayout;
-import com.vaadin.ui.Window;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 /**
  * A component that represents color selection popup within a color picker.
@@ -540,7 +526,7 @@ public class ColorPickerPopup extends Window implements HasValue<Color> {
             blueSlider.setValue(((Integer) color.getBlue()).doubleValue());
             greenSlider.setValue(((Integer) color.getGreen()).doubleValue());
         } catch (ValueOutOfBoundsException e) {
-            getLogger().log(Level.WARNING,
+            getLogger().warn(
                     "Unable to set RGB color value to " + color.getRed() + ","
                             + color.getGreen() + "," + color.getBlue(),
                     e);
@@ -553,8 +539,8 @@ public class ColorPickerPopup extends Window implements HasValue<Color> {
             saturationSlider.setValue(((Float) (hsv[1] * 100f)).doubleValue());
             valueSlider.setValue(((Float) (hsv[2] * 100f)).doubleValue());
         } catch (ValueOutOfBoundsException e) {
-            getLogger().log(Level.WARNING, "Unable to set HSV color value to "
-                    + hsv[0] + "," + hsv[1] + "," + hsv[2], e);
+            getLogger().warn("Unable to set HSV color value to {},{},{}",
+                    hsv[0], hsv[1], hsv[2], e);
         }
     }
 
@@ -733,7 +719,7 @@ public class ColorPickerPopup extends Window implements HasValue<Color> {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(ColorPickerPopup.class.getName());
+        return LoggerFactory.getLogger(ColorPickerPopup.class);
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/declarative/Design.java
+++ b/server/src/main/java/com/vaadin/ui/declarative/Design.java
@@ -15,28 +15,6 @@
  */
 package com.vaadin.ui.declarative;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.beans.IntrospectionException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Serializable;
-import java.lang.annotation.Annotation;
-import java.util.Collection;
-import java.util.Locale;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Document.OutputSettings.Syntax;
-import org.jsoup.nodes.DocumentType;
-import org.jsoup.nodes.Element;
-import org.jsoup.nodes.Node;
-import org.jsoup.parser.Parser;
-import org.jsoup.select.Elements;
-
 import com.vaadin.annotations.DesignRoot;
 import com.vaadin.server.VaadinServiceClassLoaderUtil;
 import com.vaadin.shared.util.SharedUtil;
@@ -47,6 +25,27 @@ import com.vaadin.ui.CustomComponent;
 import com.vaadin.ui.declarative.DesignContext.ComponentCreatedEvent;
 import com.vaadin.ui.declarative.DesignContext.ComponentCreationListener;
 import com.vaadin.util.ReflectTools;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Document.OutputSettings.Syntax;
+import org.jsoup.nodes.DocumentType;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.parser.Parser;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.beans.IntrospectionException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Locale;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Design is used for reading a component hierarchy from an html string or input
@@ -618,13 +617,13 @@ public class Design implements Serializable {
             try {
                 stream.close();
             } catch (IOException e) {
-                getLogger().log(Level.FINE, "Error closing design stream", e);
+                getLogger().debug("Error closing design stream", e);
             }
         }
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(Design.class.getName());
+        return LoggerFactory.getLogger(Design.class);
     }
 
     /**
@@ -698,7 +697,7 @@ public class Design implements Serializable {
             try {
                 stream.close();
             } catch (IOException e) {
-                getLogger().log(Level.FINE, "Error closing design stream", e);
+                getLogger().debug("Error closing design stream", e);
             }
         }
     }

--- a/server/src/main/java/com/vaadin/ui/declarative/DesignAttributeHandler.java
+++ b/server/src/main/java/com/vaadin/ui/declarative/DesignAttributeHandler.java
@@ -15,6 +15,19 @@
  */
 package com.vaadin.ui.declarative;
 
+import com.googlecode.gentyref.GenericTypeReflector;
+import com.vaadin.data.Converter;
+import com.vaadin.data.ValueContext;
+import com.vaadin.shared.ui.AlignmentInfo;
+import com.vaadin.shared.util.SharedUtil;
+import com.vaadin.ui.Alignment;
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
@@ -22,28 +35,10 @@ import java.beans.PropertyDescriptor;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.jsoup.nodes.Attribute;
-import org.jsoup.nodes.Attributes;
-import org.jsoup.nodes.Element;
-import org.jsoup.nodes.Node;
-
-import com.googlecode.gentyref.GenericTypeReflector;
-import com.vaadin.data.Converter;
-import com.vaadin.data.ValueContext;
-import com.vaadin.shared.ui.AlignmentInfo;
-import com.vaadin.shared.util.SharedUtil;
-import com.vaadin.ui.Alignment;
 
 /**
  * Default attribute handler implementation used when parsing designs to
@@ -56,7 +51,7 @@ import com.vaadin.ui.Alignment;
 public class DesignAttributeHandler implements Serializable {
 
     private static Logger getLogger() {
-        return Logger.getLogger(DesignAttributeHandler.class.getName());
+        return LoggerFactory.getLogger(DesignAttributeHandler.class);
     }
 
     private static final Map<Class<?>, AttributeCacheEntry> CACHE = new ConcurrentHashMap<>();
@@ -125,7 +120,7 @@ public class DesignAttributeHandler implements Serializable {
                 success = true;
             }
         } catch (Exception e) {
-            getLogger().log(Level.WARNING, "Failed to set value \"" + value
+            getLogger().warn("Failed to set value \"" + value
                     + "\" to attribute " + attribute, e);
         }
         if (!success) {
@@ -206,7 +201,7 @@ public class DesignAttributeHandler implements Serializable {
             Attributes attr, Object defaultInstance, DesignContext context) {
         Method getter = findGetterForAttribute(component.getClass(), attribute);
         if (getter == null) {
-            getLogger().warning(
+            getLogger().warn(
                     "Could not find getter for attribute " + attribute);
         } else {
             try {
@@ -218,7 +213,7 @@ public class DesignAttributeHandler implements Serializable {
                                 component.getClass()),
                         context);
             } catch (Exception e) {
-                getLogger().log(Level.SEVERE,
+                getLogger().error(
                         "Failed to invoke getter for attribute " + attribute,
                         e);
             }

--- a/server/src/main/java/com/vaadin/ui/declarative/FieldBinder.java
+++ b/server/src/main/java/com/vaadin/ui/declarative/FieldBinder.java
@@ -15,19 +15,14 @@
  */
 package com.vaadin.ui.declarative;
 
+import com.vaadin.ui.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.beans.IntrospectionException;
 import java.io.Serializable;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.logging.Logger;
-
-import com.vaadin.ui.Component;
+import java.util.*;
 
 /**
  * Binder utility that binds member fields of a design class instance to given
@@ -92,7 +87,7 @@ public class FieldBinder implements Serializable {
             }
         }
         if (!unboundFields.isEmpty()) {
-            getLogger().severe(
+            getLogger().error(
                     "Found unbound fields in component root :" + unboundFields);
         }
         return unboundFields;
@@ -151,8 +146,8 @@ public class FieldBinder implements Serializable {
         if (!success) {
             String idInfo = "localId: " + localId + " id: " + instance.getId()
                     + " caption: " + instance.getCaption();
-            getLogger().finest("Could not bind component to a field "
-                    + instance.getClass().getName() + " " + idInfo);
+            getLogger().trace("Could not bind component to a field {} {}",
+                    instance.getClass().getName(), idInfo);
         }
         return success;
     }
@@ -182,15 +177,16 @@ public class FieldBinder implements Serializable {
             // validate that the field can be found
             Field field = fieldMap.get(fieldName.toLowerCase(Locale.ROOT));
             if (field == null) {
-                getLogger()
-                        .fine("No field was found by identifier " + identifier);
+                getLogger().debug("No field was found by identifier {}",
+                        identifier);
                 return false;
             }
             // validate that the field is not set
             Object fieldValue = getFieldValue(bindTarget, field);
             if (fieldValue != null) {
-                getLogger().fine("The field \"" + fieldName
-                        + "\" was already mapped. Ignoring.");
+                getLogger().debug(
+                        "The field \"{}\" was already mapped. Ignoring.",
+                        fieldName);
             } else {
                 // set the field value
                 field.set(bindTarget, instance);
@@ -255,7 +251,7 @@ public class FieldBinder implements Serializable {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(FieldBinder.class.getName());
+        return LoggerFactory.getLogger(FieldBinder.class);
     }
 
 }

--- a/server/src/main/java/com/vaadin/util/CurrentInstance.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstance.java
@@ -16,6 +16,14 @@
 
 package com.vaadin.util;
 
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.server.VaadinResponse;
+import com.vaadin.server.VaadinService;
+import com.vaadin.server.VaadinSession;
+import com.vaadin.ui.UI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
 import java.util.Collections;
@@ -23,14 +31,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinResponse;
-import com.vaadin.server.VaadinService;
-import com.vaadin.server.VaadinSession;
-import com.vaadin.ui.UI;
 
 /**
  * Keeps track of various current instances for the current thread. All the
@@ -116,8 +116,8 @@ public class CurrentInstance implements Serializable {
             Object instance = entry.getValue().instance.get();
             if (instance == null) {
                 iterator.remove();
-                getLogger().log(Level.FINE,
-                        "CurrentInstance for {0} has been garbage collected.",
+                getLogger().debug(
+                        "CurrentInstance for {} has been garbage collected.",
                         entry.getKey());
             }
         }
@@ -287,6 +287,6 @@ public class CurrentInstance implements Serializable {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(CurrentInstance.class.getName());
+        return LoggerFactory.getLogger(CurrentInstance.class);
     }
 }

--- a/uitest/src/main/java/com/vaadin/launcher/ApplicationRunnerServlet.java
+++ b/uitest/src/main/java/com/vaadin/launcher/ApplicationRunnerServlet.java
@@ -15,6 +15,20 @@
  */
 package com.vaadin.launcher;
 
+import com.vaadin.launcher.CustomDeploymentConfiguration.Conf;
+import com.vaadin.server.*;
+import com.vaadin.shared.ApplicationConstants;
+import com.vaadin.tests.components.TestBase;
+import com.vaadin.ui.UI;
+import com.vaadin.util.CurrentInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -25,43 +39,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-
-import com.vaadin.launcher.CustomDeploymentConfiguration.Conf;
-import com.vaadin.server.DefaultDeploymentConfiguration;
-import com.vaadin.server.DeploymentConfiguration;
-import com.vaadin.server.LegacyApplication;
-import com.vaadin.server.LegacyVaadinServlet;
-import com.vaadin.server.ServiceException;
-import com.vaadin.server.SystemMessages;
-import com.vaadin.server.SystemMessagesInfo;
-import com.vaadin.server.SystemMessagesProvider;
-import com.vaadin.server.UIClassSelectionEvent;
-import com.vaadin.server.UICreateEvent;
-import com.vaadin.server.UIProvider;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinService;
-import com.vaadin.server.VaadinServlet;
-import com.vaadin.server.VaadinServletRequest;
-import com.vaadin.server.VaadinServletService;
-import com.vaadin.server.VaadinSession;
-import com.vaadin.shared.ApplicationConstants;
-import com.vaadin.tests.components.TestBase;
-import com.vaadin.ui.UI;
-import com.vaadin.util.CurrentInstance;
+import java.util.*;
 
 @SuppressWarnings("serial")
 public class ApplicationRunnerServlet extends LegacyVaadinServlet {
@@ -119,7 +97,7 @@ public class ApplicationRunnerServlet extends LegacyVaadinServlet {
             try {
                 path = new URI(path).getPath();
             } catch (URISyntaxException e) {
-                getLogger().log(Level.FINE, "Failed to decode url", e);
+                getLogger().debug("Failed to decode url", e);
             }
             File comVaadinTests = new File(path).getParentFile()
                     .getParentFile();
@@ -410,7 +388,7 @@ public class ApplicationRunnerServlet extends LegacyVaadinServlet {
                     // Ignore as this is expected for many packages
                 } catch (Exception e2) {
                     // TODO: handle exception
-                    getLogger().log(Level.FINE,
+                    getLogger().debug(
                             "Failed to find application class " + pkg + "."
                                     + baseName,
                             e2);
@@ -426,7 +404,7 @@ public class ApplicationRunnerServlet extends LegacyVaadinServlet {
     }
 
     private Logger getLogger() {
-        return Logger.getLogger(ApplicationRunnerServlet.class.getName());
+        return LoggerFactory.getLogger(ApplicationRunnerServlet.class);
     }
 
     @Override

--- a/uitest/src/main/java/com/vaadin/tests/components/DeclarativeTestUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/DeclarativeTestUI.java
@@ -15,6 +15,12 @@
  */
 package com.vaadin.tests.components;
 
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.declarative.Design;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.lang.annotation.ElementType;
@@ -23,12 +29,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.ui.Component;
-import com.vaadin.ui.declarative.Design;
 
 /**
  * Declarative test UI. Provides simple instantiation of HTML designs located
@@ -92,7 +92,7 @@ public class DeclarativeTestUI extends AbstractTestUI {
 
     private Component readDesign() throws Exception {
         String path = getDesignPath();
-        getLogger().log(Level.INFO, "Reading design from " + path);
+        getLogger().info("Reading design from {}", path);
 
         File file = new File(path);
         return Design.read(new FileInputStream(file));
@@ -108,7 +108,7 @@ public class DeclarativeTestUI extends AbstractTestUI {
             try {
                 component = readDesign();
             } catch (Exception e1) {
-                getLogger().log(Level.SEVERE, "Error reading design", e1);
+                getLogger().error("Error reading design", e1);
                 return;
             }
 
@@ -120,17 +120,9 @@ public class DeclarativeTestUI extends AbstractTestUI {
                 if (m.isAnnotationPresent(OnLoad.class)) {
                     try {
                         m.invoke(this, (Object[]) null);
-                    } catch (IllegalAccessException e) {
-                        getLogger().log(Level.SEVERE,
-                                "Error invoking @OnLoad method", e);
-                        return;
-                    } catch (IllegalArgumentException e) {
-                        getLogger().log(Level.SEVERE,
-                                "Error invoking @OnLoad method", e);
-                        return;
-                    } catch (InvocationTargetException e) {
-                        getLogger().log(Level.SEVERE,
-                                "Error invoking @OnLoad method", e);
+                    } catch (IllegalAccessException | InvocationTargetException
+                            | IllegalArgumentException e) {
+                        getLogger().error("Error invoking @OnLoad method", e);
                         return;
                     }
                 }
@@ -155,8 +147,7 @@ public class DeclarativeTestUI extends AbstractTestUI {
         try {
             return (T) component;
         } catch (ClassCastException ex) {
-            getLogger().log(Level.SEVERE, "Component code/design type mismatch",
-                    ex);
+            getLogger().error("Component code/design type mismatch", ex);
         }
         return null;
     }
@@ -168,7 +159,7 @@ public class DeclarativeTestUI extends AbstractTestUI {
      */
     protected Logger getLogger() {
         if (logger == null) {
-            logger = Logger.getLogger(getClass().getName());
+            logger = LoggerFactory.getLogger(getClass());
         }
         return logger;
     }

--- a/uitest/src/main/java/com/vaadin/tests/components/table/ExpandingContainer.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/ExpandingContainer.java
@@ -1,11 +1,5 @@
 package com.vaadin.tests.components.table;
 
-import java.util.AbstractList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.logging.Logger;
-
 import com.vaadin.server.VaadinSession;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Label;
@@ -14,6 +8,13 @@ import com.vaadin.v7.data.Item;
 import com.vaadin.v7.data.Property;
 import com.vaadin.v7.data.util.AbstractContainer;
 import com.vaadin.v7.data.util.BeanItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 @SuppressWarnings("serial")
 public class ExpandingContainer extends AbstractContainer implements
@@ -23,7 +24,7 @@ public class ExpandingContainer extends AbstractContainer implements
             "column1", "column2");
 
     private final Label sizeLabel;
-    private final Logger log = Logger.getLogger(this.getClass().getName());
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     private int currentSize = 300;
 

--- a/uitest/src/main/java/com/vaadin/tests/integration/JSR286Portlet.java
+++ b/uitest/src/main/java/com/vaadin/tests/integration/JSR286Portlet.java
@@ -1,42 +1,19 @@
 package com.vaadin.tests.integration;
 
+import com.vaadin.annotations.StyleSheet;
+import com.vaadin.server.*;
+import com.vaadin.server.VaadinPortletSession.PortletListener;
+import com.vaadin.shared.ui.ContentMode;
+import com.vaadin.ui.*;
+import com.vaadin.ui.Notification.Type;
+import com.vaadin.ui.Upload.Receiver;
+import com.vaadin.v7.ui.TextField;
+import org.slf4j.LoggerFactory;
+
+import javax.portlet.*;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.portlet.ActionRequest;
-import javax.portlet.ActionResponse;
-import javax.portlet.EventRequest;
-import javax.portlet.EventResponse;
-import javax.portlet.PortletMode;
-import javax.portlet.PortletRequest;
-import javax.portlet.PortletURL;
-import javax.portlet.RenderRequest;
-import javax.portlet.RenderResponse;
-import javax.portlet.ResourceRequest;
-import javax.portlet.ResourceResponse;
-import javax.portlet.WindowState;
-
-import com.vaadin.annotations.StyleSheet;
-import com.vaadin.server.ExternalResource;
-import com.vaadin.server.VaadinPortletRequest;
-import com.vaadin.server.VaadinPortletService;
-import com.vaadin.server.VaadinPortletSession;
-import com.vaadin.server.VaadinPortletSession.PortletListener;
-import com.vaadin.shared.ui.ContentMode;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.ui.Embedded;
-import com.vaadin.ui.Label;
-import com.vaadin.ui.Link;
-import com.vaadin.ui.Notification;
-import com.vaadin.ui.Notification.Type;
-import com.vaadin.ui.UI;
-import com.vaadin.ui.Upload;
-import com.vaadin.ui.Upload.Receiver;
-import com.vaadin.ui.VerticalLayout;
-import com.vaadin.v7.ui.TextField;
 
 /**
  * Adapted from old PortletDemo to support integration testing.
@@ -172,7 +149,8 @@ public class JSR286Portlet extends UI {
             portletEdit.setResource(new ExternalResource(url.toString()));
         } catch (Exception e) {
             portletEdit.setEnabled(false);
-            Logger.getLogger(getClass().getName()).log(Level.SEVERE,
+
+            LoggerFactory.getLogger(getClass()).error(
                     "Error creating edit mode link", e);
         }
 
@@ -190,7 +168,8 @@ public class JSR286Portlet extends UI {
             portletMax.setResource(new ExternalResource(url.toString()));
         } catch (Exception e) {
             portletMax.setEnabled(false);
-            Logger.getLogger(getClass().getName()).log(Level.SEVERE,
+
+            LoggerFactory.getLogger(getClass()).error(
                     "Error creating state change link", e);
         }
 

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/dd/SpacebarPannerConnector.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/dd/SpacebarPannerConnector.java
@@ -1,8 +1,5 @@
 package com.vaadin.tests.widgetset.client.dd;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
@@ -16,12 +13,13 @@ import com.vaadin.client.ui.VUI;
 import com.vaadin.client.ui.dd.VDragAndDropManager;
 import com.vaadin.client.ui.ui.UIConnector;
 import com.vaadin.shared.ui.Connect;
+import org.slf4j.LoggerFactory;
 
 @Connect(com.vaadin.tests.dd.SpacebarPanner.class)
 public class SpacebarPannerConnector extends AbstractExtensionConnector {
 
-    Logger logger = Logger
-            .getLogger(SpacebarPannerConnector.class.getSimpleName());
+    org.slf4j.Logger logger = LoggerFactory
+            .getLogger(SpacebarPannerConnector.class);
 
     private boolean trigger = false;
     private VUI vui;
@@ -76,7 +74,7 @@ public class SpacebarPannerConnector extends AbstractExtensionConnector {
                     }
                     break;
                 case Event.ONMOUSEDOWN:
-                    logger.log(Level.INFO, "Drag started");
+                    logger.info("Drag started");
                     lastMouseX = ne.getClientX();
                     lastMouseY = ne.getClientY();
 
@@ -91,12 +89,12 @@ public class SpacebarPannerConnector extends AbstractExtensionConnector {
 
                 case Event.ONMOUSEMOVE:
                     if (mouseDown && shouldPan) {
-                        logger.log(Level.INFO, "In mousemove: mouseDown:"
+                        logger.info("In mousemove: mouseDown:"
                                 + mouseDown + ", shouldPan: " + shouldPan);
                         trigger = false;
                         vui.removeStyleName("triggered");
 
-                        logger.log(Level.INFO, "Panning!");
+                        logger.info("Panning!");
                         int currentClientX = ne.getClientX();
                         int currentClientY = ne.getClientY();
 

--- a/uitest/src/main/java/com/vaadin/tests/widgetset/client/v7/grid/GridBasicClientFeaturesWidget.java
+++ b/uitest/src/main/java/com/vaadin/tests/widgetset/client/v7/grid/GridBasicClientFeaturesWidget.java
@@ -15,15 +15,6 @@
  */
 package com.vaadin.tests.widgetset.client.v7.grid;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.logging.Logger;
-
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Style.Unit;
@@ -34,32 +25,13 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HTML;
-import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.MenuItem;
-import com.google.gwt.user.client.ui.MenuItemSeparator;
-import com.google.gwt.user.client.ui.TextBox;
-import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.user.client.ui.*;
 import com.vaadin.client.data.DataSource;
 import com.vaadin.client.data.DataSource.RowHandle;
 import com.vaadin.client.ui.VLabel;
 import com.vaadin.tests.widgetset.client.v7.grid.GridBasicClientFeaturesWidget.Data;
-import com.vaadin.v7.client.renderers.DateRenderer;
-import com.vaadin.v7.client.renderers.HtmlRenderer;
-import com.vaadin.v7.client.renderers.NumberRenderer;
-import com.vaadin.v7.client.renderers.Renderer;
-import com.vaadin.v7.client.renderers.TextRenderer;
-import com.vaadin.v7.client.widget.grid.CellReference;
-import com.vaadin.v7.client.widget.grid.CellStyleGenerator;
-import com.vaadin.v7.client.widget.grid.DetailsGenerator;
-import com.vaadin.v7.client.widget.grid.EditorHandler;
-import com.vaadin.v7.client.widget.grid.EventCellReference;
-import com.vaadin.v7.client.widget.grid.RendererCellReference;
-import com.vaadin.v7.client.widget.grid.RowReference;
-import com.vaadin.v7.client.widget.grid.RowStyleGenerator;
+import com.vaadin.v7.client.renderers.*;
+import com.vaadin.v7.client.widget.grid.*;
 import com.vaadin.v7.client.widget.grid.datasources.ListDataSource;
 import com.vaadin.v7.client.widget.grid.datasources.ListSorter;
 import com.vaadin.v7.client.widget.grid.events.BodyKeyDownHandler;
@@ -78,6 +50,7 @@ import com.vaadin.v7.client.widget.grid.events.GridKeyUpEvent;
 import com.vaadin.v7.client.widget.grid.events.HeaderKeyDownHandler;
 import com.vaadin.v7.client.widget.grid.events.HeaderKeyPressHandler;
 import com.vaadin.v7.client.widget.grid.events.HeaderKeyUpHandler;
+import com.vaadin.v7.client.widget.grid.events.*;
 import com.vaadin.v7.client.widget.grid.selection.SelectionModel;
 import com.vaadin.v7.client.widget.grid.selection.SelectionModel.None;
 import com.vaadin.v7.client.widgets.Grid;
@@ -86,6 +59,9 @@ import com.vaadin.v7.client.widgets.Grid.FooterRow;
 import com.vaadin.v7.client.widgets.Grid.HeaderRow;
 import com.vaadin.v7.client.widgets.Grid.SelectionMode;
 import com.vaadin.v7.shared.ui.grid.ScrollDestination;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 /**
  * Grid basic client features test application.
@@ -103,7 +79,7 @@ public class GridBasicClientFeaturesWidget
     public static final String CELL_STYLE_GENERATOR_SIMPLE = "Simple";
     public static final String CELL_STYLE_GENERATOR_COL_INDEX = "Column index";
 
-    public static enum Renderers {
+    public enum Renderers {
         TEXT_RENDERER, HTML_RENDERER, NUMBER_RENDERER, DATE_RENDERER;
     }
 
@@ -167,7 +143,7 @@ public class GridBasicClientFeaturesWidget
                 ds.asList().set(request.getRowIndex(), rowData);
                 request.success();
             } catch (Exception e) {
-                Logger.getLogger(getClass().getName()).warning(e.toString());
+                LoggerFactory.getLogger(getClass()).warn(e.toString());
                 request.failure(null, null);
             }
         }
@@ -1498,8 +1474,8 @@ public class GridBasicClientFeaturesWidget
 
     }
 
-    private static Logger getLogger() {
-        return Logger.getLogger(GridBasicClientFeaturesWidget.class.getName());
+    private static org.slf4j.Logger getLogger() {
+        return LoggerFactory.getLogger(GridBasicClientFeaturesWidget.class);
     }
 
     private void createSidebarMenu() {


### PR DESCRIPTION
Introduced new dependencies for server:

org.slf4j:slf4j-api
org.slf4j:slf4j-jdk14

Replaced custom 2.4.11.vaadin2 version of
org.atmosphere:atmosphere-runtime with original 2.4.11.

For client side introduced small implementation of SLF4J that uses GWT
JUL as backend: ru.finam:slf4j-gwt.

All usages of java.util.logging.Logger were replaced with SLF4J API.
There are a couple of places where it is still used, such as client side
classes. Since GWT uses JUL as backend everything should work as before.

Now, applications can easily exclude slf4j-jdk14. They can use any
available SLF4J binding, such as slf4j-simple or logback-classic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10267)
<!-- Reviewable:end -->
