### PR TITLE
Fixes bug in constructor Button(icon, listener)

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Button.java
+++ b/server/src/main/java/com/vaadin/ui/Button.java
@@ -133,7 +133,7 @@ public class Button extends AbstractFocusable
      * @since 8.2
      */
     public Button(Resource icon, ClickListener listener) {
-        setIcon(icon);
+        this(icon);
         addClickListener(listener);
     }
 


### PR DESCRIPTION
With this bug the method registerRpc is never called and the following error is logged when the user clicks the button:

"Ignoring RPC call to com.vaadin.shared.ui.button.ButtonServerRpc.click in connector com.vaadin.ui.Button(4) as no RPC implementation is registered"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10539)
<!-- Reviewable:end -->
