### PR TITLE
Fix temporal renderers serialization

### DIFF
--- a/all/src/main/templates/release-notes.html
+++ b/all/src/main/templates/release-notes.html
@@ -101,6 +101,7 @@
         <li><tt>setStyleName(String, boolean)</tt> has been moved from <tt>AbstractComponent</tt> to <tt>Component</tt> interface as a default method.</li>
         <li><tt>Window</tt> closing animation disabled by default.</li>
         <li><tt>FileTypeResolver</tt> icon features have been moved to a compatibility version of the class.</li>
+        <li><tt>LocalDateRenderer</tt> and <tt>LocalDateTimeRenderer</tt> should not be created from <tt>LocalDateTimeFormatter</tt> because of serialization issues. Alternative providers are available.</li>
 
         <h2>For incompatible or behavior-altering changes in 8.4, please see <a href="https://vaadin.com/download/release/8.4/8.4.0/release-notes.html#incompatible">8.4 release notes</a></h2>
 

--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -2189,8 +2189,8 @@ public class Binder<BEAN> implements Serializable {
      * <p>
      * Added listener is notified every time whenever any bound field value is
      * changed, i.e. the UI component value was changed, passed all the
-     * conversions and validations then propagated to the bound bean field. The same
-     * functionality can be achieved by adding a
+     * conversions and validations then propagated to the bound bean field. The
+     * same functionality can be achieved by adding a
      * {@link ValueChangeListener} to all fields in the {@link Binder}.
      * <p>
      * The listener is added to all fields regardless of whether the method is

--- a/server/src/main/java/com/vaadin/server/GlobalResourceHandler.java
+++ b/server/src/main/java/com/vaadin/server/GlobalResourceHandler.java
@@ -122,7 +122,6 @@ public class GlobalResourceHandler implements RequestHandler {
         return true;
     }
 
-
     private String urlEncodedKey(String key) {
         // getPathInfo return path decoded but without decoding plus as spaces
         return ResourceReference.encodeFileName(key.replace("+", " "));

--- a/server/src/main/java/com/vaadin/ui/renderers/LocalDateRenderer.java
+++ b/server/src/main/java/com/vaadin/ui/renderers/LocalDateRenderer.java
@@ -15,11 +15,14 @@
  */
 package com.vaadin.ui.renderers;
 
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Locale;
 
+import com.vaadin.server.SerializableSupplier;
 import com.vaadin.shared.ui.grid.renderers.LocalDateRendererState;
 
 import elemental.json.JsonValue;
@@ -32,7 +35,7 @@ import elemental.json.JsonValue;
  */
 public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
 
-    private DateTimeFormatter formatter;
+    private SerializableSupplier<DateTimeFormatter> formatterSupplier;
     private boolean getLocaleFromGrid;
 
     /**
@@ -47,7 +50,7 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      *      FormatStyle.LONG</a>
      */
     public LocalDateRenderer() {
-        this(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG), "");
+        this(() -> DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG), "");
         getLocaleFromGrid = true;
     }
 
@@ -133,7 +136,8 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
             throw new IllegalArgumentException("locale may not be null");
         }
 
-        formatter = DateTimeFormatter.ofPattern(formatPattern, locale);
+        formatterSupplier = () -> DateTimeFormatter.ofPattern(formatPattern,
+                locale);
     }
 
     /**
@@ -142,12 +146,21 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      * The renderer is configured to render with the given formatter, with an
      * empty string as its null representation.
      *
+     * <p>
+     * <b>Note</b> the {@code DateTimeFormatter} is not a serializable class, so
+     * using this method in an environment which requires session persistence
+     * may produce {@link java.io.NotSerializableException}.
+     *
      * @param formatter
      *            the formatter to use, not {@code null}
      *
      * @throws IllegalArgumentException
      *             if formatter is null
+     * @deprecated the method is unsafe for serialization, may produce troubles
+     *             in a cluster environment
+     * @see #LocalDateRenderer(SerializableSupplier)
      */
+    @Deprecated
     public LocalDateRenderer(DateTimeFormatter formatter) {
         this(formatter, "");
     }
@@ -155,7 +168,68 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
     /**
      * Creates a new LocalDateRenderer.
      * <p>
+     * The renderer is configured to render with the given formatterSupplier.
+     *
+     * @param formatterSupplier
+     *            the formatterSupplier supplier to use, not {@code null}, it
+     *            should not supply {@code null} either
+     * @param nullRepresentation
+     *            the textual representation of the {@code null} value
+     *
+     * @throws IllegalArgumentException
+     *             if formatterSupplier is null
+     */
+    public LocalDateRenderer(
+            SerializableSupplier<DateTimeFormatter> formatterSupplier,
+            String nullRepresentation) {
+        super(LocalDate.class, nullRepresentation);
+
+        if (formatterSupplier == null) {
+            throw new IllegalArgumentException(
+                    "formatterSupplier may not be null");
+        }
+        this.formatterSupplier = formatterSupplier;
+        assert checkSerialization(formatterSupplier);
+    }
+
+    public static boolean checkSerialization(Object obj) {
+        try {
+            new ObjectOutputStream(new OutputStream() {
+                @Override
+                public void write(int b) {
+                }
+            }).writeObject(obj);
+        } catch (Throwable e) {
+            throw new AssertionError(e);
+        }
+        return true;
+    }
+
+    /**
+     * Creates a new LocalDateRenderer.
+     * <p>
+     * The renderer is configured to render with the given formatterSupplier.
+     *
+     * @param formatterSupplier
+     *            the formatterSupplier supplier to use, not {@code null}, it
+     *            should not supply {@code null} either
+     * @throws IllegalArgumentException
+     *             if formatterSupplier is null
+     */
+    public LocalDateRenderer(
+            SerializableSupplier<DateTimeFormatter> formatterSupplier) {
+        this(formatterSupplier, "");
+    }
+
+    /**
+     * Creates a new LocalDateRenderer.
+     * <p>
      * The renderer is configured to render with the given formatter.
+     *
+     * <p>
+     * <b>Note</b> the {@code DateTimeFormatter} is not a serializable class, so
+     * using this method in an environment which requires session persistence
+     * may produce {@link java.io.NotSerializableException}.
      *
      * @param formatter
      *            the formatter to use, not {@code null}
@@ -164,7 +238,11 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      *
      * @throws IllegalArgumentException
      *             if formatter is null
+     * @deprecated the method is unsafe for serialization, may produce troubles
+     *             in acluster environment
+     * @see #LocalDateRenderer(SerializableSupplier, String)
      */
+    @Deprecated
     public LocalDateRenderer(DateTimeFormatter formatter,
             String nullRepresentation) {
         super(LocalDate.class, nullRepresentation);
@@ -173,7 +251,7 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
             throw new IllegalArgumentException("formatter may not be null");
         }
 
-        this.formatter = formatter;
+        this.formatterSupplier = () -> formatter;
     }
 
     @Override
@@ -188,10 +266,10 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
                                 + "this renderer should either be attached to a grid "
                                 + "or constructed with locale information");
             }
-            dateString = value
-                    .format(formatter.withLocale(getParentGrid().getLocale()));
+            dateString = value.format(formatterSupplier.get()
+                    .withLocale(getParentGrid().getLocale()));
         } else {
-            dateString = value.format(formatter);
+            dateString = value.format(formatterSupplier.get());
         }
         return encode(dateString, String.class);
     }

--- a/server/src/main/java/com/vaadin/ui/renderers/LocalDateRenderer.java
+++ b/server/src/main/java/com/vaadin/ui/renderers/LocalDateRenderer.java
@@ -26,6 +26,7 @@ import com.vaadin.server.SerializableSupplier;
 import com.vaadin.shared.ui.grid.renderers.LocalDateRendererState;
 
 import elemental.json.JsonValue;
+import static java.util.Objects.*;
 
 /**
  * A renderer for presenting date values.
@@ -43,7 +44,7 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      * <p>
      * The renderer is configured to render with the grid's locale it is
      * attached to, with the format style being {@code FormatStyle.LONG} and an
-     * empty string as its null representation.
+     * empty string as its {@code null} representation.
      *
      * @see <a href=
      *      "https://docs.oracle.com/javase/8/docs/api/java/time/format/FormatStyle.html#LONG">
@@ -59,13 +60,13 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      * <p>
      * The renderer is configured to render with the given string format, as
      * displayed in the grid's locale it is attached to, with an empty string as
-     * its null representation.
+     * its {@code null} representation.
      *
      * @param formatPattern
      *            the format pattern to format the date with, not {@code null}
      *
-     * @throws IllegalArgumentException
-     *             if format pattern is null
+     * @throws NullPointerException
+     *             if format pattern is {@code null}
      *
      * @see <a href=
      *      "https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns">
@@ -80,7 +81,7 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      * Creates a new LocalDateRenderer.
      * <p>
      * The renderer is configured to render with the given string format, as
-     * displayed in the given locale, with an empty string as its null
+     * displayed in the given locale, with an empty string as its {@code null}
      * representation.
      *
      * @param formatPattern
@@ -88,10 +89,10 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      * @param locale
      *            the locale to use, not {@code null}
      *
-     * @throws IllegalArgumentException
-     *             if format pattern is null
-     * @throws IllegalArgumentException
-     *             if locale is null
+     * @throws NullPointerException
+     *             if format pattern is {@code null}
+     * @throws NullPointerException
+     *             if locale is {@code null}
      *
      * @see <a href=
      *      "https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns">
@@ -114,10 +115,10 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      * @param nullRepresentation
      *            the textual representation of the {@code null} value
      *
-     * @throws IllegalArgumentException
-     *             if format pattern is null
-     * @throws IllegalArgumentException
-     *             if locale is null
+     * @throws NullPointerException
+     *             if format pattern is {@code null}
+     * @throws NullPointerException
+     *             if locale is {@code null}
      *
      * @see <a href=
      *      "https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns">
@@ -127,24 +128,16 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
             String nullRepresentation) {
         super(LocalDate.class, nullRepresentation);
 
-        if (formatPattern == null) {
-            throw new IllegalArgumentException(
-                    "format pattern may not be null");
-        }
-
-        if (locale == null) {
-            throw new IllegalArgumentException("locale may not be null");
-        }
-
-        formatterSupplier = () -> DateTimeFormatter.ofPattern(formatPattern,
-                locale);
+        formatterSupplier = () -> DateTimeFormatter.ofPattern(
+                requireNonNull(formatPattern, "format pattern may not be null"),
+                requireNonNull(locale, "locale may not be null"));
     }
 
     /**
      * Creates a new LocalDateRenderer.
      * <p>
      * The renderer is configured to render with the given formatter, with an
-     * empty string as its null representation.
+     * empty string as its {@code null} representation.
      *
      * <p>
      * <b>Note</b> the {@code DateTimeFormatter} is not a serializable class, so
@@ -154,8 +147,8 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      * @param formatter
      *            the formatter to use, not {@code null}
      *
-     * @throws IllegalArgumentException
-     *             if formatter is null
+     * @throws NullPointerException
+     *             if formatter is {@code null}
      * @deprecated the method is unsafe for serialization, may produce troubles
      *             in a cluster environment
      * @see #LocalDateRenderer(SerializableSupplier)
@@ -176,19 +169,16 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      * @param nullRepresentation
      *            the textual representation of the {@code null} value
      *
-     * @throws IllegalArgumentException
-     *             if formatterSupplier is null
+     * @throws NullPointerException
+     *             if formatterSupplier is {@code null}
      */
     public LocalDateRenderer(
             SerializableSupplier<DateTimeFormatter> formatterSupplier,
             String nullRepresentation) {
         super(LocalDate.class, nullRepresentation);
 
-        if (formatterSupplier == null) {
-            throw new IllegalArgumentException(
-                    "formatterSupplier may not be null");
-        }
-        this.formatterSupplier = formatterSupplier;
+        this.formatterSupplier = requireNonNull(formatterSupplier,
+                "formatterSupplier may not be null");
         assert checkSerialization(formatterSupplier);
     }
 
@@ -200,7 +190,7 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
                 }
             }).writeObject(obj);
         } catch (Throwable e) {
-            throw new AssertionError(e);
+            throw new AssertionError("Non-serializable object " + obj, e);
         }
         return true;
     }
@@ -213,8 +203,8 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      * @param formatterSupplier
      *            the formatterSupplier supplier to use, not {@code null}, it
      *            should not supply {@code null} either
-     * @throws IllegalArgumentException
-     *             if formatterSupplier is null
+     * @throws NullPointerException
+     *             if formatterSupplier is {@code null}
      */
     public LocalDateRenderer(
             SerializableSupplier<DateTimeFormatter> formatterSupplier) {
@@ -236,10 +226,10 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
      * @param nullRepresentation
      *            the textual representation of the {@code null} value
      *
-     * @throws IllegalArgumentException
-     *             if formatter is null
+     * @throws NullPointerException
+     *             if formatter is {@code null}
      * @deprecated the method is unsafe for serialization, may produce troubles
-     *             in acluster environment
+     *             in a cluster environment
      * @see #LocalDateRenderer(SerializableSupplier, String)
      */
     @Deprecated
@@ -248,7 +238,7 @@ public class LocalDateRenderer extends AbstractRenderer<Object, LocalDate> {
         super(LocalDate.class, nullRepresentation);
 
         if (formatter == null) {
-            throw new IllegalArgumentException("formatter may not be null");
+            throw new NullPointerException("formatter may not be null");
         }
 
         this.formatterSupplier = () -> formatter;

--- a/server/src/main/java/com/vaadin/ui/renderers/LocalDateTimeRenderer.java
+++ b/server/src/main/java/com/vaadin/ui/renderers/LocalDateTimeRenderer.java
@@ -25,6 +25,7 @@ import com.vaadin.shared.ui.grid.renderers.LocalDateTimeRendererState;
 
 import elemental.json.JsonValue;
 import static com.vaadin.ui.renderers.LocalDateRenderer.checkSerialization;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A renderer for presenting {@code LocalDateTime} objects.
@@ -44,7 +45,7 @@ public class LocalDateTimeRenderer
      * The renderer is configured to render with the grid's locale it is
      * attached to, with the format style being {@code FormatStyle.LONG} for the
      * date and {@code FormatStyle.SHORT} for time, with an empty string as its
-     * null representation.
+     * {@code null} representation.
      *
      * @see <a href=
      *      "https://docs.oracle.com/javase/8/docs/api/java/time/format/FormatStyle.html#LONG">
@@ -63,7 +64,7 @@ public class LocalDateTimeRenderer
      * Creates a new LocalDateTimeRenderer.
      * <p>
      * The renderer is configured to render with the given formatter, with the
-     * empty string as its null representation.
+     * empty string as its {@code null} representation.
      *
      * <p>
      * <b>Note</b> the {@code DateTimeFormatter} is not a serializable class, so
@@ -73,8 +74,8 @@ public class LocalDateTimeRenderer
      * @param formatter
      *            the formatter to use, not {@code null}
      *
-     * @throws IllegalArgumentException
-     *             if formatter is null
+     * @throws NullPointerException
+     *             if formatter is {@code null}
      * @deprecated the method is unsafe for serialization, may produce troubles
      *             in a cluster environment
      * @see #LocalDateTimeRenderer(SerializableSupplier)
@@ -100,10 +101,10 @@ public class LocalDateTimeRenderer
      * @param nullRepresentation
      *            the textual representation of the {@code null} value
      *
-     * @throws IllegalArgumentException
-     *             if formatter is null
+     * @throws NullPointerException
+     *             if formatter is {@code null}
      * @deprecated the method is unsafe for serialization, may produce troubles
-     *             in acluster environment
+     *             in a cluster environment
      * @see #LocalDateTimeRenderer(SerializableSupplier, String)
      */
     @Deprecated
@@ -112,7 +113,7 @@ public class LocalDateTimeRenderer
         super(LocalDateTime.class, nullRepresentation);
 
         if (formatter == null) {
-            throw new IllegalArgumentException("formatter may not be null");
+            throw new NullPointerException("formatter may not be null");
         }
 
         this.formatterSupplier = () -> formatter;
@@ -123,13 +124,13 @@ public class LocalDateTimeRenderer
      * <p>
      * The renderer is configured to render with the given string format, as
      * displayed in the grid's locale it is attached to, with an empty string as
-     * its null representation.
+     * its {@code null} representation.
      *
      * @param formatPattern
      *            the format pattern to format the date with, not {@code null}
      *
-     * @throws IllegalArgumentException
-     *             if format pattern is null
+     * @throws NullPointerException
+     *             if format pattern is {@code null}
      *
      * @see <a href=
      *      "https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns">
@@ -144,7 +145,7 @@ public class LocalDateTimeRenderer
      * Creates a new LocalDateTimeRenderer.
      * <p>
      * The renderer is configured to render with the given string format, as
-     * displayed in the given locale, with an empty string as its null
+     * displayed in the given locale, with an empty string as its {@code null}
      * representation.
      *
      * @param formatPattern
@@ -152,10 +153,10 @@ public class LocalDateTimeRenderer
      * @param locale
      *            the locale to use, not {@code null}
      *
-     * @throws IllegalArgumentException
-     *             if format pattern is null
-     * @throws IllegalArgumentException
-     *             if locale is null
+     * @throws NullPointerException
+     *             if format pattern is {@code null}
+     * @throws NullPointerException
+     *             if locale is {@code null}
      *
      * @see <a href=
      *      "https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns">
@@ -178,10 +179,10 @@ public class LocalDateTimeRenderer
      * @param nullRepresentation
      *            the textual representation of the {@code null} value
      *
-     * @throws IllegalArgumentException
-     *             if format pattern is null
-     * @throws IllegalArgumentException
-     *             if locale is null
+     * @throws NullPointerException
+     *             if format pattern is {@code null}
+     * @throws NullPointerException
+     *             if locale is {@code null}
      *
      * @see <a href=
      *      "https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns">
@@ -191,17 +192,9 @@ public class LocalDateTimeRenderer
             String nullRepresentation) {
         super(LocalDateTime.class, nullRepresentation);
 
-        if (formatPattern == null) {
-            throw new IllegalArgumentException(
-                    "format pattern may not be null");
-        }
-
-        if (locale == null) {
-            throw new IllegalArgumentException("locale may not be null");
-        }
-
-        formatterSupplier = () -> DateTimeFormatter.ofPattern(formatPattern,
-                locale);
+        formatterSupplier = () -> DateTimeFormatter.ofPattern(
+                requireNonNull(formatPattern, "format pattern may not be null"),
+                requireNonNull(locale, "locale may not be null"));
     }
 
     /**
@@ -212,8 +205,8 @@ public class LocalDateTimeRenderer
      * @param formatterSupplier
      *            the formatterSupplier supplier to use, not {@code null}, it
      *            should not supply {@code null} either
-     * @throws IllegalArgumentException
-     *             if formatterSupplier is null
+     * @throws NullPointerException
+     *             if formatterSupplier is {@code null}
      */
     public LocalDateTimeRenderer(
             SerializableSupplier<DateTimeFormatter> formatterSupplier) {
@@ -231,19 +224,16 @@ public class LocalDateTimeRenderer
      * @param nullRepresentation
      *            the textual representation of the {@code null} value
      *
-     * @throws IllegalArgumentException
-     *             if formatterSupplier is null
+     * @throws NullPointerException
+     *             if formatterSupplier is {@code null}
      */
     public LocalDateTimeRenderer(
             SerializableSupplier<DateTimeFormatter> formatterSupplier,
             String nullRepresentation) {
         super(LocalDateTime.class, nullRepresentation);
 
-        if (formatterSupplier == null) {
-            throw new IllegalArgumentException(
-                    "formatterSupplier may not be null");
-        }
-        this.formatterSupplier = formatterSupplier;
+        this.formatterSupplier = requireNonNull(formatterSupplier,
+                "formatterSupplier may not be null");
         assert checkSerialization(formatterSupplier);
     }
 

--- a/server/src/main/java/com/vaadin/ui/renderers/LocalDateTimeRenderer.java
+++ b/server/src/main/java/com/vaadin/ui/renderers/LocalDateTimeRenderer.java
@@ -20,9 +20,11 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Locale;
 
+import com.vaadin.server.SerializableSupplier;
 import com.vaadin.shared.ui.grid.renderers.LocalDateTimeRendererState;
 
 import elemental.json.JsonValue;
+import static com.vaadin.ui.renderers.LocalDateRenderer.checkSerialization;
 
 /**
  * A renderer for presenting {@code LocalDateTime} objects.
@@ -33,7 +35,7 @@ import elemental.json.JsonValue;
 public class LocalDateTimeRenderer
         extends AbstractRenderer<Object, LocalDateTime> {
 
-    private DateTimeFormatter formatter;
+    private SerializableSupplier<DateTimeFormatter> formatterSupplier;
     private boolean getLocaleFromGrid;
 
     /**
@@ -52,7 +54,7 @@ public class LocalDateTimeRenderer
      *      FormatStyle.SHORT</a>
      */
     public LocalDateTimeRenderer() {
-        this(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG,
+        this(() -> DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG,
                 FormatStyle.SHORT), "");
         getLocaleFromGrid = true;
     }
@@ -63,12 +65,21 @@ public class LocalDateTimeRenderer
      * The renderer is configured to render with the given formatter, with the
      * empty string as its null representation.
      *
+     * <p>
+     * <b>Note</b> the {@code DateTimeFormatter} is not a serializable class, so
+     * using this method in an environment which requires session persistence
+     * may produce {@link java.io.NotSerializableException}.
+     *
      * @param formatter
      *            the formatter to use, not {@code null}
      *
      * @throws IllegalArgumentException
      *             if formatter is null
+     * @deprecated the method is unsafe for serialization, may produce troubles
+     *             in a cluster environment
+     * @see #LocalDateTimeRenderer(SerializableSupplier)
      */
+    @Deprecated
     public LocalDateTimeRenderer(DateTimeFormatter formatter) {
         this(formatter, "");
     }
@@ -78,6 +89,12 @@ public class LocalDateTimeRenderer
      * <p>
      * The renderer is configured to render with the given formatter.
      *
+     * <p>
+     * <b>Note</b> the {@code DateTimeFormatter} is not a serializable class, so
+     * using this method in an environment which requires session persistence
+     * may produce {@link java.io.NotSerializableException}.
+     *
+     *
      * @param formatter
      *            the formatter to use, not {@code null}
      * @param nullRepresentation
@@ -85,7 +102,11 @@ public class LocalDateTimeRenderer
      *
      * @throws IllegalArgumentException
      *             if formatter is null
+     * @deprecated the method is unsafe for serialization, may produce troubles
+     *             in acluster environment
+     * @see #LocalDateTimeRenderer(SerializableSupplier, String)
      */
+    @Deprecated
     public LocalDateTimeRenderer(DateTimeFormatter formatter,
             String nullRepresentation) {
         super(LocalDateTime.class, nullRepresentation);
@@ -94,7 +115,7 @@ public class LocalDateTimeRenderer
             throw new IllegalArgumentException("formatter may not be null");
         }
 
-        this.formatter = formatter;
+        this.formatterSupplier = () -> formatter;
     }
 
     /**
@@ -179,7 +200,51 @@ public class LocalDateTimeRenderer
             throw new IllegalArgumentException("locale may not be null");
         }
 
-        formatter = DateTimeFormatter.ofPattern(formatPattern, locale);
+        formatterSupplier = () -> DateTimeFormatter.ofPattern(formatPattern,
+                locale);
+    }
+
+    /**
+     * Creates a new LocalDateTimeRenderer.
+     * <p>
+     * The renderer is configured to render with the given formatterSupplier.
+     *
+     * @param formatterSupplier
+     *            the formatterSupplier supplier to use, not {@code null}, it
+     *            should not supply {@code null} either
+     * @throws IllegalArgumentException
+     *             if formatterSupplier is null
+     */
+    public LocalDateTimeRenderer(
+            SerializableSupplier<DateTimeFormatter> formatterSupplier) {
+        this(formatterSupplier, "");
+    }
+
+    /**
+     * Creates a new LocalDateTimeRenderer.
+     * <p>
+     * The renderer is configured to render with the given formatterSupplier.
+     *
+     * @param formatterSupplier
+     *            the formatterSupplier supplier to use, not {@code null}, it
+     *            should not supply {@code null} either
+     * @param nullRepresentation
+     *            the textual representation of the {@code null} value
+     *
+     * @throws IllegalArgumentException
+     *             if formatterSupplier is null
+     */
+    public LocalDateTimeRenderer(
+            SerializableSupplier<DateTimeFormatter> formatterSupplier,
+            String nullRepresentation) {
+        super(LocalDateTime.class, nullRepresentation);
+
+        if (formatterSupplier == null) {
+            throw new IllegalArgumentException(
+                    "formatterSupplier may not be null");
+        }
+        this.formatterSupplier = formatterSupplier;
+        assert checkSerialization(formatterSupplier);
     }
 
     @Override
@@ -194,10 +259,10 @@ public class LocalDateTimeRenderer
                                 + "this renderer should either be attached to a grid "
                                 + "or constructed with locale information");
             }
-            dateString = value
-                    .format(formatter.withLocale(getParentGrid().getLocale()));
+            dateString = value.format(formatterSupplier.get()
+                    .withLocale(getParentGrid().getLocale()));
         } else {
-            dateString = value.format(formatter);
+            dateString = value.format(formatterSupplier.get());
         }
         return encode(dateString, String.class);
     }

--- a/server/src/test/java/com/vaadin/server/GlobalResourceHandlerTest.java
+++ b/server/src/test/java/com/vaadin/server/GlobalResourceHandlerTest.java
@@ -18,20 +18,26 @@ import static org.mockito.Mockito.when;
 public class GlobalResourceHandlerTest {
 
     @Test
-    public void globalResourceHandlerShouldWorkWithEncodedFilename() throws IOException {
+    public void globalResourceHandlerShouldWorkWithEncodedFilename()
+            throws IOException {
         assertEncodedFilenameIsHandled("simple.txt", "simple.txt");
         assertEncodedFilenameIsHandled("with spaces.txt", "with+spaces.txt");
         assertEncodedFilenameIsHandled("with # hash.txt", "with+%23+hash.txt");
-        assertEncodedFilenameIsHandled("with ; semicolon.txt", "with+%3B+semicolon.txt");
-        assertEncodedFilenameIsHandled("with , comma.txt", "with+%2C+comma.txt");
+        assertEncodedFilenameIsHandled("with ; semicolon.txt",
+                "with+%3B+semicolon.txt");
+        assertEncodedFilenameIsHandled("with , comma.txt",
+                "with+%2C+comma.txt");
 
-        // ResourceReference.encodeFileName does not encode slashes and backslashes
+        // ResourceReference.encodeFileName does not encode slashes and
+        // backslashes
         // See comment inside2 method for more details
-        assertEncodedFilenameIsHandled("with \\ backslash.txt", "with+\\+backslash.txt");
+        assertEncodedFilenameIsHandled("with \\ backslash.txt",
+                "with+\\+backslash.txt");
         assertEncodedFilenameIsHandled("with / slash.txt", "with+/+slash.txt");
     }
 
-    private void assertEncodedFilenameIsHandled(String filename, String expectedFilename) throws IOException {
+    private void assertEncodedFilenameIsHandled(String filename,
+            String expectedFilename) throws IOException {
         DownloadStream stream = mock(DownloadStream.class);
         ConnectorResource resource = mock(ConnectorResource.class);
         when(resource.getFilename()).thenReturn(filename);
@@ -58,11 +64,13 @@ public class GlobalResourceHandlerTest {
         VaadinResponse response = mock(VaadinResponse.class);
 
         // getPathInfo return path decoded but without decoding plus as spaces
-        when(request.getPathInfo()).thenReturn("APP/global/0/legacy/0/"+ filename.replace(" ", "+"));
+        when(request.getPathInfo()).thenReturn(
+                "APP/global/0/legacy/0/" + filename.replace(" ", "+"));
         when(session.getUIById(anyInt())).thenReturn(ui);
 
         // Verify that decoded path info is correctly handled
-        assertTrue("Request not handled", handler.handleRequest(session, request, response));
+        assertTrue("Request not handled",
+                handler.handleRequest(session, request, response));
         verify(stream).writeResponse(request, response);
     }
 }

--- a/server/src/test/java/com/vaadin/server/VaadinSessionTest.java
+++ b/server/src/test/java/com/vaadin/server/VaadinSessionTest.java
@@ -293,7 +293,7 @@ public class VaadinSessionTest implements Serializable {
 
         VaadinSession deserializedSession = (VaadinSession) in.readObject();
 
-        assertNull("Current session shouldn't leak from deserialisation",
+        assertNull("Current session shouldn't leak from deserialization",
                 VaadinSession.getCurrent());
 
         assertNotSame("Should get a new session", session, deserializedSession);

--- a/server/src/test/java/com/vaadin/tests/TestTemporalSerialization.java
+++ b/server/src/test/java/com/vaadin/tests/TestTemporalSerialization.java
@@ -1,0 +1,155 @@
+package com.vaadin.tests;
+
+import javax.swing.text.DateFormatter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Locale;
+
+import org.apache.commons.lang.SerializationUtils;
+import org.junit.Test;
+
+import com.vaadin.server.SerializableSupplier;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.renderers.LocalDateRenderer;
+import com.vaadin.ui.renderers.LocalDateTimeRenderer;
+
+import static java.lang.reflect.Modifier.isPublic;
+import static java.lang.reflect.Modifier.isStatic;
+import static junit.framework.TestCase.assertNotNull;
+
+public class TestTemporalSerialization {
+
+    @Test
+    public void smokeTestRendererSerialization()
+            throws IOException, ClassNotFoundException {
+        Grid<Object> grid = new Grid<>();
+        grid.addColumn(
+                o -> new Date(o.hashCode()).toInstant()
+                        .atZone(ZoneId.systemDefault()).toLocalDate(),
+                new LocalDateRenderer());
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutputStream = new ObjectOutputStream(
+                outputStream);
+        objectOutputStream.writeObject(grid);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(
+                outputStream.toByteArray());
+        Grid readGrid = (Grid) new ObjectInputStream(inputStream).readObject();
+        assertNotNull(readGrid.getColumns().get(0));
+    }
+
+    @Test
+    public void testLocalDateRenderer() throws IllegalAccessException,
+            InstantiationException, InvocationTargetException {
+        testSerialization(LocalDateRenderer.class);
+    }
+
+    @Test
+    public void testLocalDateTimeRenderer() throws IllegalAccessException,
+            InstantiationException, InvocationTargetException {
+        testSerialization(LocalDateTimeRenderer.class);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testAssertionFail() {
+        new LocalDateRenderer(new NonSerializableThing());
+    }
+
+    private static class NonSerializableThing
+            implements SerializableSupplier<DateTimeFormatter> {
+        public NonSerializableThing() {
+        }
+
+        private DateTimeFormatter useless = DateTimeFormatter.ofPattern("Y");
+
+        @Override
+        public DateTimeFormatter get() {
+            return useless;
+        }
+    }
+
+    private void testSerialization(Class<?> rendererClass)
+            throws IllegalAccessException, InvocationTargetException,
+            InstantiationException {
+        for (Constructor<?> constructor : rendererClass.getConstructors()) {
+            if (!isPublic(constructor.getModifiers()))
+                continue;
+            Object[] params = simulateParams(constructor);
+            if (params != null) {
+                Object o = constructor.newInstance(params);
+                checkSerialization(constructor, o);
+            }
+        }
+        for (Method method : rendererClass.getMethods()) {
+            if (!isPublic(method.getModifiers())
+                    || !isStatic(method.getModifiers())) {
+                continue;
+            }
+            if (!method.getReturnType().isAssignableFrom(rendererClass)) {
+                continue;
+            }
+            Object[] params = simulateParams(method);
+            if (params != null) {
+                Object o = method.invoke(simulateParams(method));
+                checkSerialization(method, o);
+            }
+        }
+    }
+
+    private Object[] simulateParams(Executable executable) {
+        Parameter[] parameters = executable.getParameters();
+        Object[] args = new Object[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            Parameter parameter = parameters[i];
+            Class<?> type = parameter.getType();
+            if (type.isAssignableFrom(String.class)) {
+                args[i] = "";
+            } else if (type.isAssignableFrom(Locale.class)) {
+                args[i] = Locale.US;
+            } else if (type.isAssignableFrom(SerializableSupplier.class)) {
+                Type genericType = ((ParameterizedType) parameter
+                        .getParameterizedType()).getActualTypeArguments()[0];
+                args[i] = (SerializableSupplier) () -> {
+                    try {
+                        return ((Class) genericType).newInstance();
+                    } catch (Exception e) {
+                        throw new AssertionError(e);
+                    }
+                };
+            } else if (type.isAssignableFrom(DateFormatter.class)
+                    || type.isAssignableFrom(DateTimeFormatter.class)) {
+                assertNotNull(
+                        "Non-deprecated code has non-serializable parameter: "
+                                + executable.toGenericString(),
+                        executable.getAnnotation(Deprecated.class));
+                return null;
+            } else {
+                throw new IllegalArgumentException(
+                        "Unsupported parameter type: " + type.getName());
+            }
+        }
+        return args;
+    }
+
+    private void checkSerialization(Executable method, Object o) {
+        try {
+            byte[] serialize = SerializationUtils.serialize((Serializable) o);
+            SerializationUtils.deserialize(serialize);
+        } catch (Throwable e) {
+            throw new AssertionError(method.toGenericString(), e);
+        }
+    }
+}

--- a/server/src/test/java/com/vaadin/tests/server/ClassesSerializableTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/ClassesSerializableTest.java
@@ -97,6 +97,7 @@ public class ClassesSerializableTest {
             "com\\.vaadin\\.server\\.communication\\.PushConnection", //
             "com\\.vaadin\\.server\\.communication\\.AtmospherePushConnection.*", //
             "com\\.vaadin\\.ui\\.components\\.colorpicker\\.ColorUtil", //
+            "com\\.vaadin\\.ui\\.renderers\\.LocalDateRenderer\\$.*", //
             "com\\.vaadin\\.util\\.ConnectorHelper", //
             "com\\.vaadin\\.server\\.VaadinSession\\$FutureAccess", //
             "com\\.vaadin\\.external\\..*", //

--- a/server/src/test/java/com/vaadin/tests/server/ClassesSerializableTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/ClassesSerializableTest.java
@@ -69,6 +69,7 @@ public class ClassesSerializableTest {
             "com\\.vaadin\\.server\\.communication\\.PushHandler.*", // PushHandler
             "com\\.vaadin\\.server\\.communication\\.DateSerializer", //
             "com\\.vaadin\\.server\\.communication\\.JSONSerializer", //
+            "com\\.vaadin\\.ui\\.declarative\\.DesignContext", //
             // and its inner classes do not need to be serializable
             "com\\.vaadin\\.util\\.SerializerHelper", // fully static
             // class level filtering, also affecting nested classes and
@@ -142,7 +143,7 @@ public class ClassesSerializableTest {
                 continue;
             }
 
-            if (Component.class.isAssignableFrom(cls) && !cls.isInterface()
+            if (!cls.isInterface()
                     && !Modifier.isAbstract(cls.getModifiers())) {
                 serializeAndDeserialize(cls);
             }


### PR DESCRIPTION
Unfortunately, there is no correct way to make `LocalDateFormatter` and `LocalDateTimeFormatter` serializable, and we have the only way to workaround the problem by providing alternative constructors.

Fixes #10175

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10919)
<!-- Reviewable:end -->
