### PR TITLE
Removing obsolete link

### DIFF
--- a/documentation/addons/addons-cval.asciidoc
+++ b/documentation/addons/addons-cval.asciidoc
@@ -64,11 +64,6 @@ usually with a [literal]#++-D++# option. For example, on the command-line:
 
 where the [literal]`<product>` is the product ID, such as `charts`, `spreadsheet`, `designer`, or `testbench`.
 
-ifdef::web[]
-See link:https://vaadin.com/directory/help/installing-cval-license[the CVAL
-license key installation instructions] for more details.
-endif::web[]
-
 [[addons.cval.systemproperty.environments]]
 === Passing License Key in Different Environments
 


### PR DESCRIPTION
Removing an obsolete link that currently just redirects back to this same documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10857)
<!-- Reviewable:end -->
