### PR TITLE
Treat fields as readonly when bound with null setter

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -228,6 +228,10 @@ public class Binder<BEAN> implements Serializable {
          * binder.forField(nameField).bind(Person::getName, Person::setName);
          * </pre>
          *
+         * <p>
+         * <strong>Note:</strong> when a {@code null} setter is given the field will be
+         * marked as readonly by invoking ({@link HasValue::setReadOnly}.
+         *
          * @param getter
          *            the function to get the value of the property to the
          *            field, not null
@@ -255,6 +259,10 @@ public class Binder<BEAN> implements Serializable {
          * The property must have an accessible getter method. It need not have
          * an accessible setter; in that case the property value is never
          * updated and the binding is said to be <i>read-only</i>.
+         *
+         * <p>
+         * <strong>Note:</strong> when the binding is <i>read-only</i> the field will be
+         * marked as readonly by invoking ({@link HasValue::setReadOnly}.
          *
          * @param propertyName
          *            the name of the property to bind, not null
@@ -740,6 +748,9 @@ public class Binder<BEAN> implements Serializable {
             getBinder().bindings.add(binding);
             if (getBinder().getBean() != null) {
                 binding.initFieldValue(getBinder().getBean());
+            }
+            if (setter == null) {
+                binding.getField().setReadOnly(true);
             }
             getBinder().fireStatusChangeEvent(false);
 
@@ -1443,6 +1454,10 @@ public class Binder<BEAN> implements Serializable {
      * TextField nameField = new TextField();
      * binder.bind(nameField, Person::getName, Person::setName);
      * </pre>
+     *
+     * <p>
+     * <strong>Note:</strong> when a {@code null} setter is given the field will be
+     * marked as readonly by invoking ({@link HasValue::setReadOnly}.
      *
      * @param <FIELDVALUE>
      *            the value type of the field

--- a/server/src/test/java/com/vaadin/data/BeanBinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BeanBinderTest.java
@@ -311,21 +311,28 @@ public class BeanBinderTest
     }
 
     @Test
+    public void bindReadOnlyPropertyShouldMarkFieldAsReadonly() {
+        binder.bind(nameField, "readOnlyProperty");
+
+        assertTrue("Name field should be readonly", nameField.isReadOnly());
+    }
+
+    @Test
     public void setReadonlyShouldIgnoreBindingsForReadOnlyProperties() {
         binder.bind(nameField, "readOnlyProperty");
 
         binder.setReadOnly(true);
-        assertFalse("Name field should be ignored and not be readonly", nameField.isReadOnly());
+        assertTrue("Name field should be ignored and be readonly", nameField.isReadOnly());
 
         binder.setReadOnly(false);
-        assertFalse("Name field should be ignored and not be readonly", nameField.isReadOnly());
+        assertTrue("Name field should be ignored and be readonly", nameField.isReadOnly());
 
-        nameField.setReadOnly(true);
+        nameField.setReadOnly(false);
         binder.setReadOnly(true);
-        assertTrue("Name field should be ignored and be readonly", nameField.isReadOnly());
+        assertFalse("Name field should be ignored and not be readonly", nameField.isReadOnly());
 
         binder.setReadOnly(false);
-        assertTrue("Name field should be ignored and be readonly", nameField.isReadOnly());
+        assertFalse("Name field should be ignored and not be readonly", nameField.isReadOnly());
     }
 
     @Test

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -616,11 +616,11 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
             .bind(Person::getAge, Person::setAge);
 
         binder.setReadOnly(true);
-        assertFalse("Name field should be ignored and not be readonly", nameField.isReadOnly());
+        assertTrue("Name field should be ignored but should be readonly", nameField.isReadOnly());
         assertTrue("Age field should be readonly", ageField.isReadOnly());
 
         binder.setReadOnly(false);
-        assertFalse("Name field should be ignored and remain not readonly", nameField.isReadOnly());
+        assertTrue("Name field should be ignored and should remain readonly", nameField.isReadOnly());
         assertFalse("Age field should not be readonly", ageField.isReadOnly());
 
         nameField.setReadOnly(false);
@@ -1043,5 +1043,16 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         Binding<Person, String> binding = anotherBinder.bind(nameField,
                 Person::getFirstName, Person::setFirstName);
         binder.removeBinding(binding);
+    }
+
+    @Test
+    public void bindWithNullSetterShouldMarkFieldAsReadonly() {
+        binder.bind(nameField, Person::getFirstName, null);
+        binder.forField(ageField)
+            .withConverter(new StringToIntegerConverter(""))
+            .bind(Person::getAge, Person::setAge);
+
+        assertTrue("Name field should be readonly", nameField.isReadOnly());
+        assertFalse("Name field should be readonly", ageField.isReadOnly());
     }
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/DateTextHandling.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/DateTextHandling.java
@@ -45,7 +45,7 @@ public class DateTextHandling extends AbstractTestUI {
         layout.addComponent(errorLabel);
 
         Binder<Void> binder = new Binder<>();
-        binder.forField(dateField).withStatusLabel(errorLabel).bind(o -> dateField.getValue(), null);
+        binder.forField(dateField).withStatusLabel(errorLabel).bind(o -> dateField.getValue(), (aVoid, date) -> {});
 
         Button buttonValidate = new Button("Validate!");
         buttonValidate.addClickListener(event1 -> {


### PR DESCRIPTION
Fields bound with a null setter or to a property
with no accessible setter will be marked as readonly
Fixes #10476

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10477)
<!-- Reviewable:end -->
