### PR TITLE
Updated stalebot behaviour

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ staleLabel: Stale
 only: issues
 # Comment to post when closing a stale Issue or Pull Request.
 closeComment: >
-  The issue was automatically closed due to inactivity. If you found some new details to it or started working on it, feel free to re-open it.
+  The issue was automatically closed due to inactivity. If you found some new details to it or started working on it, comment on the issue so that maintainers can re-open it.
 
 markComment: |
   Hello there!

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,26 @@
-daysUntilStale: 10335
-daysUntilClose: 30
+daysUntilStale: 150
+daysUntilClose: 900
 exemptLabels:
  - BFP
  - Pinned
 staleLabel: Stale
 only: issues
-markComment: >
-  A lot of tickets have been left hanging in the issue tracker through the
-  years. Some of them are still relevant, some of them have been fixed a long
-  time ago and some are no longer valid. To get a better look on what is
-  important and still relevant, we are closing old tickets which have not been
-  touched in a long time.
-  No further work will be done on this ticket. If the ticket seems to be still
-  actual, please verify the problem existence over latest framework version
-  and then open a new ticket in [vaadin/framework](https://github.com/vaadin/framework)
-  with all the suitable information.
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  The issue was automatically closed due to inactivity. If you found some new details to it or started working on it, feel free to re-open it.
+
+markComment: |
+  Hello there!
+  
+  It looks like this issue hasn't progressed lately. There are so many issues that we just can't deal them all within a reasonable timeframe.
+  
+  There are a couple of things you could help to get things rolling on this issue (this is an automated message, so expect that some of these are already in use):
+  
+   * Check if the issue is still valid for the latest version. There are dozens of duplicates in our issue tracker, so it is possible that the issue is already tackled. If it appears to be fixed, close the issue, otherwise report to the issue that it is still valid.
+   * Provide more details how to reproduce the issue.
+   * Explain why it is important to get this issue fixed and politely draw others attention to it e.g. via the forum or social media.
+   * Add a reduced test case about the issue, so it is easier for somebody to start working on a solution.
+   * Try [fixing the issue yourself](https://github.com/vaadin/framework/blob/master/CONTRIBUTING.md) and [create a pull request](https://help.github.com/categories/collaborating-with-issues-and-pull-requests/) that contains the test case and/or a fix for it. Handling the pull requests is the top priority for the core team.
+   * If the issue is clearly a bug, use the [Warranty](https://vaadin.com/pricing) in your Vaadin subscription to raise its priority.
+  
+  Thanks again for your contributions! Even though we haven't been able to get this issue fixed, we hope you to report your findings and enhancement ideas in the future too!


### PR DESCRIPTION
Improved the stalebot behaviour:

 * Attack stalled issues earlier (maybe could even be earlier, especially if the issue has absolutely no reactions?).
 * More polite message, that tries to get things solved instead of just sweeping them away from the sight.
 * Closing much later, when really nothing just seems to happen. Hopefully we don't get there at all, but close issues manually earlier if we see there is nothing we can do with reasonable timeframe/resources. I wouldn't personally use automatic closing as all, as old tickets can be filtered otherwise if really needed, but this seems to be a big wish from the core team, so trying to make some kind of compromise here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10718)
<!-- Reviewable:end -->
