### PR TITLE
Set no-store headers for error responses

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinResponse.java
+++ b/server/src/main/java/com/vaadin/server/VaadinResponse.java
@@ -186,6 +186,23 @@ public interface VaadinResponse extends Serializable {
     public void setContentLength(int len);
 
     /**
+     * Sets all conceivable headers that might prevent a response from being
+     * stored in any caches.
+     *
+     * @since
+     */
+    public default void setNoCacheHeaders() {
+        // no-store to disallow storing even if cache would be revalidated
+        // must-revalidate to not use stored value even if someone asks for it
+        setHeader("Cache-Control",
+                "no-cache, no-store, must-revalidate");
+
+        // Also set legacy values in case of old proxies in between
+        setHeader("Pragma", "no-cache");
+        setHeader("Expires", "0");
+    }
+
+    /**
      * Gets the currently processed Vaadin response. The current response is
      * automatically defined when the request is started. The current response
      * can not be used in e.g. background threads because of the way server

--- a/server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinService.java
@@ -1635,7 +1635,7 @@ public abstract class VaadinService implements Serializable {
                 SystemMessages ci = getSystemMessages(ServletPortletHelper
                         .findLocale(null, vaadinSession, request), request);
                 try {
-                    writeStringResponse(response,
+                    writeUncachedStringResponse(response,
                             JsonConstants.JSON_CONTENT_TYPE,
                             createCriticalNotificationJSON(
                                     ci.getInternalErrorCaption(),
@@ -1667,21 +1667,44 @@ public abstract class VaadinService implements Serializable {
      *            The response reference
      * @param contentType
      *            The content type of the response
-     * @param reponseString
+     * @param responseString
      *            The actual response
      * @throws IOException
      *             If an error occurred while writing the response
      */
     public void writeStringResponse(VaadinResponse response, String contentType,
-            String reponseString) throws IOException {
+            String responseString) throws IOException {
 
         response.setContentType(contentType);
 
         final OutputStream out = response.getOutputStream();
         try (PrintWriter outWriter = new PrintWriter(
                 new BufferedWriter(new OutputStreamWriter(out, UTF_8)))) {
-            outWriter.print(reponseString);
+            outWriter.print(responseString);
         }
+    }
+
+    /**
+     * Writes the given string as a response with headers to prevent caching and
+     * using the given content type.
+     *
+     * @param response
+     *            The response reference
+     * @param contentType
+     *            The content type of the response
+     * @param responseString
+     *            The actual response
+     * @throws IOException
+     *             If an error occurred while writing the response
+     * @since
+     */
+    public void writeUncachedStringResponse(VaadinResponse response,
+            String contentType, String responseString) throws IOException {
+        // Response might contain sensitive information, so prevent all forms of
+        // caching
+        response.setNoCacheHeaders();
+
+        writeStringResponse(response, contentType, responseString);
     }
 
     /**
@@ -1802,7 +1825,7 @@ public abstract class VaadinService implements Serializable {
     public void criticalNotification(VaadinRequest request,
             VaadinResponse response, String caption, String message,
             String details, String url) throws IOException {
-        writeStringResponse(response, JsonConstants.JSON_CONTENT_TYPE,
+        writeUncachedStringResponse(response, JsonConstants.JSON_CONTENT_TYPE,
                 createCriticalNotificationJSON(caption, message, details, url));
     }
 

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -578,7 +578,7 @@ public class VaadinServlet extends HttpServlet implements Constants {
                 SystemMessages systemMessages = getService().getSystemMessages(
                         ServletPortletHelper.findLocale(null, null, request),
                         request);
-                getService().writeStringResponse(response,
+                getService().writeUncachedStringResponse(response,
                         JsonConstants.JSON_CONTENT_TYPE,
                         VaadinService.createCriticalNotificationJSON(
                                 systemMessages.getCookiesDisabledCaption(),
@@ -625,7 +625,7 @@ public class VaadinServlet extends HttpServlet implements Constants {
         if (ServletPortletHelper.isUIDLRequest(request)) {
             String output = VaadinService.createCriticalNotificationJSON(
                     caption, message, details, url);
-            getService().writeStringResponse(response,
+            getService().writeUncachedStringResponse(response,
                     JsonConstants.JSON_CONTENT_TYPE, output);
         } else {
             // Create an HTML reponse with the error
@@ -649,7 +649,7 @@ public class VaadinServlet extends HttpServlet implements Constants {
             if (url != null) {
                 output += "</a>";
             }
-            getService().writeStringResponse(response,
+            getService().writeUncachedStringResponse(response,
                     ApplicationConstants.CONTENT_TYPE_TEXT_HTML_UTF_8, output);
         }
     }

--- a/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/UIInitHandler.java
@@ -109,15 +109,9 @@ public abstract class UIInitHandler extends SynchronizedRequestHandler {
         // The response was produced without errors so write it to the client
         response.setContentType(JsonConstants.JSON_CONTENT_TYPE);
 
-        // Response might contain sensitive information, so prevent caching
-        // no-store to disallow storing even if cache would be revalidated
-        // must-revalidate to not use stored value even if someone asks for it
-        response.setHeader("Cache-Control",
-                "no-cache, no-store, must-revalidate");
-
-        // Also set legacy values in case of old proxies in between
-        response.setHeader("Pragma", "no-cache");
-        response.setHeader("Expires", "0");
+        // Response might contain sensitive information, so prevent all forms of
+        // caching
+        response.setNoCacheHeaders();
 
         byte[] b = json.getBytes(UTF_8);
         response.setContentLength(b.length);
@@ -228,7 +222,7 @@ public abstract class UIInitHandler extends SynchronizedRequestHandler {
         session.addUI(ui);
         if (initException != null) {
             ui.getSession().getCommunicationManager()
-                    .handleConnectorRelatedException(ui, initException);
+            .handleConnectorRelatedException(ui, initException);
         }
         // Warn if the window can't be preserved
         if (embedId == null
@@ -316,7 +310,7 @@ public abstract class UIInitHandler extends SynchronizedRequestHandler {
         String seckey = session.getCsrfToken();
 
         return "\"" + ApplicationConstants.UIDL_SECURITY_TOKEN_ID + "\":\""
-                + seckey + "\",";
+        + seckey + "\",";
     }
 
     /**

--- a/server/src/main/java/com/vaadin/server/communication/UidlRequestHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/UidlRequestHandler.java
@@ -164,7 +164,8 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
         SystemMessages systemMessages = service.getSystemMessages(
                 ServletPortletHelper.findLocale(null, null, request), request);
 
-        service.writeStringResponse(response, JsonConstants.JSON_CONTENT_TYPE,
+        service.writeUncachedStringResponse(response,
+                JsonConstants.JSON_CONTENT_TYPE,
                 VaadinService.createCriticalNotificationJSON(
                         systemMessages.getSessionExpiredCaption(),
                         systemMessages.getSessionExpiredMessage(), null,

--- a/uitest/src/main/java/com/vaadin/tests/application/CriticalNotifications.java
+++ b/uitest/src/main/java/com/vaadin/tests/application/CriticalNotifications.java
@@ -96,7 +96,7 @@ public class CriticalNotifications extends AbstractReindeerTestUI {
         VaadinResponse response = VaadinService.getCurrentResponse();
 
         try {
-            service.writeStringResponse(response,
+            service.writeUncachedStringResponse(response,
                     JsonConstants.JSON_CONTENT_TYPE,
                     VaadinService.createCriticalNotificationJSON(caption,
                             message, details, url));


### PR DESCRIPTION
Follow-up to #10306 that only applied the headers for regular UIDL
responses but not to various error message responses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10628)
<!-- Reviewable:end -->
