### PR TITLE
Color picker add methods to set modality of the color picker

### DIFF
--- a/server/src/main/java/com/vaadin/ui/AbstractColorPicker.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractColorPicker.java
@@ -561,16 +561,23 @@ public abstract class AbstractColorPicker extends AbstractField<Color> {
     }
 
     /**
-     *
+     * Sets ColorPicker modality. When a modal ColorPicker is open, components
+     * outside that ColorPicker cannot be accessed.
+     * 
      * @since
+     * @param modal
+     *            true if modality is to be turned on
      */
     public void setModal(boolean modal) {
         this.modal = modal;
     }
 
     /**
+     * Checks the modality of the dialog.
      *
+     * @see #setModal(boolean)
      * @since
+     * @return true if the dialog is modal, false otherwise
      */
     public boolean isModal() {
         return this.modal;

--- a/server/src/main/java/com/vaadin/ui/AbstractColorPicker.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractColorPicker.java
@@ -112,6 +112,7 @@ public abstract class AbstractColorPicker extends AbstractField<Color> {
     protected boolean swatchesVisible = true;
     protected boolean historyVisible = true;
     protected boolean textfieldVisible = true;
+    private boolean modal;
 
     /**
      * Instantiates a new color picker.
@@ -453,7 +454,7 @@ public abstract class AbstractColorPicker extends AbstractField<Color> {
                 window.setPositionX(positionX);
                 window.setPositionY(positionY);
                 window.setVisible(true);
-
+                window.setModal(modal);
                 parent.addWindow(window);
                 window.focus();
 
@@ -468,7 +469,7 @@ public abstract class AbstractColorPicker extends AbstractField<Color> {
                 window.setValue(color);
                 window.getHistory().setValue(color);
                 window.setVisible(true);
-
+                window.setModal(modal);
                 parent.addWindow(window);
                 window.focus();
             }
@@ -537,5 +538,13 @@ public abstract class AbstractColorPicker extends AbstractField<Color> {
     @Override
     public Color getEmptyValue() {
         return Color.WHITE;
+    }
+
+    public void setModal(boolean modal) {
+        this.modal = modal;
+    }
+
+    public boolean isModal() {
+        return this.modal;
     }
 }

--- a/server/src/main/java/com/vaadin/ui/AbstractColorPicker.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractColorPicker.java
@@ -564,10 +564,11 @@ public abstract class AbstractColorPicker extends AbstractField<Color> {
      * Sets ColorPicker modality. When a modal ColorPicker is open, components
      * outside that ColorPicker cannot be accessed.
      * <p>
-     * Note: If ColorPicker is the child of modal component, it must be set to
-     * modal too.
+     * Note: It must be set to {@code true} if ColorPicker is a child of modal
+     * {@link Window}
      * </p>
      * 
+     * @see Window#setModal
      * @since
      * @param modal
      *            true if modality is to be turned on

--- a/server/src/main/java/com/vaadin/ui/AbstractColorPicker.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractColorPicker.java
@@ -540,10 +540,18 @@ public abstract class AbstractColorPicker extends AbstractField<Color> {
         return Color.WHITE;
     }
 
+    /**
+     *
+     * @since
+     */
     public void setModal(boolean modal) {
         this.modal = modal;
     }
 
+    /**
+     *
+     * @since
+     */
     public boolean isModal() {
         return this.modal;
     }

--- a/server/src/main/java/com/vaadin/ui/AbstractColorPicker.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractColorPicker.java
@@ -563,6 +563,10 @@ public abstract class AbstractColorPicker extends AbstractField<Color> {
     /**
      * Sets ColorPicker modality. When a modal ColorPicker is open, components
      * outside that ColorPicker cannot be accessed.
+     * <p>
+     * Note: If ColorPicker is the child of modal component, it must be set to
+     * modal too.
+     * </p>
      * 
      * @since
      * @param modal

--- a/server/src/main/java/com/vaadin/ui/components/colorpicker/ColorPickerPopup.java
+++ b/server/src/main/java/com/vaadin/ui/components/colorpicker/ColorPickerPopup.java
@@ -765,4 +765,9 @@ public class ColorPickerPopup extends Window implements HasValue<Color> {
             }
         }
     }
+
+    @Override
+    public void setModal(boolean modal) {
+        getState().modal = modal;
+    }
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/colorpicker/ColorPickerModal.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/colorpicker/ColorPickerModal.java
@@ -1,0 +1,40 @@
+package com.vaadin.tests.components.colorpicker;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.shared.ui.colorpicker.Color;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.ColorPicker;
+import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.Window;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class ColorPickerModal extends AbstractTestUI {
+
+    private org.eclipse.jetty.util.log.Logger log;
+
+    @Override
+    protected void setup(VaadinRequest req) {
+        Window modalWindow = new Window("Modal window");
+        modalWindow.setModal(true);
+        VerticalLayout vl = new VerticalLayout();
+        ColorPicker cp = new ColorPicker("Color Picker test", Color.GREEN);
+        cp.setId("colorP");
+        cp.setModal(true);
+        vl.addComponent(cp);
+        modalWindow.setContent(vl);
+        addWindow(modalWindow);
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Test that setting color picker to modal, when it's on top of modal "
+                + "Window doesn't produce IllegalStateException";
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 9511;
+    }
+
+}

--- a/uitest/src/main/java/com/vaadin/tests/components/colorpicker/ColorPickerModal.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/colorpicker/ColorPickerModal.java
@@ -1,20 +1,22 @@
 package com.vaadin.tests.components.colorpicker;
 
 import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.DefaultErrorHandler;
+import com.vaadin.server.ErrorHandler;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.shared.ui.colorpicker.Color;
-import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.tests.components.AbstractTestUIWithLog;
 import com.vaadin.ui.ColorPicker;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.Window;
 
 @Widgetset("com.vaadin.DefaultWidgetSet")
-public class ColorPickerModal extends AbstractTestUI {
-
-    private org.eclipse.jetty.util.log.Logger log;
+public class ColorPickerModal extends AbstractTestUIWithLog
+        implements ErrorHandler {
 
     @Override
     protected void setup(VaadinRequest req) {
+        getSession().setErrorHandler(this);
         Window modalWindow = new Window("Modal window");
         modalWindow.setModal(true);
         VerticalLayout vl = new VerticalLayout();
@@ -27,14 +29,16 @@ public class ColorPickerModal extends AbstractTestUI {
     }
 
     @Override
-    protected String getTestDescription() {
-        return "Test that setting color picker to modal, when it's on top of modal "
-                + "Window doesn't produce IllegalStateException";
-    }
-
-    @Override
     protected Integer getTicketNumber() {
         return 9511;
     }
 
+    @Override
+    public void error(com.vaadin.server.ErrorEvent event) {
+        log("Exception caught on execution with "
+                + event.getClass().getSimpleName() + " : "
+                + event.getThrowable().getClass().getName());
+
+        DefaultErrorHandler.doDefault(event);
+    }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/colorpicker/ColorPickerModalTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/colorpicker/ColorPickerModalTest.java
@@ -1,0 +1,29 @@
+package com.vaadin.tests.components.colorpicker;
+
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.eclipse.jetty.util.log.Log;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ColorPickerModalTest extends MultiBrowserTest {
+
+    @Test
+    public void testNoError() {
+        openTestURL();
+        try {
+            setDebug(true);
+            WebElement cp = getDriver().findElement(By.id("colorP"));
+            cp.click();
+            assertEquals("Errors present in console", 0,
+                    findElements(By.className("SEVERE"))
+                            .size());
+        } catch (Exception e) {
+            Assert.assertTrue(false);
+        }
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/colorpicker/ColorPickerModalTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/colorpicker/ColorPickerModalTest.java
@@ -1,29 +1,20 @@
 package com.vaadin.tests.components.colorpicker;
 
 import com.vaadin.tests.tb3.MultiBrowserTest;
-import org.eclipse.jetty.util.log.Log;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class ColorPickerModalTest extends MultiBrowserTest {
 
     @Test
     public void testNoError() {
         openTestURL();
-        try {
-            setDebug(true);
-            WebElement cp = getDriver().findElement(By.id("colorP"));
-            cp.click();
-            assertEquals("Errors present in console", 0,
-                    findElements(By.className("SEVERE"))
-                            .size());
-        } catch (Exception e) {
-            Assert.assertTrue(false);
-        }
+        WebElement cp = getDriver().findElement(By.id("colorP"));
+        cp.click();
+        WebElement label = findElement(By.id("Log_row_0"));
+        Assert.assertEquals(false,
+                label.getText().contains("Exception caught"));
     }
 }


### PR DESCRIPTION
Overriding **setModal** in ColorPickerPopup to eliminate centering the window

Resolves https://github.com/vaadin/framework/issues/9511

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10815)
<!-- Reviewable:end -->
