### PR TITLE
Open methods to allow custom static file serving logic

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -716,8 +716,10 @@ public class VaadinServlet extends HttpServlet implements Constants {
      *         otherwise.
      * @throws IOException
      * @throws ServletException
+     * 
+     * @since
      */
-    private boolean serveStaticResources(HttpServletRequest request,
+    protected boolean serveStaticResources(HttpServletRequest request,
             HttpServletResponse response) throws IOException, ServletException {
 
         String pathInfo = request.getPathInfo();
@@ -754,8 +756,10 @@ public class VaadinServlet extends HttpServlet implements Constants {
      * @param response
      * @throws IOException
      * @throws ServletException
+     * 
+     * @since
      */
-    private void serveStaticResourcesInVAADIN(String filename,
+    protected void serveStaticResourcesInVAADIN(String filename,
             HttpServletRequest request, HttpServletResponse response)
             throws IOException, ServletException {
 


### PR DESCRIPTION
The methods `serveStaticResources` and `serveStaticResourcesInVAADIN` have been changed from `private` to `protected` to allow subclasses to change how static files are served.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10910)
<!-- Reviewable:end -->
