### PR TITLE
Make Binder.setReadonly ignore effectively readonly bindings

### DIFF
--- a/server/src/test/java/com/vaadin/data/BeanBinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BeanBinderTest.java
@@ -311,6 +311,24 @@ public class BeanBinderTest
     }
 
     @Test
+    public void setReadonlyShouldIgnoreBindingsForReadOnlyProperties() {
+        binder.bind(nameField, "readOnlyProperty");
+
+        binder.setReadOnly(true);
+        assertFalse("Name field should be ignored and not be readonly", nameField.isReadOnly());
+
+        binder.setReadOnly(false);
+        assertFalse("Name field should be ignored and not be readonly", nameField.isReadOnly());
+
+        nameField.setReadOnly(true);
+        binder.setReadOnly(true);
+        assertTrue("Name field should be ignored and be readonly", nameField.isReadOnly());
+
+        binder.setReadOnly(false);
+        assertTrue("Name field should be ignored and be readonly", nameField.isReadOnly());
+    }
+
+    @Test
     public void beanBound_setInvalidFieldValue_validationError() {
         binder.setBean(item);
         binder.bind(nameField, "firstname");

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -609,6 +609,31 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
+    public void setReadonlyShouldIgnoreBindingsWithNullSetter() {
+        binder.bind(nameField, Person::getFirstName, null);
+        binder.forField(ageField)
+            .withConverter(new StringToIntegerConverter(""))
+            .bind(Person::getAge, Person::setAge);
+
+        binder.setReadOnly(true);
+        assertFalse("Name field should be ignored and not be readonly", nameField.isReadOnly());
+        assertTrue("Age field should be readonly", ageField.isReadOnly());
+
+        binder.setReadOnly(false);
+        assertFalse("Name field should be ignored and remain not readonly", nameField.isReadOnly());
+        assertFalse("Age field should not be readonly", ageField.isReadOnly());
+
+        nameField.setReadOnly(false);
+        binder.setReadOnly(false);
+        assertFalse("Name field should be ignored and remain not readonly", nameField.isReadOnly());
+        assertFalse("Age field should not be readonly", ageField.isReadOnly());
+
+        binder.setReadOnly(true);
+        assertFalse("Name field should be ignored and remain not readonly", nameField.isReadOnly());
+        assertTrue("Age field should be readonly", ageField.isReadOnly());
+    }
+
+    @Test
     public void isValidTest_bound_binder() {
         binder.forField(nameField)
                 .withValidator(Validator.from(


### PR DESCRIPTION
Binder.setReadonly will ignore bindings with null setter
or property without an accessile setter when changing
field read only flag.

References #10252

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10368)
<!-- Reviewable:end -->
