### PR TITLE
Added possibility to add listener for connectorMarkedDirty

### DIFF
--- a/server/src/main/java/com/vaadin/event/MarkedAsDirtyConnectorEvent.java
+++ b/server/src/main/java/com/vaadin/event/MarkedAsDirtyConnectorEvent.java
@@ -1,0 +1,27 @@
+package com.vaadin.event;
+
+import com.vaadin.server.ClientConnector;
+import com.vaadin.ui.UI;
+
+/**
+ * Event which is fired for all registered MarkDirtyListeners when a
+ * connector is marked as dirty.
+ */
+public class MarkedAsDirtyConnectorEvent extends ConnectorEvent {
+
+    private final UI ui;
+
+    public MarkedAsDirtyConnectorEvent(ClientConnector source, UI ui) {
+        super(source);
+        this.ui = ui;
+    }
+
+    /**
+     * Get the UI for which the connector event was fired
+     *
+     * @return target ui for event
+     */
+    public UI getUi() {
+        return ui;
+    }
+}

--- a/server/src/main/java/com/vaadin/event/MarkedAsDirtyConnectorEvent.java
+++ b/server/src/main/java/com/vaadin/event/MarkedAsDirtyConnectorEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.event;
 
 import com.vaadin.server.ClientConnector;

--- a/server/src/main/java/com/vaadin/event/MarkedAsDirtyConnectorEvent.java
+++ b/server/src/main/java/com/vaadin/event/MarkedAsDirtyConnectorEvent.java
@@ -21,6 +21,8 @@ import com.vaadin.ui.UI;
 /**
  * Event which is fired for all registered MarkDirtyListeners when a
  * connector is marked as dirty.
+ *
+ * @since 8.4
  */
 public class MarkedAsDirtyConnectorEvent extends ConnectorEvent {
 

--- a/server/src/main/java/com/vaadin/event/MarkedAsDirtyListener.java
+++ b/server/src/main/java/com/vaadin/event/MarkedAsDirtyListener.java
@@ -1,0 +1,16 @@
+package com.vaadin.event;
+
+/**
+ * An interface used for listening to marked as dirty events.
+ */
+@FunctionalInterface
+public interface MarkedAsDirtyListener extends ConnectorEventListener {
+
+    /**
+     * Method called when a client connector has been marked as dirty.
+     *
+     * @param event
+     *         marked as dirty connector event object
+     */
+    void connectorMarkedAsDirty(MarkedAsDirtyConnectorEvent event);
+}

--- a/server/src/main/java/com/vaadin/event/MarkedAsDirtyListener.java
+++ b/server/src/main/java/com/vaadin/event/MarkedAsDirtyListener.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.event;
 
 /**

--- a/server/src/main/java/com/vaadin/event/MarkedAsDirtyListener.java
+++ b/server/src/main/java/com/vaadin/event/MarkedAsDirtyListener.java
@@ -17,6 +17,8 @@ package com.vaadin.event;
 
 /**
  * An interface used for listening to marked as dirty events.
+ *
+ * @since 8.4
  */
 @FunctionalInterface
 public interface MarkedAsDirtyListener extends ConnectorEventListener {

--- a/server/src/main/java/com/vaadin/ui/ConnectorTracker.java
+++ b/server/src/main/java/com/vaadin/ui/ConnectorTracker.java
@@ -948,6 +948,9 @@ public class ConnectorTracker implements Serializable {
      * @return unmodifiable list of registered listeners for navigation handler
      */
     public <E> List<E> getRegisteredListeners(Class<E> listenerType) {
+        if (listeners == null) {
+            return Collections.emptyList();
+        }
         List<E> registeredListeners = (List<E>) listeners
                 .computeIfAbsent(listenerType, key -> new ArrayList<>());
         return Collections.unmodifiableList(registeredListeners);

--- a/server/src/main/java/com/vaadin/ui/ConnectorTracker.java
+++ b/server/src/main/java/com/vaadin/ui/ConnectorTracker.java
@@ -917,6 +917,7 @@ public class ConnectorTracker implements Serializable {
      *
      * @param listener
      *         listener to add
+     * @since 8.4
      * @return registration for removing listener registration
      */
     public Registration addMarkedAsDirtyListener(
@@ -931,6 +932,7 @@ public class ConnectorTracker implements Serializable {
      *
      * @param connector
      *         client connector marked as dirty
+     * @since 8.4
      */
     public void notifyMarkedAsDirtyListeners(ClientConnector connector) {
         MarkedAsDirtyConnectorEvent event = new MarkedAsDirtyConnectorEvent(

--- a/server/src/main/java/com/vaadin/ui/ConnectorTracker.java
+++ b/server/src/main/java/com/vaadin/ui/ConnectorTracker.java
@@ -502,7 +502,8 @@ public class ConnectorTracker implements Serializable {
     }
 
     /**
-     * Mark the connector as dirty. This should not be done while the response
+     * Mark the connector as dirty and notifies any marked as dirty listeners.
+     * This should not be done while the response
      * is being written.
      *
      * @see #getDirtyConnectors()
@@ -518,10 +519,14 @@ public class ConnectorTracker implements Serializable {
         }
 
         if (getLogger().isLoggable(Level.FINE)) {
-            if (!dirtyConnectors.contains(connector)) {
+            if (!isDirty(connector)) {
                 getLogger().log(Level.FINE, "{0} is now dirty",
                         getConnectorAndParentInfo(connector));
             }
+        }
+
+        if(!isDirty(connector)) {
+            uI.notifyMarkedAsDirtyListeners(connector);
         }
 
         dirtyConnectors.add(connector);

--- a/server/src/main/java/com/vaadin/ui/UI.java
+++ b/server/src/main/java/com/vaadin/ui/UI.java
@@ -39,7 +39,6 @@ import com.vaadin.annotations.PreserveOnRefresh;
 import com.vaadin.event.Action;
 import com.vaadin.event.Action.Handler;
 import com.vaadin.event.ActionManager;
-import com.vaadin.event.ConnectorEvent;
 import com.vaadin.event.ConnectorEventListener;
 import com.vaadin.event.MouseEvents.ClickEvent;
 import com.vaadin.event.MouseEvents.ClickListener;
@@ -2033,76 +2032,5 @@ public abstract class UI extends AbstractSingleComponentContainer
          * @param event
          */
         public void windowOrderUpdated(WindowOrderUpdateEvent event);
-    }
-
-    /**
-     * Event which is fired for all registered MarkDirtyListeners when a
-     * connector is marked as dirty.
-     */
-    public static class MarkedAsDirtyConnectorEvent extends ConnectorEvent {
-
-        private static final String MARK_DIRTY = "connectorMarkedAsDirty";
-
-        private final UI ui;
-
-        public MarkedAsDirtyConnectorEvent(ClientConnector source, UI ui) {
-            super(source);
-            this.ui = ui;
-        }
-
-        /**
-         * Get the UI for which the connector event was fired
-         *
-         * @return target ui for event
-         */
-        public UI getUi() {
-            return ui;
-        }
-    }
-
-    /**
-     * An interface used for listening to marked as dirty events.
-     */
-    @FunctionalInterface
-    public interface MarkedAsDirtyListener extends ConnectorEventListener {
-
-        Method markedAsDirtyMethod = ReflectTools
-                .findMethod(MarkedAsDirtyListener.class,
-                        "connectorMarkedAsDirty",
-                        MarkedAsDirtyConnectorEvent.class);
-
-        /**
-         * Method called when a client connector has been marked as dirty.
-         *
-         * @param event
-         *            marked as dirty connector event object
-         */
-        void connectorMarkedAsDirty(MarkedAsDirtyConnectorEvent event);
-    }
-
-    /**
-     * Add a marked as dirty listener that will be called when a client
-     * connector is marked as dirty.
-     *
-     * @param listener
-     *            listener to add
-     * @return registration for removing listener registration
-     */
-    public Registration addMarkedAsDirtyListener(
-            MarkedAsDirtyListener listener) {
-        return addListener(MarkedAsDirtyConnectorEvent.MARK_DIRTY,
-                MarkedAsDirtyConnectorEvent.class, listener,
-                MarkedAsDirtyListener.markedAsDirtyMethod);
-    }
-
-    /**
-     * Notify all registered MarkedAsDirtyListeners the given client connector
-     * has been marked as dirty.
-     *
-     * @param connector
-     *            client connector marked as dirty
-     */
-    public void notifyMarkedAsDirtyListeners(ClientConnector connector) {
-        fireEvent(new MarkedAsDirtyConnectorEvent(connector, this));
     }
 }

--- a/server/src/main/java/com/vaadin/ui/UI.java
+++ b/server/src/main/java/com/vaadin/ui/UI.java
@@ -39,6 +39,7 @@ import com.vaadin.annotations.PreserveOnRefresh;
 import com.vaadin.event.Action;
 import com.vaadin.event.Action.Handler;
 import com.vaadin.event.ActionManager;
+import com.vaadin.event.ConnectorEvent;
 import com.vaadin.event.ConnectorEventListener;
 import com.vaadin.event.MouseEvents.ClickEvent;
 import com.vaadin.event.MouseEvents.ClickListener;
@@ -2032,5 +2033,76 @@ public abstract class UI extends AbstractSingleComponentContainer
          * @param event
          */
         public void windowOrderUpdated(WindowOrderUpdateEvent event);
+    }
+
+    /**
+     * Event which is fired for all registered MarkDirtyListeners when a
+     * connector is marked as dirty.
+     */
+    public static class MarkedAsDirtyConnectorEvent extends ConnectorEvent {
+
+        private static final String MARK_DIRTY = "connectorMarkedAsDirty";
+
+        private final UI ui;
+
+        public MarkedAsDirtyConnectorEvent(ClientConnector source, UI ui) {
+            super(source);
+            this.ui = ui;
+        }
+
+        /**
+         * Get the UI for which the connector event was fired
+         *
+         * @return target ui for event
+         */
+        public UI getUi() {
+            return ui;
+        }
+    }
+
+    /**
+     * An interface used for listening to marked as dirty events.
+     */
+    @FunctionalInterface
+    public interface MarkedAsDirtyListener extends ConnectorEventListener {
+
+        Method markedAsDirtyMethod = ReflectTools
+                .findMethod(MarkedAsDirtyListener.class,
+                        "connectorMarkedAsDirty",
+                        MarkedAsDirtyConnectorEvent.class);
+
+        /**
+         * Method called when a client connector has been marked as dirty.
+         *
+         * @param event
+         *            marked as dirty connector event object
+         */
+        void connectorMarkedAsDirty(MarkedAsDirtyConnectorEvent event);
+    }
+
+    /**
+     * Add a marked as dirty listener that will be called when a client
+     * connector is marked as dirty.
+     *
+     * @param listener
+     *            listener to add
+     * @return registration for removing listener registration
+     */
+    public Registration addMarkedAsDirtyListener(
+            MarkedAsDirtyListener listener) {
+        return addListener(MarkedAsDirtyConnectorEvent.MARK_DIRTY,
+                MarkedAsDirtyConnectorEvent.class, listener,
+                MarkedAsDirtyListener.markedAsDirtyMethod);
+    }
+
+    /**
+     * Notify all registered MarkedAsDirtyListeners the given client connector
+     * has been marked as dirty.
+     *
+     * @param connector
+     *            client connector marked as dirty
+     */
+    public void notifyMarkedAsDirtyListeners(ClientConnector connector) {
+        fireEvent(new MarkedAsDirtyConnectorEvent(connector, this));
     }
 }

--- a/server/src/test/java/com/vaadin/tests/event/MarkAsDirtyListenerTest.java
+++ b/server/src/test/java/com/vaadin/tests/event/MarkAsDirtyListenerTest.java
@@ -24,10 +24,12 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.event.MarkedAsDirtyConnectorEvent;
 import com.vaadin.server.ClientConnector;
 import com.vaadin.tests.util.MockUI;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.ComponentTest;
+import com.vaadin.ui.ConnectorTracker;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.TextField;
 import com.vaadin.ui.UI;
@@ -41,8 +43,8 @@ public class MarkAsDirtyListenerTest {
     public void fire_event_when_ui_marked_dirty() {
         UI ui = new MockUI();
 
-        AtomicReference<UI.MarkedAsDirtyConnectorEvent> events = new AtomicReference<>();
-        ui.addMarkedAsDirtyListener(event -> Assert
+        AtomicReference<MarkedAsDirtyConnectorEvent> events = new AtomicReference<>();
+        ui.getConnectorTracker().addMarkedAsDirtyListener(event -> Assert
                 .assertTrue("No reference should have been registered",
                         events.compareAndSet(null, event)));
         // UI is marked dirty on creation and when adding a listener
@@ -60,9 +62,9 @@ public class MarkAsDirtyListenerTest {
 
     @Test
     public void fire_event_for_setContent() {
-        List<UI.MarkedAsDirtyConnectorEvent> events = new ArrayList<>();
+        List<MarkedAsDirtyConnectorEvent> events = new ArrayList<>();
         UI ui = new MockUI() {{
-            addMarkedAsDirtyListener(event -> events.add(event));
+            getConnectorTracker().addMarkedAsDirtyListener(event -> events.add(event));
         }};
         ComponentTest.syncToClient(ui);
 
@@ -84,8 +86,8 @@ public class MarkAsDirtyListenerTest {
         ui.setContent(button);
         ComponentTest.syncToClient(button);
 
-        AtomicReference<UI.MarkedAsDirtyConnectorEvent> events = new AtomicReference<>();
-        ui.addMarkedAsDirtyListener(event -> Assert
+        AtomicReference<MarkedAsDirtyConnectorEvent> events = new AtomicReference<>();
+        ui.getConnectorTracker().addMarkedAsDirtyListener(event -> Assert
                 .assertTrue("No reference should have been registered",
                         events.compareAndSet(null, event)));
 
@@ -101,9 +103,9 @@ public class MarkAsDirtyListenerTest {
 
     @Test
     public void fire_events_for_each_component() {
-        List<UI.MarkedAsDirtyConnectorEvent> events = new ArrayList<>();
+        List<MarkedAsDirtyConnectorEvent> events = new ArrayList<>();
         UI ui = new MockUI() {{
-            addMarkedAsDirtyListener(event -> events.add(event));
+            getConnectorTracker().addMarkedAsDirtyListener(event -> events.add(event));
         }};
 
         HorizontalLayout layout = new HorizontalLayout();
@@ -119,7 +121,7 @@ public class MarkAsDirtyListenerTest {
                 events.size());
 
         Set<ClientConnector> connectors = events.stream()
-                .map(UI.MarkedAsDirtyConnectorEvent::getConnector)
+                .map(MarkedAsDirtyConnectorEvent::getConnector)
                 .collect(Collectors.toSet());
 
         Assert.assertTrue(

--- a/server/src/test/java/com/vaadin/tests/event/MarkAsDirtyListenerTest.java
+++ b/server/src/test/java/com/vaadin/tests/event/MarkAsDirtyListenerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.event;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.server.ClientConnector;
+import com.vaadin.tests.util.MockUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.ComponentTest;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.TextField;
+import com.vaadin.ui.UI;
+
+/**
+ * Test for mark as dirty listener functionality.
+ */
+public class MarkAsDirtyListenerTest {
+
+    @Test
+    public void fire_event_when_ui_marked_dirty() {
+        UI ui = new MockUI();
+
+        AtomicReference<UI.MarkedAsDirtyConnectorEvent> events = new AtomicReference<>();
+        ui.addMarkedAsDirtyListener(event -> Assert
+                .assertTrue("No reference should have been registered",
+                        events.compareAndSet(null, event)));
+        // UI is marked dirty on creation and when adding a listener
+        ComponentTest.syncToClient(ui);
+
+        ui.getConnectorTracker().markDirty(ui);
+
+        Assert.assertNotNull("Mark as dirty event should have fired",
+                events.get());
+        Assert.assertEquals("Event contains wrong ui", ui,
+                events.get().getUi());
+        Assert.assertEquals("Found wrong connector in event", ui,
+                events.get().getConnector());
+    }
+
+    @Test
+    public void fire_event_for_setContent() {
+        List<UI.MarkedAsDirtyConnectorEvent> events = new ArrayList<>();
+        UI ui = new MockUI() {{
+            addMarkedAsDirtyListener(event -> events.add(event));
+        }};
+        ComponentTest.syncToClient(ui);
+
+        Button button = new Button("Button");
+        ui.setContent(button);
+
+        Assert.assertEquals("Mark as dirty events should have fired", 2,
+                events.size());
+        Assert.assertEquals("Expected button to inform first for creation",
+                button, events.get(0).getConnector());
+        Assert.assertEquals("Expected UI marked as dirty for setContent", ui,
+                events.get(1).getConnector());
+    }
+
+    @Test
+    public void fire_event_for_component_stateChange() {
+        UI ui = new MockUI();
+        Button button = new Button("empty");
+        ui.setContent(button);
+        ComponentTest.syncToClient(button);
+
+        AtomicReference<UI.MarkedAsDirtyConnectorEvent> events = new AtomicReference<>();
+        ui.addMarkedAsDirtyListener(event -> Assert
+                .assertTrue("No reference should have been registered",
+                        events.compareAndSet(null, event)));
+
+        button.setIconAlternateText("alternate");
+
+        Assert.assertNotNull("Mark as dirty event should have fired",
+                events.get());
+        Assert.assertEquals("Event contains wrong ui", ui,
+                events.get().getUi());
+        Assert.assertEquals("Found wrong connector in event", button,
+                events.get().getConnector());
+    }
+
+    @Test
+    public void fire_events_for_each_component() {
+        List<UI.MarkedAsDirtyConnectorEvent> events = new ArrayList<>();
+        UI ui = new MockUI() {{
+            addMarkedAsDirtyListener(event -> events.add(event));
+        }};
+
+        HorizontalLayout layout = new HorizontalLayout();
+        // UI initially marked as dirty so should not show as event.
+        ui.setContent(layout);
+        TextField field = new TextField("Name");
+        Button button = new Button("say hello");
+        layout.addComponents(field, button);
+
+        Assert.assertFalse("Mark as dirty event should have fired",
+                events.isEmpty());
+        Assert.assertEquals("Unexpected amount of connector events", 3,
+                events.size());
+
+        Set<ClientConnector> connectors = events.stream()
+                .map(UI.MarkedAsDirtyConnectorEvent::getConnector)
+                .collect(Collectors.toSet());
+
+        Assert.assertTrue(
+                "HorizontalLayout should have fired an markedAsDirty event",
+                connectors.contains(layout));
+        Assert.assertTrue("TextField should have fired an markedAsDirty event",
+                connectors.contains(field));
+        Assert.assertTrue("Button should have fired an markedAsDirty event",
+                connectors.contains(button));
+    }
+}


### PR DESCRIPTION
Now there is the possibility to add a listener to the UI
that is fired when ever a connector is marked as dirty.
Only the first markDirty for a connector will create an event
and no events will be fired untill it has been marked clean.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10773)
<!-- Reviewable:end -->
