### PR TITLE
Ensure that popup is closed in Tabsheet

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/popupview/PopupViewConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/popupview/PopupViewConnector.java
@@ -135,7 +135,7 @@ public class PopupViewConnector extends AbstractHasComponentsConnector
 
         } else {
             // The popup shouldn't be visible, try to hide it.
-            popup.hide();
+            popup.hide(false,false,false);
         }
     }
 

--- a/server/src/main/java/com/vaadin/ui/PopupView.java
+++ b/server/src/main/java/com/vaadin/ui/PopupView.java
@@ -413,4 +413,18 @@ public class PopupView extends AbstractComponent implements HasComponents {
          */
         public void popupVisibilityChange(PopupVisibilityEvent event);
     }
+
+    @Override
+    public void detach() {
+        setPopupVisible(false);
+        super.detach();
+    }
+
+    @Override
+    public void setVisible(boolean visible) {
+        if (!visible) {
+            setPopupVisible(false);
+        }
+        super.setVisible(visible);
+    }
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/popupview/PopUpViewInTabsheet.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/popupview/PopUpViewInTabsheet.java
@@ -6,12 +6,6 @@ import com.vaadin.ui.*;
 
 public class PopUpViewInTabsheet extends AbstractTestUI {
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.vaadin.tests.components.AbstractTestUI#setup(com.vaadin.server.
-     * VaadinRequest)
-     */
     @Override
     protected void setup(VaadinRequest request) {
         CssLayout layout = new CssLayout();

--- a/uitest/src/main/java/com/vaadin/tests/components/popupview/PopUpViewInTabsheet.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/popupview/PopUpViewInTabsheet.java
@@ -1,0 +1,40 @@
+package com.vaadin.tests.components.popupview;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.*;
+
+public class PopUpViewInTabsheet extends AbstractTestUI {
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.vaadin.tests.components.AbstractTestUI#setup(com.vaadin.server.
+     * VaadinRequest)
+     */
+    @Override
+    protected void setup(VaadinRequest request) {
+        CssLayout layout = new CssLayout();
+        addComponent(layout);
+
+        VerticalLayout popupContent = new VerticalLayout();
+        popupContent.setId("content");
+        PopupView popup = new PopupView("Pop it up", popupContent);
+        popupContent.addComponent(new Button("Button"));
+
+        popup.setHideOnMouseOut(false);
+        popup.setId("popupId");
+        popup.setHeight("40px");
+
+        TabSheet tabsheet = new TabSheet();
+
+        VerticalLayout tab1 = new VerticalLayout();
+        tab1.addComponent(popup);
+        tabsheet.addTab(tab1, "Mercury").setId("tab0");
+        VerticalLayout tab2 = new VerticalLayout();
+        tab2.addComponent(new TextField("Enter"));
+        tab2.setCaption("Venus");
+        tabsheet.addTab(tab2).setId("tab1");
+        layout.addComponent(tabsheet);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/popupview/PopUpViewInTabsheetTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/popupview/PopUpViewInTabsheetTest.java
@@ -11,24 +11,19 @@ import com.vaadin.tests.tb3.MultiBrowserTest;
 
 public class PopUpViewInTabsheetTest extends MultiBrowserTest {
 
-    private static final String FIRST_TAB = "//*[@id = 'tab0']";
-    private static final String SECOND_TAB = "//*[@id = 'tab1']";
-
-    WebElement view;
-
     @Before
     public void testPopupView() {
         openTestURL();
-        view = findElement(By.className("v-popupview"));
     }
 
     @Test
     public void testPopUpNotVisisble() {
+        WebElement view = findElement(By.className("v-popupview"));
         view.click();
         assertTrue(
                 findElement(By.className("v-popupview-popup")).isDisplayed());
-        findElement(By.xpath(SECOND_TAB)).click();
-        findElement(By.xpath(FIRST_TAB)).click();
+        findElement(By.id("tab1")).click();
+        findElement(By.id("tab0")).click();
         assertTrue(findElements(By.className("v-popupview-popup")).isEmpty());
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/popupview/PopUpViewInTabsheetTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/popupview/PopUpViewInTabsheetTest.java
@@ -1,0 +1,34 @@
+package com.vaadin.tests.components.popupview;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.testbench.By;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class PopUpViewInTabsheetTest extends MultiBrowserTest {
+
+    private static final String FIRST_TAB = "//*[@id = 'tab0']";
+    private static final String SECOND_TAB = "//*[@id = 'tab1']";
+
+    WebElement view;
+
+    @Before
+    public void testPopupView() {
+        openTestURL();
+        view = findElement(By.className("v-popupview"));
+    }
+
+    @Test
+    public void testPopUpNotVisisble() {
+        view.click();
+        assertTrue(
+                findElement(By.className("v-popupview-popup")).isDisplayed());
+        findElement(By.xpath(SECOND_TAB)).click();
+        findElement(By.xpath(FIRST_TAB)).click();
+        assertTrue(findElements(By.className("v-popupview-popup")).isEmpty());
+    }
+}


### PR DESCRIPTION
When switching between two tabs, with a popup.setHideOnMouseOut(false) (for example, in the first one), popup is reopened, when going back to the first tab.

Adding detach, to ensure visibility is set to false on server side also.
This change also eliminates console errors, occurred due to removed Connector.
Resolve: https://github.com/vaadin/framework/issues/10739

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10738)
<!-- Reviewable:end -->
