### PR TITLE
Use XMLHttpRequest2 API for html5 DnD uploads

### DIFF
--- a/client/src/main/java/com/vaadin/client/extensions/FileDropTargetConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/FileDropTargetConnector.java
@@ -199,7 +199,7 @@ public class FileDropTargetConnector extends DropTargetExtensionConnector {
 
         public final native void postFile(File file)
         /*-{
-            var formData = new FormData();
+            var formData = new $wnd.FormData();
             formData.append("File", file);
             this.send(formData);
         }-*/;

--- a/client/src/main/java/com/vaadin/client/extensions/FileDropTargetConnector.java
+++ b/client/src/main/java/com/vaadin/client/extensions/FileDropTargetConnector.java
@@ -199,8 +199,9 @@ public class FileDropTargetConnector extends DropTargetExtensionConnector {
 
         public final native void postFile(File file)
         /*-{
-            this.setRequestHeader('Content-Type', 'multipart/form-data');
-            this.send(file);
+            var formData = new FormData();
+            formData.append("File", file);
+            this.send(formData);
         }-*/;
 
     }


### PR DESCRIPTION
- Some WAFs rely on the content disposition header in the upload
- Supported in most browsers http://caniuse.com/#search=XHR2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10896)
<!-- Reviewable:end -->
