### PR TITLE
Don't allow editing if both ReadOnly and disabled are set

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VRichTextArea.java
+++ b/client/src/main/java/com/vaadin/client/ui/VRichTextArea.java
@@ -163,8 +163,8 @@ public class VRichTextArea extends Composite implements Field, KeyPressHandler,
     public void setEnabled(boolean enabled) {
         if (this.enabled != enabled) {
             // rta.setEnabled(enabled);
-            swapEditableArea();
             this.enabled = enabled;
+            swapEditableArea();
         }
     }
 
@@ -179,6 +179,9 @@ public class VRichTextArea extends Composite implements Field, KeyPressHandler,
     private void swapEditableArea() {
         String value = getValue();
         if (html.isAttached()) {
+            if (isReadOnly() || !isEnabled()) {
+                return;
+            }
             fp.remove(html);
             if (BrowserInfo.get().isWebkit()) {
                 fp.remove(formatter);
@@ -218,8 +221,8 @@ public class VRichTextArea extends Composite implements Field, KeyPressHandler,
 
     public void setReadOnly(boolean b) {
         if (isReadOnly() != b) {
-            swapEditableArea();
             readOnly = b;
+            swapEditableArea();
         }
         // reset visibility in case enabled state changed and the formatter was
         // recreated

--- a/uitest/src/main/java/com/vaadin/tests/components/richtextarea/RichTextAreaReadOnlyDisabled.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/richtextarea/RichTextAreaReadOnlyDisabled.java
@@ -1,0 +1,31 @@
+package com.vaadin.tests.components.richtextarea;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.RichTextArea;
+
+public class RichTextAreaReadOnlyDisabled extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        RichTextArea readOnlyDisabledTextArea = new RichTextArea(
+                "Readonly & Disabled");
+        readOnlyDisabledTextArea.setReadOnly(true);
+        readOnlyDisabledTextArea.setEnabled(false);
+        readOnlyDisabledTextArea.setValue("Random value");
+        readOnlyDisabledTextArea.setId("rtA");
+
+        final Button but1 = new Button("set Read ",
+                event -> readOnlyDisabledTextArea
+                        .setReadOnly(!readOnlyDisabledTextArea.isReadOnly()));
+        but1.setId("readPr");
+        final Button but2 = new Button("Enable/Disable ",
+                event -> readOnlyDisabledTextArea
+                        .setEnabled(!readOnlyDisabledTextArea.isEnabled()));
+        but2.setId("enablePr");
+        addComponent(readOnlyDisabledTextArea);
+        addComponent(but1);
+        addComponent(but2);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/richtextarea/RichTextAreaReadOnlyDisabledTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/richtextarea/RichTextAreaReadOnlyDisabledTest.java
@@ -29,5 +29,9 @@ public class RichTextAreaReadOnlyDisabledTest extends MultiBrowserTest {
         enablePrB.click();
 
         assertElementPresent(By.className("gwt-RichTextArea"));
+        readPrB.click();//Set to read-only
+        assertElementNotPresent(By.className("gwt-RichTextArea"));
+        enablePrB.click();//Set disabled
+        assertElementNotPresent(By.className("gwt-RichTextArea"));
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/richtextarea/RichTextAreaReadOnlyDisabledTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/richtextarea/RichTextAreaReadOnlyDisabledTest.java
@@ -1,0 +1,33 @@
+package com.vaadin.tests.components.richtextarea;
+
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.util.List;
+
+public class RichTextAreaReadOnlyDisabledTest extends MultiBrowserTest {
+
+    @Override
+    public List<DesiredCapabilities> getBrowsersToTest() {
+        return getBrowsersExcludingPhantomJS();
+    }
+
+    @Test
+    public void shouldDelegateToShortcutActionHandler() {
+        openTestURL();
+        // gwt-RichTextArea is classname used by iframe
+        WebElement readPrB = findElement(By.id("readPr"));
+        WebElement enablePrB = findElement(By.id("enablePr"));
+
+        assertElementNotPresent(By.className("gwt-RichTextArea"));
+        readPrB.click();
+
+        assertElementNotPresent(By.className("gwt-RichTextArea"));
+        enablePrB.click();
+
+        assertElementPresent(By.className("gwt-RichTextArea"));
+    }
+}


### PR DESCRIPTION
Fixes #10541

While formatting field is handled in setReadOnly method, swapEditableArea needs to take into account situations, when one of the properties is changed, but the second one is not. In this case don't replace html with rta.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10831)
<!-- Reviewable:end -->
