### PR TITLE
Add fallback resolvers for CurrentInstance

### DIFF
--- a/server/src/main/java/com/vaadin/util/CurrentInstance.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstance.java
@@ -61,7 +61,7 @@ public class CurrentInstance implements Serializable {
     private static final Object NULL_OBJECT = new Object();
     private static final CurrentInstance CURRENT_INSTANCE_NULL = new CurrentInstance(
             NULL_OBJECT, true);
-    private static final Map<Class<?>, CurrentInstanceFallbackResolver<?>> fallbackResolvers = new ConcurrentHashMap<Class<?>, CurrentInstanceFallbackResolver<?>>();
+    private static final ConcurrentHashMap<Class<?>, CurrentInstanceFallbackResolver<?>> fallbackResolvers = new ConcurrentHashMap<Class<?>, CurrentInstanceFallbackResolver<?>>();
 
     private final WeakReference<Object> instance;
     private final boolean inheritable;
@@ -176,13 +176,10 @@ public class CurrentInstance implements Serializable {
             throw new IllegalArgumentException(
                     "The fallback resolver can not be null.");
         }
-        synchronized (fallbackResolvers) {
-            if (fallbackResolvers.containsKey(type)) {
-                throw new IllegalArgumentException(
-                        "A fallback resolver for the type " + type
-                                + " is already defined.");
-            }
-            fallbackResolvers.put(type, fallbackResolver);
+        if (fallbackResolvers.putIfAbsent(type, fallbackResolver) != null) {
+            throw new IllegalArgumentException(
+                    "A fallback resolver for the type " + type
+                            + " is already defined.");
         }
     }
 

--- a/server/src/main/java/com/vaadin/util/CurrentInstance.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstance.java
@@ -87,11 +87,7 @@ public class CurrentInstance implements Serializable {
         }
     };
 
-    protected CurrentInstance() {
-        this(null, false);
-    }
-
-    private CurrentInstance(Object instance, boolean inheritable) {
+    protected CurrentInstance(Object instance, boolean inheritable) {
         this.instance = new WeakReference<Object>(instance);
         this.inheritable = inheritable;
     }

--- a/server/src/main/java/com/vaadin/util/CurrentInstance.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstance.java
@@ -172,16 +172,15 @@ public class CurrentInstance implements Serializable {
      */
     public static <T> void defineFallbackResolver(Class<T> type,
             CurrentInstanceFallbackResolver<T> fallbackResolver) {
-        if (fallbackResolvers.containsKey(type)) {
-            throw new IllegalArgumentException(
-                    "A fallback resolver for the type " + type
-                            + " is already defined.");
-        }
         if (fallbackResolver == null) {
             throw new IllegalArgumentException(
                     "The fallback resolver can not be null.");
         }
-        fallbackResolvers.put(type, fallbackResolver);
+        if (fallbackResolvers.putIfAbsent(type, fallbackResolver) != null) {
+            throw new IllegalArgumentException(
+                    "A fallback resolver for the type " + type
+                            + " is already defined.");
+        }
     }
 
     private static void removeStaleInstances(

--- a/server/src/main/java/com/vaadin/util/CurrentInstance.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstance.java
@@ -97,8 +97,8 @@ public class CurrentInstance implements Serializable {
      * <p>
      * When a current instance of the specific type is not found, the
      * {@link CurrentInstanceFallbackResolver} registered via
-     * {@link #setFallbackResolver(Class, CurrentInstanceFallbackResolver)} (if
-     * any) is invoked.
+     * {@link #defineFallbackResolver(Class, CurrentInstanceFallbackResolver)}
+     * (if any) is invoked.
      *
      * @param type
      *            the class to get an instance of
@@ -163,17 +163,25 @@ public class CurrentInstance implements Serializable {
      *            the class used on {@link #get(Class)} invocations to retrieve
      *            the current instance
      * @param fallbackResolver
-     *            the resolver, or <code>null</code> to clean any resolver that
-     *            was previously set for the given type
+     *            the resolver, not <code>null</code>
+     * 
+     * @throws IllegalArgumentException
+     *             if there's already a defined fallback resolver for the given
+     *             type
      * @since
      */
-    public static <T> void setFallbackResolver(Class<T> type,
+    public static <T> void defineFallbackResolver(Class<T> type,
             CurrentInstanceFallbackResolver<T> fallbackResolver) {
-        if (fallbackResolver == null) {
-            fallbackResolvers.remove(type);
-        } else {
-            fallbackResolvers.put(type, fallbackResolver);
+        if (fallbackResolvers.containsKey(type)) {
+            throw new IllegalArgumentException(
+                    "A fallback resolver for the type " + type
+                            + " is already defined.");
         }
+        if (fallbackResolver == null) {
+            throw new IllegalArgumentException(
+                    "The fallback resolver can not be null.");
+        }
+        fallbackResolvers.put(type, fallbackResolver);
     }
 
     private static void removeStaleInstances(

--- a/server/src/main/java/com/vaadin/util/CurrentInstance.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstance.java
@@ -176,10 +176,13 @@ public class CurrentInstance implements Serializable {
             throw new IllegalArgumentException(
                     "The fallback resolver can not be null.");
         }
-        if (fallbackResolvers.putIfAbsent(type, fallbackResolver) != null) {
-            throw new IllegalArgumentException(
-                    "A fallback resolver for the type " + type
-                            + " is already defined.");
+        synchronized (fallbackResolvers) {
+            if (fallbackResolvers.containsKey(type)) {
+                throw new IllegalArgumentException(
+                        "A fallback resolver for the type " + type
+                                + " is already defined.");
+            }
+            fallbackResolvers.put(type, fallbackResolver);
         }
     }
 

--- a/server/src/main/java/com/vaadin/util/CurrentInstance.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstance.java
@@ -87,7 +87,7 @@ public class CurrentInstance implements Serializable {
         }
     };
 
-    protected CurrentInstance(Object instance, boolean inheritable) {
+    private CurrentInstance(Object instance, boolean inheritable) {
         this.instance = new WeakReference<Object>(instance);
         this.inheritable = inheritable;
     }
@@ -160,14 +160,14 @@ public class CurrentInstance implements Serializable {
      * parameter.
      * 
      * @param type
-     *            the class used on {@link #get(Class)} invocations to retrive
+     *            the class used on {@link #get(Class)} invocations to retrieve
      *            the current instance
      * @param fallbackResolver
-     *            the resolver, of <code>null</code> to clean any resolver that
+     *            the resolver, or <code>null</code> to clean any resolver that
      *            was previously set for the given type
      * @since
      */
-    protected static <T> void setFallbackResolver(Class<T> type,
+    public static <T> void setFallbackResolver(Class<T> type,
             CurrentInstanceFallbackResolver<T> fallbackResolver) {
         if (fallbackResolver == null) {
             fallbackResolvers.remove(type);

--- a/server/src/main/java/com/vaadin/util/CurrentInstance.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstance.java
@@ -87,6 +87,10 @@ public class CurrentInstance implements Serializable {
         }
     };
 
+    protected CurrentInstance() {
+        this(null, false);
+    }
+
     private CurrentInstance(Object instance, boolean inheritable) {
         this.instance = new WeakReference<Object>(instance);
         this.inheritable = inheritable;
@@ -97,7 +101,7 @@ public class CurrentInstance implements Serializable {
      * <p>
      * When a current instance of the specific type is not found, the
      * {@link CurrentInstanceFallbackResolver} registered via
-     * {@link #addFallbackResolver(Class, CurrentInstanceFallbackResolver)} (if
+     * {@link #setFallbackResolver(Class, CurrentInstanceFallbackResolver)} (if
      * any) is invoked.
      *
      * @param type
@@ -163,23 +167,17 @@ public class CurrentInstance implements Serializable {
      *            the class used on {@link #get(Class)} invocations to retrive
      *            the current instance
      * @param fallbackResolver
-     *            the resolver
+     *            the resolver, of <code>null</code> to clean any resolver that
+     *            was previously set for the given type
      * @since
      */
-    public static <T> void addFallbackResolver(Class<T> type,
+    protected static <T> void setFallbackResolver(Class<T> type,
             CurrentInstanceFallbackResolver<T> fallbackResolver) {
-        fallbackResolvers.put(type, fallbackResolver);
-    }
-
-    /**
-     * Removes the {@link CurrentInstanceFallbackResolver} for the given type.
-     * 
-     * @param type
-     *            the class associated with the resolver
-     * @since
-     */
-    public static void removeFallbackResolver(Class<?> type) {
-        fallbackResolvers.remove(type);
+        if (fallbackResolver == null) {
+            fallbackResolvers.remove(type);
+        } else {
+            fallbackResolvers.put(type, fallbackResolver);
+        }
     }
 
     private static void removeStaleInstances(

--- a/server/src/main/java/com/vaadin/util/CurrentInstanceFallbackResolver.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstanceFallbackResolver.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.util;
+
+import java.io.Serializable;
+
+/**
+ * Fallback that is used to revolve current instances when they are not
+ * available by regular means.
+ * 
+ * @author Vaadin Ltd.
+ *
+ * @param <T>
+ *            the type of the instances returned by this resolver
+ * 
+ * @see CurrentInstance#get(Class)
+ * @see CurrentInstance#addFallbackResolver(Class,
+ *      CurrentInstanceFallbackResolver)
+ * 
+ * @since
+ * 
+ */
+public interface CurrentInstanceFallbackResolver<T> extends Serializable {
+
+    /**
+     * Resolves a current instance for the type {@code T}.
+     * 
+     * @return the current instance, or <code>null</code> if none can be found
+     */
+    T resolve();
+
+}

--- a/server/src/main/java/com/vaadin/util/CurrentInstanceFallbackResolver.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstanceFallbackResolver.java
@@ -31,7 +31,7 @@ import java.io.Serializable;
  *            the type of the instances returned by this resolver
  * 
  * @see CurrentInstance#get(Class)
- * @see CurrentInstance#setFallbackResolver(Class,
+ * @see CurrentInstance#defineFallbackResolver(Class,
  *      CurrentInstanceFallbackResolver)
  * 
  * @since

--- a/server/src/main/java/com/vaadin/util/CurrentInstanceFallbackResolver.java
+++ b/server/src/main/java/com/vaadin/util/CurrentInstanceFallbackResolver.java
@@ -21,6 +21,9 @@ import java.io.Serializable;
 /**
  * Fallback that is used to revolve current instances when they are not
  * available by regular means.
+ * <p>
+ * This interface is used internally by the framework and it's not meant for
+ * public usage.
  * 
  * @author Vaadin Ltd.
  *
@@ -28,7 +31,7 @@ import java.io.Serializable;
  *            the type of the instances returned by this resolver
  * 
  * @see CurrentInstance#get(Class)
- * @see CurrentInstance#addFallbackResolver(Class,
+ * @see CurrentInstance#setFallbackResolver(Class,
  *      CurrentInstanceFallbackResolver)
  * 
  * @since

--- a/server/src/test/java/com/vaadin/util/CurrentInstanceTest.java
+++ b/server/src/test/java/com/vaadin/util/CurrentInstanceTest.java
@@ -225,31 +225,28 @@ public class CurrentInstanceTest {
         TestFallbackResolver<UI> uiResolver = new TestFallbackResolver<UI>();
         CurrentInstance.setFallbackResolver(UI.class, uiResolver);
 
-        UI.getCurrent();
-        Assert.assertEquals(
-                "The UI fallback resolver should have been called exactly once",
-                1, uiResolver.getCalled());
-
         TestFallbackResolver<VaadinSession> sessionResolver = new TestFallbackResolver<VaadinSession>();
         CurrentInstance.setFallbackResolver(VaadinSession.class,
                 sessionResolver);
-
-        VaadinSession.getCurrent();
-        Assert.assertEquals(
-                "The VaadinSession fallback resolver should have been called exactly once",
-                1, sessionResolver.getCalled());
 
         TestFallbackResolver<VaadinService> serviceResolver = new TestFallbackResolver<VaadinService>();
         CurrentInstance.setFallbackResolver(VaadinService.class,
                 serviceResolver);
 
+        UI.getCurrent();
+        VaadinSession.getCurrent();
         VaadinService.getCurrent();
+        VaadinServlet.getCurrent();
+
         Assert.assertEquals(
-                "The VaadinService fallback resolver should have been called exactly once",
-                1, serviceResolver.getCalled());
+                "The UI fallback resolver should have been called exactly once",
+                1, uiResolver.getCalled());
+
+        Assert.assertEquals(
+                "The VaadinSession fallback resolver should have been called exactly once",
+                1, sessionResolver.getCalled());
 
         // the VaadinServlet.getCurrent() resolution uses the VaadinService type
-        VaadinServlet.getCurrent();
         Assert.assertEquals(
                 "The VaadinService fallback resolver should have been called exactly twice",
                 2, serviceResolver.getCalled());

--- a/server/src/test/java/com/vaadin/util/CurrentInstanceTest.java
+++ b/server/src/test/java/com/vaadin/util/CurrentInstanceTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.easymock.EasyMock;
 import org.hamcrest.CoreMatchers;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +33,7 @@ public class CurrentInstanceTest {
     }
 
     @Before
+    @After
     public void clearExistingFallbackResolvers() throws Exception {
         // Removes all static fallback resolvers
         Field field = CurrentInstance.class


### PR DESCRIPTION
This allow applications to inject custom default instances when the current instances cannot be found by regular means.

For example, when VaadinServlet.getCurrent() would return null, a fallback resolver could be invoked to properly create the servlet and return it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10974)
<!-- Reviewable:end -->
