### PR TITLE
Clear client's selection helper fields when selection updated on server

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/combobox/ComboBoxConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/combobox/ComboBoxConnector.java
@@ -126,6 +126,10 @@ public class ComboBoxConnector extends AbstractListingConnector
     @OnStateChange({ "selectedItemKey", "selectedItemCaption",
             "selectedItemIcon" })
     private void onSelectionChange() {
+        if (getWidget().selectedOptionKey != getState().selectedItemKey) {
+            getWidget().selectedOptionKey = null;
+            getWidget().currentSuggestion = null;
+        }
         getDataReceivedHandler().updateSelectionFromServer(
                 getState().selectedItemKey, getState().selectedItemCaption,
                 getState().selectedItemIcon);

--- a/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxMixedUpdate.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxMixedUpdate.java
@@ -1,0 +1,75 @@
+package com.vaadin.tests.components.combobox;
+
+import java.util.Arrays;
+
+import com.vaadin.data.Binder;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUIWithLog;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.ComboBox;
+import com.vaadin.ui.HorizontalLayout;
+
+public class ComboBoxMixedUpdate extends AbstractTestUIWithLog {
+
+    private Pojo pojo;
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        Binder<Pojo> binder = new Binder<>();
+        ComboBox<Integer> numbers = new ComboBox<>();
+        numbers.setItems(Arrays.asList(0, 1, 2, 3));
+        binder.forField(numbers).bind(Pojo::getNumber, Pojo::setNumber);
+
+        pojo = new Pojo(1);
+        binder.setBean(pojo);
+
+        Button reset = new Button("reset");
+        reset.setId("reset");
+        reset.addClickListener(e -> {
+            pojo.setNumber(0);
+            // refresh binder
+            binder.readBean(pojo);
+        });
+
+        Button show = new Button("show values");
+        show.setId("show");
+        show.addClickListener(e -> {
+            log("Bean value = " + pojo.getNumber() + " - ComboBox value = "
+                    + numbers.getValue());
+        });
+
+        HorizontalLayout buttons = new HorizontalLayout(numbers, show, reset);
+
+        getLayout().addComponents(buttons);
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "1: Write not null value (1-3) that differs from previous selection and TAB out -- don't select from drop down"
+                + "<br>2: Click the 'show values' button to confirm both ComboBox and bean values were updated"
+                + "<br>3: Click the 'reset' button (both ComboBox and bean values should go to 0)"
+                + "<br>4: Re-focus ComboBox, write the previous value and TAB out -- don't select from drop down"
+                + "<br>5: Both ComboBox and bean values should have the written value, not 0.";
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 10660;
+    }
+
+    public class Pojo {
+        int number;
+
+        public Pojo(int number) {
+            this.number = number;
+        }
+
+        public int getNumber() {
+            return number;
+        }
+
+        public void setNumber(int number) {
+            this.number = number;
+        }
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxMixedUpdateTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxMixedUpdateTest.java
@@ -1,0 +1,51 @@
+package com.vaadin.tests.components.combobox;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.interactions.Actions;
+
+import com.vaadin.testbench.By;
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.ComboBoxElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class ComboBoxMixedUpdateTest extends MultiBrowserTest {
+
+    private ComboBoxElement comboBox;
+    private ButtonElement reset;
+    private ButtonElement show;
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+
+        openTestURL();
+        waitForElementPresent(By.className("v-filterselect"));
+        comboBox = $(ComboBoxElement.class).first();
+        reset = $(ButtonElement.class).id("reset");
+        show = $(ButtonElement.class).id("show");
+    }
+
+    private void sendKeysToInput(CharSequence... keys) {
+        comboBox.clear();
+        // ensure mouse is located over the ComboBox to avoid hover issues
+        new Actions(getDriver()).moveToElement(comboBox).perform();
+        comboBox.sendKeys(keys);
+    }
+
+    @Test
+    public void testMixedUpdateWorks() {
+        comboBox.focus();
+        sendKeysToInput("2", Keys.TAB);
+        show.click();
+        assertEquals("1. Bean value = 2 - ComboBox value = 2", getLogRow(0));
+        reset.click();
+        show.click();
+        assertEquals("2. Bean value = 0 - ComboBox value = 0", getLogRow(0));
+        sendKeysToInput("2", Keys.TAB);
+        show.click();
+        assertEquals("3. Bean value = 2 - ComboBox value = 2", getLogRow(0));
+    }
+}


### PR DESCRIPTION
Fixes #10660

- Previous manual selection's state shouldn't leak through programmatic
selection process and interfere with any subsequent manual selection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10692)
<!-- Reviewable:end -->
