### PR TITLE
Add null check to Grid's DnD focus handling

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -4597,7 +4597,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
         private void transferCellFocusOnDrop() {
             final Cell focusedCell = cellFocusHandler.getFocusedCell();
-            if (focusedCell != null) {
+            if (focusedCell != null && focusedCell.getElement() != null) {
                 final int focusedColumnIndexDOM = focusedCell.getColumn();
                 final int focusedRowIndex = focusedCell.getRow();
                 final int draggedColumnIndex = eventCell.getColumnIndex();

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridReorderColumns.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridReorderColumns.java
@@ -1,0 +1,58 @@
+package com.vaadin.tests.components.grid;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.data.provider.DataProvider;
+import com.vaadin.data.provider.ListDataProvider;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Grid;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class GridReorderColumns extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        getLayout().setSpacing(true);
+
+        Grid<String> emptyGrid = createGrid(false);
+        emptyGrid.setId("emptyGrid");
+
+        Grid<String> contentGrid = createGrid(true);
+        contentGrid.setId("contentGrid");
+
+        addComponents(emptyGrid, contentGrid);
+    }
+
+    private Grid<String> createGrid(boolean includeItem) {
+        Grid<String> grid = new Grid<>();
+        grid.addColumn(t -> t + "1").setCaption("caption1");
+        grid.addColumn(t -> t + "2").setCaption("caption2");
+        grid.addColumn(t -> t + "3").setCaption("caption3");
+        grid.addColumn(t -> t + "4").setCaption("caption4");
+        grid.setColumnReorderingAllowed(true);
+        grid.setHeight("100px");
+
+        List<String> items = new ArrayList<>();
+        if (includeItem) {
+            items.add("content");
+        }
+        ListDataProvider<String> dataProvider = DataProvider
+                .ofCollection(items);
+        grid.setDataProvider(dataProvider);
+        return grid;
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 10699;
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Column reordering without changing initial focus should complete "
+                + "without errors on all browsers even if the Grid is empty.";
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridReorderColumnsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridReorderColumnsTest.java
@@ -1,0 +1,45 @@
+package com.vaadin.tests.components.grid;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.interactions.Actions;
+
+import com.vaadin.testbench.elements.GridElement;
+import com.vaadin.testbench.elements.GridElement.GridCellElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class GridReorderColumnsTest extends MultiBrowserTest {
+
+    @Test
+    public void testEmptyGrid() {
+        openTestURL();
+
+        testReordering("emptyGrid");
+    }
+
+    @Test
+    public void testContentGrid() {
+        openTestURL();
+
+        testReordering("contentGrid");
+    }
+
+    private void testReordering(String id) {
+        GridElement grid = $(GridElement.class).id(id);
+        GridCellElement headerCell1 = grid.getHeaderCellByCaption("caption1");
+        GridCellElement headerCell3 = grid.getHeaderCellByCaption("caption3");
+
+        assertThat(grid.getHeaderCell(0, 0), is(headerCell1));
+
+        new Actions(getDriver()).clickAndHold(headerCell1)
+                .moveToElement(headerCell3, 5, 0).release().perform();
+
+        waitForElementNotPresent(By.className("dragged-column-header"));
+
+        assertThat(grid.getHeaderCell(0, 0), not(is(headerCell1)));
+    }
+}


### PR DESCRIPTION
Initial focus on empty Grid doesn't need to be transferred.

Fixes #10699

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10822)
<!-- Reviewable:end -->
