### PR TITLE
Open methods to allow custom static file serving logic (#10910)

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -777,8 +777,10 @@ public class VaadinServlet extends HttpServlet implements Constants {
      *         otherwise.
      * @throws IOException
      * @throws ServletException
+     * 
+     * @since
      */
-    private boolean serveStaticResources(HttpServletRequest request,
+    protected boolean serveStaticResources(HttpServletRequest request,
             HttpServletResponse response) throws IOException, ServletException {
 
         String filePath = getStaticFilePath(request);
@@ -799,8 +801,10 @@ public class VaadinServlet extends HttpServlet implements Constants {
      * @param response
      * @throws IOException
      * @throws ServletException
+     * 
+     * @since
      */
-    private void serveStaticResourcesInVAADIN(String filename,
+    protected void serveStaticResourcesInVAADIN(String filename,
             HttpServletRequest request, HttpServletResponse response)
             throws IOException, ServletException {
 


### PR DESCRIPTION
* Open methods to allow custom static file serving logic

The methods serveStaticResources and serveStaticResourcesInVAADIN have
been changed from private to protected to allow subclasses to change how
static files are served.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10921)
<!-- Reviewable:end -->
