### PR TITLE
Making the select(T item) method more functional and exposing the HierarchyMapper for easier use of the scrollTo(int row, ScrollDestination) method in the Tree class.

### DIFF
--- a/server/src/main/java/com/vaadin/data/provider/HierarchicalDataCommunicator.java
+++ b/server/src/main/java/com/vaadin/data/provider/HierarchicalDataCommunicator.java
@@ -327,7 +327,7 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
      *
      * @return the hierarchy mapper used by this data communicator
      */
-    protected HierarchyMapper<T, ?> getHierarchyMapper() {
+    public HierarchyMapper<T, ?> getHierarchyMapper() {
         return mapper;
     }
 }

--- a/server/src/main/java/com/vaadin/ui/Tree.java
+++ b/server/src/main/java/com/vaadin/ui/Tree.java
@@ -86,6 +86,17 @@ public class Tree<T> extends Composite
     private static final Method ITEM_CLICK_METHOD = ReflectTools
             .findMethod(ItemClickListener.class, "itemClick", ItemClick.class);
     private Registration contextClickRegistration = null;
+    
+     /**
+     * Setting the default scroll behavior
+     *
+     * @see ScrollType
+     * @see ScrollDestination
+     * @since 8.2
+     */
+
+    private ScrollType scrollType = ScrollType.SCROLL;
+    private ScrollDestination scrollDestination = ScrollDestination.ANY;
 
     /**
      * A listener for item click events.
@@ -355,6 +366,10 @@ public class Tree<T> extends Composite
     public HierarchicalDataProvider<T, ?> getDataProvider() {
         return treeGrid.getDataProvider();
     }
+    
+    public HierarchicalDataCommunicator<T> getDataCommunicator() {
+        return treeGrid.getDataCommunicator();
+    }
 
     @Override
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
@@ -490,7 +505,8 @@ public class Tree<T> extends Composite
 
     /**
      * This method is a shorthand that delegates to the currently set selection
-     * model.
+     * model. Depending on user defined scroll type and destination the currently
+     * selected model will also be focused.
      *
      * @param item
      *            item to select
@@ -500,6 +516,10 @@ public class Tree<T> extends Composite
      */
     public void select(T item) {
         treeGrid.select(item);
+        
+        if(scrollType.equals(ScrollType.SCROLL)) {
+        	scrollTo(getDataCommunicator().getHierarchyMapper().getIndexOf(item).get(), getScrollDestination());
+        } 
     }
 
     /**
@@ -838,6 +858,22 @@ public class Tree<T> extends Composite
     @Override
     public void setComponentError(ErrorMessage componentError) {
         treeGrid.setComponentError(componentError);
+    }
+
+    public ScrollType getScrollType() {
+    	return this.scrollType;
+    }
+    
+    public void setScrollType(ScrollType scrollType) {
+    	this.scrollType = scrollType;
+    }
+    
+    public ScrollDestination getScrollDestination() {
+    	return this.scrollDestination;
+    }
+    
+    public void setScrollDestination(ScrollDestination scrollDestination) {
+    	this.scrollDestination = scrollDestination;
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/shared/ui/grid/ScrollType.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/grid/ScrollType.java
@@ -1,0 +1,15 @@
+package com.vaadin.shared.ui.grid;
+
+public enum ScrollType {
+	
+    /**
+	*Automatically scrolls to the currently selected object in the grid.
+     */
+	SCROLL,
+	
+	/**
+	 *Disables automatic scrolling to the secleced object in the grid.
+	*/
+	NOSCROLL
+
+}

--- a/shared/src/main/java/com/vaadin/shared/ui/grid/ScrollType.java
+++ b/shared/src/main/java/com/vaadin/shared/ui/grid/ScrollType.java
@@ -8,7 +8,7 @@ public enum ScrollType {
 	SCROLL,
 	
 	/**
-	 *Disables automatic scrolling to the secleced object in the grid.
+	 *Disables automatic scrolling to the selected object in the grid.
 	*/
 	NOSCROLL
 


### PR DESCRIPTION
Fixes #10449

Currently, the select(T item) method in Tree only selects, while it seems more logical for the method to also focus on the currently selected item. This pull should add that functionally, though it also implements the ability to disable the auto-focus.

This also exposes the HierarchyMapper so the row of the currently selected item can be easily found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10451)
<!-- Reviewable:end -->
