### PR TITLE
Initialize VRichTextArea.client in RichTextAreaConnector

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/richtextarea/RichTextAreaConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/richtextarea/RichTextAreaConnector.java
@@ -46,6 +46,7 @@ public class RichTextAreaConnector extends AbstractFieldConnector
 
     @Override
     protected void init() {
+        getWidget().client = getConnection();
         getWidget().addBlurHandler(event -> flush());
         getWidget().addInputHandler(
                 () -> valueChangeHandler.scheduleValueChange());

--- a/uitest/src/main/java/com/vaadin/tests/components/richtextarea/RichTextAreaDelegateToShortcutHandler.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/richtextarea/RichTextAreaDelegateToShortcutHandler.java
@@ -1,0 +1,25 @@
+package com.vaadin.tests.components.richtextarea;
+
+import com.vaadin.event.ShortcutAction;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUIWithLog;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.RichTextArea;
+import com.vaadin.ui.VerticalLayout;
+
+public class RichTextAreaDelegateToShortcutHandler extends AbstractTestUIWithLog {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        final VerticalLayout layout = new VerticalLayout();
+        final RichTextArea name = new RichTextArea();
+        name.setCaption("Type your name here:");
+
+        Button button = new Button("Click Me");
+        button.setClickShortcut(ShortcutAction.KeyCode.ENTER);
+        button.addClickListener(e -> log("ShortcutHandler invoked " + name.getValue()));
+
+        layout.addComponents(name, button);
+        addComponent(layout);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/richtextarea/RichTextAreaDelegateToShortcutHandlerTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/richtextarea/RichTextAreaDelegateToShortcutHandlerTest.java
@@ -1,15 +1,23 @@
 package com.vaadin.tests.components.richtextarea;
 
+import java.util.List;
+
 import com.vaadin.testbench.elements.RichTextAreaElement;
 import com.vaadin.tests.tb3.MultiBrowserTest;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 
 public class RichTextAreaDelegateToShortcutHandlerTest extends MultiBrowserTest {
+
+    @Override
+    public List<DesiredCapabilities> getBrowsersToTest() {
+        return getBrowsersExcludingPhantomJS();
+    }
 
     @Test
     public void shouldDelegateToShortcutActionHandler() {

--- a/uitest/src/test/java/com/vaadin/tests/components/richtextarea/RichTextAreaDelegateToShortcutHandlerTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/richtextarea/RichTextAreaDelegateToShortcutHandlerTest.java
@@ -22,7 +22,7 @@ public class RichTextAreaDelegateToShortcutHandlerTest extends MultiBrowserTest 
     @Test
     public void shouldDelegateToShortcutActionHandler() {
         openTestURL();
-        
+
         WebElement textAreaEditor = $(RichTextAreaElement.class).first().getEditorIframe();
         textAreaEditor.sendKeys("Test");
         textAreaEditor.sendKeys(Keys.ENTER);

--- a/uitest/src/test/java/com/vaadin/tests/components/richtextarea/RichTextAreaDelegateToShortcutHandlerTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/richtextarea/RichTextAreaDelegateToShortcutHandlerTest.java
@@ -1,0 +1,32 @@
+package com.vaadin.tests.components.richtextarea;
+
+import com.vaadin.testbench.elements.RichTextAreaElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class RichTextAreaDelegateToShortcutHandlerTest extends MultiBrowserTest {
+
+    @Test
+    public void shouldDelegateToShortcutActionHandler() {
+        openTestURL();
+        
+        WebElement textAreaEditor = $(RichTextAreaElement.class).first().getEditorIframe();
+        textAreaEditor.sendKeys("Test");
+        textAreaEditor.sendKeys(Keys.ENTER);
+
+        assertThat("Shortcut handler has not been invoked",
+            getLogRow(0), containsString("ShortcutHandler invoked Test"));
+
+        textAreaEditor.sendKeys(Keys.chord(Keys.SHIFT, Keys.ENTER));
+        textAreaEditor.sendKeys("another row");
+        textAreaEditor.sendKeys(Keys.ENTER);
+
+        assertThat("Shortcut handler has not been invoked",
+            getLogRow(0), containsString("ShortcutHandler invoked Test\nanother row"));
+    }
+}


### PR DESCRIPTION
`VRichTextArea.client` was not initialized; this caused potentially NPEs
in `onKeyDown` method in presence of registered shortcut handlers

Fixes #10536

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10542)
<!-- Reviewable:end -->
