### PR TITLE
Remove reference to supportsParameters

### DIFF
--- a/documentation/advanced/advanced-cdi.asciidoc
+++ b/documentation/advanced/advanced-cdi.asciidoc
@@ -563,20 +563,8 @@ possible "View" suffix, making it lower case, and using a dash ("-") to separate
 words originally denoted by capital letters. Thereby, a view class such as
 [classname]#MyFunnyView# would have name " [literal]#++my-funny++#".
 
-supportsParameters:: Specifies whether view parameters can be passed to the view as a suffix to the
-name in the navigation state, that is, in the form of
-[literal]#++viewname+viewparameters++#. The view name is merely a prefix and
-there is no separator nor format for the parameters, but those are left for the
-view to handle. The parameter support mode is disabled by default.
-
-
 +
-[source, java]
-----
-@CDIView(value="myview", supportsParameters=true)
-----
-+
-You could then navigate to the state with a URI fragment such as
+You can navigate to a state with a URI fragment such as
 [literal]#++#!myview/someparameter++# or programmatically with:
 
 


### PR DESCRIPTION
SupportsParameters doesn't exist in CDIView anymore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10798)
<!-- Reviewable:end -->
