### PR TITLE
Update JS RPC doc link syntax

### DIFF
--- a/documentation/articles/UsingRPCFromJavaScript.asciidoc
+++ b/documentation/articles/UsingRPCFromJavaScript.asciidoc
@@ -8,8 +8,8 @@ layout: page
 = Using RPC from JavaScript
 
 This tutorial continues where
-link:IntegratingAJavaScriptComponent.asciidoc[Integrating a JavaScript
-component] ended. We will now add RPC functionality to the JavaScript
+<<IntegratingAJavaScriptComponent.asciidoc#,"Integrating a JavaScript
+component">> ended. We will now add RPC functionality to the JavaScript
 Flot component. RPC can be used in the same way as with ordinary GWT
 components.
 


### PR DESCRIPTION
The old syntax links to `.asciidoc` instead of `.html` on vaadin.com/docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/10975)
<!-- Reviewable:end -->
