### PR TITLE
Allow overiding ServerRpcHandler creation in PushHandler

### DIFF
--- a/server/src/main/java/com/vaadin/server/communication/PushHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushHandler.java
@@ -58,6 +58,8 @@ public class PushHandler {
 
     private int longPollingSuspendTimeout = -1;
 
+    private final ServerRpcHandler rpcHandler = createRpcHandler();
+
     /**
      * Callback interface used internally to process an event with the
      * corresponding UI properly locked.
@@ -143,7 +145,7 @@ public class PushHandler {
         assert vaadinRequest != null;
 
         try {
-            new ServerRpcHandler().handleRpc(ui, reader, vaadinRequest);
+            rpcHandler.handleRpc(ui, reader, vaadinRequest);
             connection.push(false);
         } catch (JsonException e) {
             getLogger().log(Level.SEVERE, "Error writing JSON to response", e);
@@ -162,6 +164,16 @@ public class PushHandler {
 
     public PushHandler(VaadinServletService service) {
         this.service = service;
+    }
+
+    /**
+     * Creates the ServerRpcHandler to use.
+     *
+     * @return the ServerRpcHandler to use
+     * @since
+     */
+    protected ServerRpcHandler createRpcHandler() {
+        return new ServerRpcHandler();
     }
 
     /**


### PR DESCRIPTION
The override can be used to instrument/log ServerRpcHandler, for example for collection of request metrics.

The same thing is already possible in UidlRequestHandler, this change allows the same in PushHandler.

One test fails but also fails on master

Fixes #4537

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10892)
<!-- Reviewable:end -->
