### PR TITLE
Updated to use non-deprecated API

### DIFF
--- a/documentation/layout/layout-orderedlayout.asciidoc
+++ b/documentation/layout/layout-orderedlayout.asciidoc
@@ -152,7 +152,7 @@ optional spacing).
 [source, java]
 ----
 HorizontalLayout fittingLayout = new HorizontalLayout();
-fittingLayout.setWidth(Sizeable.SIZE_UNDEFINED, 0); // Default
+fittingLayout.setWidthUndefined(); // Default, can be omitted
 fittingLayout.setSpacing(false); // Compact layout
 fittingLayout.addComponent(new Button("Small"));
 fittingLayout.addComponent(new Button("Medium-sized"));


### PR DESCRIPTION
Sizeable.SIZE_UNDEFINED constant was deprecated in V8 and replaced by setWidthUndefined()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10855)
<!-- Reviewable:end -->
