### PR TITLE
Fix column width resize event firing when mode is SIMPLE 7.7

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -5888,9 +5888,17 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         @Override
                         public void onComplete() {
                             dragEnded();
-
                             col.setWidth(width);
-                            fireEvent(new ColumnResizeEvent<T>(col));
+
+                            // Need to wait for column width recalculation
+                            // scheduled by setWidth() before firing the event
+                            Scheduler.get().scheduleDeferred(
+                                    new ScheduledCommand() {
+                                        @Override
+                                        public void execute() {
+                                            fireEvent(new ColumnResizeEvent<T>(col));
+                                        }
+                                    });
                         }
                     };
 

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/basicfeatures/GridColumnResizeModeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/basicfeatures/GridColumnResizeModeTest.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.testbench.By;
+import com.vaadin.testbench.elements.GridElement.GridCellElement;
 import com.vaadin.testbench.parallel.TestCategory;
 import com.vaadin.tests.components.grid.basicfeatures.element.CustomGridElement;
 
@@ -74,4 +75,33 @@ public class GridColumnResizeModeTest extends GridBasicFeaturesTest {
 
     }
 
+
+    @Test
+    public void testSimpleResizeModeMultipleDrag() throws Exception {
+        CustomGridElement grid = getGridElement();
+
+        List<WebElement> handles = grid
+                .findElements(By.className("v-grid-column-resize-handle"));
+        WebElement handle = handles.get(1);
+
+        GridCellElement cell = grid.getHeaderCell(0, 1);
+
+        int initialWidth = cell.getSize().getWidth();
+
+        selectMenuPath("Component", "Columns", "Simple resize mode");
+        sleep(250);
+
+        drag(handle, 100);
+        sleep(500);
+        Assert.assertEquals(initialWidth + 100, cell.getSize().getWidth());
+
+        drag(handle, -100);
+        sleep(500);
+        Assert.assertEquals(initialWidth, cell.getSize().getWidth());
+    }
+
+    private void drag(WebElement handle, int xOffset) {
+        new Actions(getDriver()).moveToElement(handle).clickAndHold()
+                .moveByOffset(xOffset, 0).release().perform();
+    }
 }


### PR DESCRIPTION
Backporting changes in #10442
Fixes issue #10139 for 7.7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10452)
<!-- Reviewable:end -->
