### PR TITLE
fix invalid formatting of maven goal

### DIFF
--- a/documentation/getting-started/getting-started-idea.asciidoc
+++ b/documentation/getting-started/getting-started-idea.asciidoc
@@ -87,7 +87,7 @@ launch a Vaadin Maven application on the light-weight Jetty web server.
 . Click [guibutton]#+# and select [guilabel]#Maven# to create a new Maven run/debug configuration.
 
 . Enter a [guilabel]#Name# for the run configuration.
-For the [guilabel]#Command line#, enter "`package jetty:run`# to first compile and package the project, and then launch Jetty to run it.
+For the [guilabel]#Command line#, enter `package jetty:run` to first compile and package the project, and then launch Jetty to run it.
 
 +
 Click [guibutton]#OK#.


### PR DESCRIPTION
Original feedback from end user:

Please fix this paragraph: For the Command line, enter "`package jetty:run`# to first compile and package the project, and then launch Jetty to run it.

I am confused on what is the actual command here. There is some opening double quote but not closing double quote

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10729)
<!-- Reviewable:end -->
