### PR TITLE
fixes double requireNonNull on same parameter in BindingValidationStatus ctor

### DIFF
--- a/server/src/main/java/com/vaadin/data/BinderValidationStatus.java
+++ b/server/src/main/java/com/vaadin/data/BinderValidationStatus.java
@@ -90,7 +90,7 @@ public class BinderValidationStatus<BEAN> implements Serializable {
     public BinderValidationStatus(Binder<BEAN> source,
             List<BindingValidationStatus<?>> bindingStatuses,
             List<ValidationResult> binderStatuses) {
-        Objects.requireNonNull(binderStatuses,
+        Objects.requireNonNull(bindingStatuses,
                 "binding statuses cannot be null");
         Objects.requireNonNull(binderStatuses,
                 "binder statuses cannot be null");

--- a/server/src/test/java/com/vaadin/data/BinderValidationStatusTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderValidationStatusTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -489,13 +490,12 @@ public class BinderValidationStatusTest
 
     @Test
     public void binderValidationStatus_nullBindingStatuses() {
-        boolean nonEmptyNPEThrown = false;
         try {
-            BinderValidationStatus<Person> bvs = new BinderValidationStatus<>(
-                    new Binder<Person>(), null, new ArrayList<>());
+            new BinderValidationStatus<>(new Binder<Person>(), null,
+                    new ArrayList<>());
+            Assert.fail("Binder should throw an NPE");
         } catch (NullPointerException npe) {
-            nonEmptyNPEThrown = npe.getMessage() != null;
+            assertNotNull(npe.getMessage());
         }
-        assertTrue(nonEmptyNPEThrown);
     }
 }

--- a/server/src/test/java/com/vaadin/data/BinderValidationStatusTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderValidationStatusTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -484,5 +485,17 @@ public class BinderValidationStatusTest
         assertNotNull(results);
         assertEquals(1, results.size());
         assertFalse(results.get(0).isError());
+    }
+
+    @Test
+    public void binderValidationStatus_nullBindingStatuses() {
+        boolean nonEmptyNPEThrown = false;
+        try {
+            BinderValidationStatus<Person> bvs = new BinderValidationStatus<>(
+                    new Binder<Person>(), null, new ArrayList<>());
+        } catch (NullPointerException npe) {
+            nonEmptyNPEThrown = npe.getMessage() != null;
+        }
+        assertTrue(nonEmptyNPEThrown);
     }
 }


### PR DESCRIPTION
BindingStatusValidator constructor was checking `Objects.requireNonNull` on `binderStatuses` twice.

**Check when you have completed**
[x] Valid tests for the pull request
[x] Contributing guidelines implemented

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10964)
<!-- Reviewable:end -->
