### PR TITLE
Improve ComboBox keyboard behavior when an item is selected

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VComboBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VComboBox.java
@@ -2361,9 +2361,13 @@ public class VComboBox extends Composite implements Field, KeyDownHandler,
             case KeyCodes.KEY_ALT:
             case KeyCodes.KEY_DOWN:
             case KeyCodes.KEY_UP:
+            case KeyCodes.KEY_RIGHT:
+            case KeyCodes.KEY_LEFT:
             case KeyCodes.KEY_PAGEDOWN:
             case KeyCodes.KEY_PAGEUP:
             case KeyCodes.KEY_ESCAPE:
+            case KeyCodes.KEY_HOME:
+            case KeyCodes.KEY_END:
                 // NOP
                 break;
             default:

--- a/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxCaretNavigation.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxCaretNavigation.java
@@ -1,0 +1,14 @@
+package com.vaadin.tests.components.combobox;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.ComboBox;
+
+public class ComboBoxCaretNavigation extends AbstractTestUI {
+    @Override
+    protected void setup(VaadinRequest request) {
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setItems("Badminton", "Chess", "Biking", "Running");
+        addComponent(comboBox);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxCaretNavigationTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxCaretNavigationTest.java
@@ -1,0 +1,80 @@
+package com.vaadin.tests.components.combobox;
+
+import com.vaadin.testbench.elements.ComboBoxElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class ComboBoxCaretNavigationTest extends SingleBrowserTest {
+
+    @Override
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+        openTestURL();
+    }
+
+    @Test
+    public void testHomeAndEndKeys() {
+        ComboBoxElement comboBox = $(ComboBoxElement.class).first();
+        String text = comboBox.getPopupSuggestions().get(1);
+        comboBox.selectByText(text);
+        comboBox.sendKeys(Keys.HOME);
+        assertCaretPosition("Home key didn't work well.", 0, comboBox);
+        comboBox.sendKeys(Keys.END);
+        assertCaretPosition("End key didn't work well.", text.length(), comboBox);
+    }
+
+    @Test
+    public void testLeftAndRightKeys() {
+        ComboBoxElement comboBox = $(ComboBoxElement.class).first();
+        String text = comboBox.getPopupSuggestions().get(1);
+        comboBox.selectByText(text);
+        comboBox.sendKeys(Keys.ARROW_LEFT);
+        assertCaretPosition("Left Arrow key didn't work well.", text.length() - 1, comboBox);
+        comboBox.sendKeys(Keys.ARROW_RIGHT);
+        assertCaretPosition("Right Arrow key didn't work well.", text.length(), comboBox);
+    }
+
+    @Test
+    public void testHomeAndRightKeys() {
+        ComboBoxElement comboBox = $(ComboBoxElement.class).first();
+        String text = comboBox.getPopupSuggestions().get(1);
+        comboBox.selectByText(text);
+        comboBox.sendKeys(Keys.HOME);
+        assertCaretPosition("Home key didn't work well.", 0, comboBox);
+        comboBox.sendKeys(Keys.ARROW_RIGHT);
+        assertCaretPosition("Right Arrow key didn't work well.", 1, comboBox);
+    }
+
+    @Test
+    public void testLeftAndEndKeys() {
+        ComboBoxElement comboBox = $(ComboBoxElement.class).first();
+        String text = comboBox.getPopupSuggestions().get(1);
+        comboBox.selectByText(text);
+        comboBox.sendKeys(Keys.ARROW_LEFT);
+        assertCaretPosition("Left Arrow key didn't work well.", text.length() - 1, comboBox);
+        comboBox.sendKeys(Keys.END);
+        assertCaretPosition("End key didn't work well.", text.length(), comboBox);
+    }
+
+    private void assertCaretPosition(String message, int position, ComboBoxElement comboBox) {
+        assertArrayEquals(message, new int[]{position, position},
+                getSelection(comboBox.getInputField()));
+    }
+
+    private int[] getSelection(WebElement element) {
+        @SuppressWarnings("unchecked")
+        List<Long> range = (List<Long>) executeScript(
+                "return [arguments[0].selectionStart,arguments[0].selectionEnd]",
+                element);
+        return new int[]{range.get(0).intValue(), range.get(1).intValue()};
+    }
+
+}


### PR DESCRIPTION
`filterOptions` method in `VComboBox` must not be called in `onKeyUp` when right arrow, left arrow, home or end key is pressed. So, these keys are added to ignore list. 
Fixes #11016

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11031)
<!-- Reviewable:end -->
