### PR TITLE
Added method asRequired with a custom required validator to BindingBuilder.

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -741,6 +741,7 @@ public class Binder<BEAN> implements Serializable {
          * @param customRequiredValidator
          *            validator responsible for the required check
          * @return this binding, for chaining
+         * @since
          */
         public BindingBuilder<BEAN, TARGET> asRequired(
                 Validator<TARGET> customRequiredValidator);

--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -728,6 +728,22 @@ public class Binder<BEAN> implements Serializable {
          */
         public BindingBuilder<BEAN, TARGET> asRequired(
                 ErrorMessageProvider errorMessageProvider);
+
+        /**
+         * Sets the field to be required and delegates the required check to a custom validator.
+         * This means two things:
+         * <ol>
+         * <li>the required indicator will be displayed for this field</li>
+         * <li>the field value is validated by customRequiredValidator</li>
+         * </ol>
+         *
+         * @see HasValue#setRequiredIndicatorVisible(boolean)
+         * @param customRequiredValidator
+         *            validator responsible for the required check
+         * @return this binding, for chaining
+         */
+        public BindingBuilder<BEAN, TARGET> asRequired(
+                Validator<TARGET> customRequiredValidator);
     }
 
     /**
@@ -885,11 +901,18 @@ public class Binder<BEAN> implements Serializable {
         @Override
         public BindingBuilder<BEAN, TARGET> asRequired(
                 ErrorMessageProvider errorMessageProvider) {
+            return asRequired(
+                    Validator.from(
+                            value -> !Objects.equals(value, field.getEmptyValue()),
+                            errorMessageProvider));
+        }
+
+        @Override
+        public BindingBuilder<BEAN, TARGET> asRequired(
+                Validator<TARGET> customRequiredValidator) {
             checkUnbound();
             field.setRequiredIndicatorVisible(true);
-            return withValidator(
-                    value -> !Objects.equals(value, field.getEmptyValue()),
-                    errorMessageProvider);
+            return withValidator(customRequiredValidator);
         }
 
         /**

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -29,6 +29,7 @@ import com.vaadin.shared.ui.ErrorLevel;
 import com.vaadin.tests.data.bean.Person;
 import com.vaadin.tests.data.bean.Sex;
 import com.vaadin.ui.TextField;
+import org.apache.commons.lang.StringUtils;
 
 public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
@@ -492,6 +493,97 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         ErrorMessage errorMessage = textField.getErrorMessage();
         assertNotNull(errorMessage);
         assertEquals("foobar", errorMessage.getFormattedHtmlMessage());
+        // validation is done for all changed bindings once.
+        assertEquals(1, invokes.get());
+
+        textField.setValue("value");
+        assertNull(textField.getErrorMessage());
+        assertTrue(textField.isRequiredIndicatorVisible());
+    }
+
+    @Test
+    public void setRequired_withCustomValidator_fieldGetsRequiredIndicatorAndValidator() {
+        TextField textField = new TextField();
+        textField.setLocale(Locale.CANADA);
+        assertFalse(textField.isRequiredIndicatorVisible());
+
+        BindingBuilder<Person, String> binding = binder.forField(textField);
+        assertFalse(textField.isRequiredIndicatorVisible());
+        AtomicInteger invokes = new AtomicInteger();
+
+        Validator<String> customRequiredValidator = (value, context) -> {
+            invokes.incrementAndGet();
+            if (StringUtils.isBlank(value)) {
+                return ValidationResult.error("Input is required.");
+            }
+            return ValidationResult.ok();
+        };
+        binding.asRequired(customRequiredValidator);
+        assertTrue(textField.isRequiredIndicatorVisible());
+
+        binding.bind(Person::getFirstName, Person::setFirstName);
+        binder.setBean(item);
+        assertNull(textField.getErrorMessage());
+        assertEquals(0, invokes.get());
+
+        textField.setValue("        ");
+        ErrorMessage errorMessage = textField.getErrorMessage();
+        assertNotNull(errorMessage);
+        assertEquals("Input&#32;is&#32;required&#46;", errorMessage.getFormattedHtmlMessage());
+        // validation is done for all changed bindings once.
+        assertEquals(1, invokes.get());
+
+        textField.setValue("value");
+        assertNull(textField.getErrorMessage());
+        assertTrue(textField.isRequiredIndicatorVisible());
+    }
+
+    @Test
+    public void setRequired_withCustomValidator_modelConverterBeforeValidator() {
+        TextField textField = new TextField();
+        textField.setLocale(Locale.CANADA);
+        assertFalse(textField.isRequiredIndicatorVisible());
+
+        Converter<String, String> stringBasicPreProcessingConverter = new Converter<String, String>() {
+            @Override
+            public Result<String> convertToModel(String value, ValueContext context) {
+                if (StringUtils.isBlank(value)) {
+                    return Result.ok(null);
+                }
+                return Result.ok(StringUtils.trim(value));
+            }
+
+            @Override
+            public String convertToPresentation(String value, ValueContext context) {
+                if (value == null) {
+                    return "";
+                }
+                return value;
+            }
+        };
+
+        AtomicInteger invokes = new AtomicInteger();
+        Validator<String> customRequiredValidator = (value, context) -> {
+            invokes.incrementAndGet();
+            if (value == null) {
+                return ValidationResult.error("Input required.");
+            }
+            return ValidationResult.ok();
+        };
+
+        binder.forField(textField)
+                .withConverter(stringBasicPreProcessingConverter)
+                .asRequired(customRequiredValidator)
+                .bind(Person::getFirstName, Person::setFirstName);
+
+        binder.setBean(item);
+        assertNull(textField.getErrorMessage());
+        assertEquals(0, invokes.get());
+
+        textField.setValue("        ");
+        ErrorMessage errorMessage = textField.getErrorMessage();
+        assertNotNull(errorMessage);
+        assertEquals("Input&#32;required&#46;", errorMessage.getFormattedHtmlMessage());
         // validation is done for all changed bindings once.
         assertEquals(1, invokes.get());
 


### PR DESCRIPTION
Hello!

Currently the Binder checks if a value is required only by comparing it with `field.getEmptyValue()`.

Since `value` can be something returned by a converted running before the validation, then sometimes it makes sense to consider values that are semantically empty from the model's perspective too (`null` or a null object, for instance).

This pull request makes this possible without breaking any backwards compatibility by providing a new method to specify a field as required and passing together the custom required validator to be used.

It will allow developers to customise required validation easily if needed, replacing the previous `binder.forField(...).asRequired()` call with `binder.forField(...).asRequired(myAppRequiredValidator)`.

I had a conversation with @Legioth about this issue and we came together with this idea.

There are unit tests included in the PR.

Please let me know if everything is ok. Best regards!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10724)
<!-- Reviewable:end -->
