### PR TITLE
Restart debug log timer on first log row instead of immediately

### DIFF
--- a/client/src/main/java/com/vaadin/client/debug/internal/VDebugWindow.java
+++ b/client/src/main/java/com/vaadin/client/debug/internal/VDebugWindow.java
@@ -111,7 +111,7 @@ public final class VDebugWindow extends VOverlay {
 
     // Timers since application start, and last timer reset
     private static final Duration START = new Duration();
-    private static Duration lastReset = START;
+    private static Duration lastReset = null;
 
     // outer panel
     protected FlowPanel window = new FlowPanel();
@@ -629,6 +629,10 @@ public final class VDebugWindow extends VOverlay {
      * @return
      */
     static int getMillisSinceReset() {
+        if (lastReset == null) {
+            lastReset = new Duration();
+        }
+
         return lastReset.elapsedMillis();
     }
 
@@ -639,7 +643,7 @@ public final class VDebugWindow extends VOverlay {
      */
     static int resetTimer() {
         int sinceLast = lastReset.elapsedMillis();
-        lastReset = new Duration();
+        lastReset = null;
         return sinceLast;
     }
 


### PR DESCRIPTION
This makes it easier to test duration of an event as the first log row
(typically 'RPC invocations to be sent to the server:') takes place at 0ms

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10640)
<!-- Reviewable:end -->
