### PR TITLE
Documentation: Change example to use imported class

### DIFF
--- a/documentation/clientsideapp/clientsideapp-entrypoint.asciidoc
+++ b/documentation/clientsideapp/clientsideapp-entrypoint.asciidoc
@@ -26,7 +26,7 @@ public class MyEntryPoint implements EntryPoint {
     @Override
     public void onModuleLoad() {
         // Create a button widget
-        Button button = new Button();
+        VButton button = new VButton();
         button.setText("Click me!");
         button.addClickHandler(new ClickHandler() {
             @Override


### PR DESCRIPTION
In the  example in chapter "Client side application entry point", change
the used class from Button to VButton, as VButton is imported.
Otherwise, the import should be changed to google one's.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10491)
<!-- Reviewable:end -->
