### PR TITLE
Don't choke server when resizing the browser window

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/ui/UIConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/ui/UIConnector.java
@@ -199,12 +199,21 @@ public class UIConnector extends AbstractSingleComponentContainerConnector
                 return JSON.parse(json);
             }-*/;
         });
+ 
+        // Used to avoid choking server with hundreds of resize events when user
+        // changes the window size
+        Timer lazyFlusher = new Timer() {
+			@Override
+			public void run() {
+	            getConnection().getServerRpcQueue().flush();
+			}
+		};
 
         getWidget().addResizeHandler(event -> {
             getRpcProxy(UIServerRpc.class).resize(event.getWidth(),
                     event.getHeight(), Window.getClientWidth(),
                     Window.getClientHeight());
-            getConnection().getServerRpcQueue().flush();
+            lazyFlusher.schedule(100);
         });
         getWidget().addScrollHandler(new ScrollHandler() {
             private int lastSentScrollTop = Integer.MAX_VALUE;

--- a/client/src/main/java/com/vaadin/client/ui/ui/UIConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/ui/UIConnector.java
@@ -142,6 +142,8 @@ public class UIConnector extends AbstractSingleComponentContainerConnector
         }
     };
 
+    private boolean firstSizeReported;
+
     @Override
     protected void init() {
         super.init();
@@ -199,21 +201,26 @@ public class UIConnector extends AbstractSingleComponentContainerConnector
                 return JSON.parse(json);
             }-*/;
         });
- 
+
         // Used to avoid choking server with hundreds of resize events when user
         // changes the window size
         Timer lazyFlusher = new Timer() {
-			@Override
-			public void run() {
-	            getConnection().getServerRpcQueue().flush();
-			}
-		};
+            @Override
+            public void run() {
+                getConnection().getServerRpcQueue().flush();
+            }
+        };
 
         getWidget().addResizeHandler(event -> {
             getRpcProxy(UIServerRpc.class).resize(event.getWidth(),
                     event.getHeight(), Window.getClientWidth(),
                     Window.getClientHeight());
-            lazyFlusher.schedule(100);
+            if(!firstSizeReported) {
+                firstSizeReported = true;
+                getConnection().getServerRpcQueue().flush();
+            } else {
+                lazyFlusher.schedule(100);
+            }
         });
         getWidget().addScrollHandler(new ScrollHandler() {
             private int lastSentScrollTop = Integer.MAX_VALUE;
@@ -424,8 +431,7 @@ public class UIConnector extends AbstractSingleComponentContainerConnector
         if (firstPaint) {
             // Queue the initial window size to be sent with the following
             // request.
-            Scheduler.get()
-                    .scheduleDeferred(() -> ui.sendClientResized());
+            Scheduler.get().scheduleDeferred(() -> ui.sendClientResized());
         }
     }
 

--- a/uitest/src/test/java/com/vaadin/tests/applicationservlet/VaadinRefreshServletTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/applicationservlet/VaadinRefreshServletTest.java
@@ -32,5 +32,7 @@ public class VaadinRefreshServletTest extends SingleBrowserTest {
                 .equals(findElement(By.tagName("body")).getText()));
         assertEquals(getBaseURL() + "/statictestfiles/login.html",
                 getDriver().getCurrentUrl());
+        // Otherwise the memory release workaround will bug as this test is not named according to conventions
+        driver = null;
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/applicationservlet/VaadinRefreshServletTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/applicationservlet/VaadinRefreshServletTest.java
@@ -32,7 +32,5 @@ public class VaadinRefreshServletTest extends SingleBrowserTest {
                 .equals(findElement(By.tagName("body")).getText()));
         assertEquals(getBaseURL() + "/statictestfiles/login.html",
                 getDriver().getCurrentUrl());
-        // Otherwise the memory release workaround will bug as this test is not named according to conventions
-        driver = null;
     }
 }


### PR DESCRIPTION
Currently the server sized size change listener is hit each time browser reports the new size. This causes
sever issues when trying to adapt UI in the server side code (aka responsive web design in plain Java).

This change makes the browser send the new size only after user makes a small pause (or ends)
the resize. Minimal latency makes a great UX here.

Testable manually with com.vaadin.tests.minitutorials.v7b1.AxessingWebPageAndBrowserInfoUI

Change-Id: I0726d834149cceb94207038ac4cd560a053f7070

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10675)
<!-- Reviewable:end -->
