### PR TITLE
Fix link format

### DIFF
--- a/documentation/articles/VaadinCDI.asciidoc
+++ b/documentation/articles/VaadinCDI.asciidoc
@@ -65,4 +65,4 @@ run.
 Related pages
 ~~~~~~~~~~~~~
 
-link:IIInjectionAndScopes.asciidoc[II - Injection and scopes]
+<<IIInjectionAndScopes#ii-injection-and-scopes,"II - Injection and scopes">>


### PR DESCRIPTION
Without this the article link will point to a nonexisting .asciidoc file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10269)
<!-- Reviewable:end -->
