### PR TITLE
Date conversion should use systemDefault zone, not UTC

### DIFF
--- a/server/src/main/java/com/vaadin/ui/AbstractLocalDateField.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractLocalDateField.java
@@ -15,9 +15,8 @@
  */
 package com.vaadin.ui;
 
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Date;
@@ -117,8 +116,7 @@ public abstract class AbstractLocalDateField
         if (date == null) {
             return null;
         }
-        return Instant.ofEpochMilli(date.getTime()).atZone(ZoneOffset.UTC)
-                .toLocalDate();
+        return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
     }
 
     @Override
@@ -126,7 +124,7 @@ public abstract class AbstractLocalDateField
         if (date == null) {
             return null;
         }
-        return Date.from(date.atStartOfDay(ZoneOffset.UTC).toInstant());
+        return Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
 
     private LocalDate getDate(LocalDate date, DateResolution forResolution) {


### PR DESCRIPTION
Using UTC ZoneOffset when doing time conversion is not correct.
See issue #9765

Note that I do not have TestBench and this issue probably needs a UI test.
Also, reproducing this issue depends on the time zone of the server running this code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10572)
<!-- Reviewable:end -->
