### PR TITLE
Set no cache rules

### DIFF
--- a/server/src/main/java/com/vaadin/server/UnsupportedBrowserHandler.java
+++ b/server/src/main/java/com/vaadin/server/UnsupportedBrowserHandler.java
@@ -44,6 +44,7 @@ public class UnsupportedBrowserHandler extends SynchronizedRequestHandler {
             // bypass if cookie set
             String c = request.getHeader("Cookie");
             if (c == null || !c.contains(FORCE_LOAD_COOKIE)) {
+                response.setNoCacheHeaders();
                 writeBrowserTooOldPage(request, response);
                 return true; // request handled
             }


### PR DESCRIPTION
Set no cache rules for response in UnsupportedBrowserHandler

Fix #10890

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10899)
<!-- Reviewable:end -->
