### PR TITLE
Fixes for Grid and TabSheet

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -4734,4 +4734,27 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
         }
     }
 
+    @Override
+    public void setEnabled(boolean enabled) {
+        if (getEditor().isOpen() && !enabled) {
+            getEditor().cancel();
+        }
+        super.setEnabled(enabled);
+    }
+
+    @Override
+    public void setVisible(boolean visible) {
+        if (getEditor().isOpen() && !visible) {
+            getEditor().cancel();
+        }
+        super.setVisible(visible);
+    }
+
+    @Override
+    public void detach() {
+        if (getEditor().isOpen()) {
+            getEditor().cancel();
+        }
+        super.detach();
+    }
 }

--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -4735,14 +4735,6 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
     }
 
     @Override
-    public void setEnabled(boolean enabled) {
-        if (getEditor().isOpen() && !enabled) {
-            getEditor().cancel();
-        }
-        super.setEnabled(enabled);
-    }
-
-    @Override
     public void setVisible(boolean visible) {
         if (getEditor().isOpen() && !visible) {
             getEditor().cancel();

--- a/server/src/main/java/com/vaadin/ui/TabSheet.java
+++ b/server/src/main/java/com/vaadin/ui/TabSheet.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.Element;
@@ -584,6 +585,10 @@ public class TabSheet extends AbstractComponentContainer
      */
     private void setSelected(Component component) {
         Tab tab = tabs.get(selected);
+        if (tab != null && !Objects.equals(tab.getComponent(), component) && tab.getComponent() != null && tab.getComponent().isAttached()) {
+            tab.getComponent().detach();
+            tab.getComponent().attach(); // ugly hack
+        }
 
         selected = component;
         // Repaint of the selected component is needed as only the selected

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/basics/GridBasics.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/basics/GridBasics.java
@@ -777,6 +777,8 @@ public class GridBasics extends AbstractTestUIWithLog {
 
         editorMenu.addItem("Save", i -> grid.getEditor().save());
         editorMenu.addItem("Cancel edit", i -> grid.getEditor().cancel());
+        editorMenu.addItem("Hide grid", i -> grid.setVisible(false));
+        editorMenu.addItem("Show grid", i -> grid.setVisible(true));
 
         Stream.of(0, 5, 100).forEach(i -> editorMenu.addItem("Edit row " + i,
                 menuItem -> grid.getEditor().editRow(i)));

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/basics/GridEditorTest.java
@@ -15,10 +15,6 @@
  */
 package com.vaadin.tests.components.grid.basics;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -31,6 +27,8 @@ import com.vaadin.testbench.By;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elements.GridElement.GridCellElement;
 import com.vaadin.testbench.elements.GridElement.GridEditorElement;
+
+import static org.junit.Assert.*;
 
 public abstract class GridEditorTest extends GridBasicsTest {
 
@@ -56,6 +54,16 @@ public abstract class GridEditorTest extends GridBasicsTest {
 
         selectMenuPath("Component", "Editor", "Cancel edit");
         assertEditorClosed();
+    }
+
+    public void testEditorReopenAfterHide() {
+        editRow(5);
+        assertEditorOpen();
+        selectMenuPath("Component", "Editor", "Hide grid");
+        selectMenuPath("Component", "Editor", "Show grid");
+        assertEditorClosed();
+        editRow(5);
+        assertEditorOpen();
     }
 
     @Test


### PR DESCRIPTION
Fixes for TabSheet not communicating to tab that it's been hidden and to Grid for not hiding editor upon visibility changes. Fixes #10146, #10543.

The fix is a bit hackish, but TBH I'm not sure one can provide a cleaner fix easily without rewriting the entire `SelectiveRenderer` mechanic and especially #10146 is quite critical in that it doesn't allow the Grid editor to be used in any rich layout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10557)
<!-- Reviewable:end -->
