### PR TITLE
remove parse error when changing from invalid to empty date text

### DIFF
--- a/server/src/main/java/com/vaadin/ui/AbstractDateField.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractDateField.java
@@ -106,14 +106,19 @@ public abstract class AbstractDateField<T extends Temporal & TemporalAdjuster & 
                     newDate = reconstructDateFromFields(resolutions, oldDate);
                 }
 
+                boolean parseErrorWasSet = currentParseErrorMessage != null;
                 hasChanges |= !Objects.equals(dateString, newDateString)
-                        || !Objects.equals(oldDate, newDate);
+                        || !Objects.equals(oldDate, newDate)
+                        || parseErrorWasSet;
 
                 if (hasChanges) {
                     dateString = newDateString;
                     currentParseErrorMessage = null;
                     if (newDateString == null || newDateString.isEmpty()) {
-                        setValue(newDate, true);
+                        boolean valueChanged = setValue(newDate, true);
+                        if(!valueChanged && parseErrorWasSet) {
+                            doSetValue(newDate);
+                        }
                     } else {
                         // invalid date string
                         if (resolutions.isEmpty()) {

--- a/server/src/test/java/com/vaadin/tests/server/component/datefield/DateFieldErrorMessageTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/datefield/DateFieldErrorMessageTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.server.component.datefield;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.vaadin.shared.ui.datefield.AbstractDateFieldServerRpc;
+import com.vaadin.shared.ui.datefield.DateResolution;
+import com.vaadin.tests.server.component.abstractdatefield.AbstractLocalDateFieldDeclarativeTest;
+import com.vaadin.ui.AbstractDateField;
+import com.vaadin.ui.InlineDateField;
+
+/**
+ * Tests the resetting of component error after setting empty date string in
+ * {@link AbstractDateField}.
+ */
+public class DateFieldErrorMessageTest
+        extends AbstractLocalDateFieldDeclarativeTest<InlineDateField> {
+
+    @Test
+    public void testErrorMessageRemoved() throws Exception {
+        InlineDateField field = new InlineDateField("Day is",
+                LocalDate.of(2003, 2, 27));
+        checkValueAndComponentError(field, "2003-02-27", LocalDate.of(2003, 2, 27), false);
+        checkValueAndComponentError(field, "", null, false);
+        checkValueAndComponentError(field, "2003-04-27", LocalDate.of(2003, 4, 27), false);
+        checkValueAndComponentError(field, "foo", null, true);
+        checkValueAndComponentError(field, "2013-07-03", LocalDate.of(2013, 7, 3), false);
+        checkValueAndComponentError(field, "foo", null, true);
+        checkValueAndComponentError(field, "", null, false);
+    }
+
+    @Override
+    protected String getComponentTag() {
+        return "vaadin-inline-date-field";
+    }
+
+    @Override
+    protected Class<? extends InlineDateField> getComponentClass() {
+        return InlineDateField.class;
+    }
+
+    private void checkValueAndComponentError(InlineDateField field, String newInput, LocalDate expectedFieldValue, boolean componentErrorExpected) throws Exception {
+        setDateByText(field, newInput);
+        assertEquals(expectedFieldValue, field.getValue());
+        assertEquals(componentErrorExpected, field.getComponentError()!=null);
+    }
+
+    private void setDateByText(InlineDateField field, String dateText) throws Exception {
+        Field rcpField = AbstractDateField.class.getDeclaredField("rpc");
+        rcpField.setAccessible(true);
+        AbstractDateFieldServerRpc rcp = (AbstractDateFieldServerRpc)rcpField.get(field);
+        Map<String, Integer> resolutions=new HashMap<String, Integer>();
+        try {
+            LocalDate date = LocalDate.parse(dateText);
+            resolutions.put(DateResolution.YEAR.name(), date.getYear());
+            resolutions.put(DateResolution.MONTH.name(), date.getMonthValue());
+            resolutions.put(DateResolution.DAY.name(), date.getDayOfMonth());
+        }catch (Exception e) {
+            //ignore
+        }
+        rcp.update(dateText, resolutions);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldIsValidTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldIsValidTest.java
@@ -52,10 +52,13 @@ public class DateFieldIsValidTest extends MultiBrowserTest {
         assertLogText("4. buttonClick: value: null, is valid: false");
 
         dateTextbox.clear();
-        dateTextbox.sendKeys("02/02/02", Keys.TAB);
-        assertLogText("5. valueChange: value: 02/02/02, is valid: true");
         button.click();
-        assertLogText("6. buttonClick: value: 02/02/02, is valid: true");
+        assertLogText("5. buttonClick: value: null, is valid: true");
+
+        dateTextbox.sendKeys("02/02/02", Keys.TAB);
+        assertLogText("6. valueChange: value: 02/02/02, is valid: true");
+        button.click();
+        assertLogText("7. buttonClick: value: 02/02/02, is valid: true");
     }
 
     private void assertLogText(String expected) throws Exception {


### PR DESCRIPTION
This pull request addresses #10673. Currently a date field change is not detected when deleting an invalid
date string ("foo"->""). This is because old and new date are null and
both datestrings are empty . As a consequence the parse error is not
removed from the component.

With this change "hasChanges" will be true also if the parse error
message is not null and hence will be re-evaluated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10771)
<!-- Reviewable:end -->
