### PR TITLE
WIP: Treat fields as readonly when bound with null setter (#10252)

### DIFF
--- a/server/src/test/java/com/vaadin/data/BeanBinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BeanBinderTest.java
@@ -311,6 +311,28 @@ public class BeanBinderTest
     }
 
     @Test
+    public void bindReadOnlyPropertyShouldMarkFieldAsReadonly() {
+        binder.bind(nameField, "readOnlyProperty");
+
+        assertTrue("Name field should be readonly", nameField.isReadOnly());
+    }
+
+    @Test
+    public void setReadonlyShouldIgnoreBindingsForReadOnlyProperties() {
+        binder.bind(nameField, "readOnlyProperty");
+
+        binder.setReadOnly(true);
+        assertTrue("Name field should be readonly", nameField.isReadOnly());
+
+        binder.setReadOnly(false);
+        assertTrue("Name field should be readonly", nameField.isReadOnly());
+
+        nameField.setReadOnly(false);
+        binder.setReadOnly(true);
+        assertFalse("Name field should not be readonly", nameField.isReadOnly());
+    }
+
+    @Test
     public void beanBound_setInvalidFieldValue_validationError() {
         binder.setBean(item);
         binder.bind(nameField, "firstname");

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -1019,4 +1019,36 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 Person::getFirstName, Person::setFirstName);
         binder.removeBinding(binding);
     }
+
+    @Test
+    public void bindWithNullSetterShouldMarkFieldAsReadonly() {
+        binder.bind(nameField, Person::getFirstName, null);
+        binder.forField(ageField)
+            .withConverter(new StringToIntegerConverter(""))
+            .bind(Person::getAge, Person::setAge);
+
+        assertTrue("Name field should be readonly", nameField.isReadOnly());
+        assertFalse("Name field should be readonly", ageField.isReadOnly());
+    }
+
+    @Test
+    public void setReadonlyShouldIgnoreBindingsWithNullSetter() {
+        binder.bind(nameField, Person::getFirstName, null);
+        binder.forField(ageField)
+            .withConverter(new StringToIntegerConverter(""))
+            .bind(Person::getAge, Person::setAge);
+
+        binder.setReadOnly(true);
+        assertTrue("Name field should be readonly", nameField.isReadOnly());
+        assertTrue("Age field should be readonly", ageField.isReadOnly());
+
+        binder.setReadOnly(false);
+        assertTrue("Name field should be readonly", nameField.isReadOnly());
+        assertFalse("Age field should not be readonly", ageField.isReadOnly());
+
+        nameField.setReadOnly(false);
+        binder.setReadOnly(true);
+        assertFalse("Name field should not be readonly", nameField.isReadOnly());
+        assertTrue("Age field should be readonly", ageField.isReadOnly());
+    }
 }


### PR DESCRIPTION
Fields bound with a null setter or to a property
with no accessible setter will be marked as readonly
and would be ignore by Binder.setReadonly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10351)
<!-- Reviewable:end -->
