### PR TITLE
Set no-store headers on UIDL messages

### DIFF
--- a/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
@@ -107,9 +107,15 @@ public abstract class UIInitHandler extends SynchronizedRequestHandler {
         // The response was produced without errors so write it to the client
         response.setContentType(JsonConstants.JSON_CONTENT_TYPE);
 
-        // Ensure that the browser does not cache UIDL responses.
-        // iOS 6 Safari requires this (#9732)
-        response.setHeader("Cache-Control", "no-cache");
+        // Response might contain sensitive information, so prevent caching
+        // no-store to disallow storing even if cache would be revalidated
+        // must-revalidate to not use stored value even if someone asks for it
+        response.setHeader("Cache-Control",
+                "no-cache, no-store, must-revalidate");
+
+        // Also set legacy values in case of old proxies in between
+        response.setHeader("Pragma", "no-cache");
+        response.setHeader("Expires", "0");
 
         byte[] b = json.getBytes("UTF-8");
         response.setContentLength(b.length);


### PR DESCRIPTION
UIDL might contain sensitive information that we should prevent from
being stored anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10308)
<!-- Reviewable:end -->
