### PR TITLE
Make the Grid fast again

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
@@ -182,12 +182,12 @@ public class GridConnector extends AbstractHasComponentsConnector
             this.resizable = state.resizable;
             this.sortable = state.sortable;
             this.headerCaption = state.headerCaption == null ? "" : state.headerCaption;
+            this.widthUser = state.width;
+            this.minimumWidthPx = state.minWidth;
+            this.maximumWidthPx = state.maxWidth;
+            this.expandRatio = state.expandRatio;
+            this.editable = state.editable;
 
-            setWidth(state.width);
-            setMinimumWidth(state.minWidth);
-            setMaximumWidth(state.maxWidth);
-            setExpandRatio(state.expandRatio);
-            setEditable(state.editable);
             setEditorConnector((AbstractComponentConnector) state.editorConnector);
         }
 
@@ -946,11 +946,10 @@ public class GridConnector extends AbstractHasComponentsConnector
             // Remove old columns
             purgeRemovedColumns();
 
-            // Add new columns
+            // Update all columns
             updateColumnsFromState();
 
             getWidget().updateHeaderAndColSpans();
-
         }
         
         if (stateChangeEvent.hasPropertyChanged("columnOrder")) {

--- a/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
@@ -948,8 +948,6 @@ public class GridConnector extends AbstractHasComponentsConnector
 
             // Update all columns
             updateColumnsFromState();
-
-            getWidget().updateHeaderAndColSpans();
         }
         
         if (stateChangeEvent.hasPropertyChanged("columnOrder")) {

--- a/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
@@ -1144,7 +1144,7 @@ public class GridConnector extends AbstractHasComponentsConnector
      */
     private void addColumnsFromState() {
         this.columnsUpdatedFromState = true;
-        final List<Column<?, JsonObject>> columns = new ArrayList<>(getState().columns.size());
+        final List<Column<?, JsonObject>> columns = new ArrayList<Column<?, JsonObject>>(getState().columns.size());
         for (final GridColumnState state : getState().columns) {
             if (!this.columnIdToColumn.containsKey(state.id)) {
                 final CustomGridColumn column = new CustomGridColumn(state);

--- a/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
@@ -171,11 +171,22 @@ public class GridConnector extends AbstractHasComponentsConnector
 
         private HandlerRegistration errorStateHandler;
 
+        public CustomGridColumn(String id,
+                AbstractRendererConnector<Object> rendererConnector) {
+            super(rendererConnector.getRenderer());
+            this.rendererConnector = rendererConnector;
+            this.id = id;
+        }
+
+
+        /**
+         * Creates and initializes a custom grid column with attributes of given state.
+         *
+         * @param state with attributes to initialize the column.
+         */
         @SuppressWarnings("unchecked")
-        public CustomGridColumn(GridColumnState state) {
-            super(((AbstractRendererConnector<Object>) state.rendererConnector).getRenderer());
-            this.rendererConnector = (AbstractRendererConnector<Object>) state.rendererConnector;
-            this.id = state.id;
+        private CustomGridColumn(GridColumnState state) {
+            this(state.id, (AbstractRendererConnector<Object>)state.rendererConnector);
             this.hidingToggleCaption = state.hidingToggleCaption;
             this.hidden = state.hidden;
             this.hidable = state.hidable;

--- a/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
@@ -192,6 +192,19 @@ public class GridConnector extends AbstractHasComponentsConnector
         }
 
 
+        /**
+         * Sets a new renderer for this column object
+         *
+         * @param rendererConnector
+         *            a renderer connector object
+         */
+        public void setRenderer(
+                AbstractRendererConnector<Object> rendererConnector) {
+            setRenderer(rendererConnector.getRenderer());
+            this.rendererConnector = rendererConnector;
+        }
+
+
         @Override
         public Object getValue(final JsonObject obj) {
             final JsonObject rowData = obj.getObject(GridState.JSONKEY_DATA);
@@ -934,7 +947,7 @@ public class GridConnector extends AbstractHasComponentsConnector
             purgeRemovedColumns();
 
             // Add new columns
-            addColumnsFromState();
+            updateColumnsFromState();
 
             getWidget().updateHeaderAndColSpans();
 
@@ -1140,23 +1153,62 @@ public class GridConnector extends AbstractHasComponentsConnector
 
 
     /**
-     * Adds new columns to the grid widget from the current state.
+     * Update columns from the current state.
      */
-    private void addColumnsFromState() {
+    private void updateColumnsFromState() {
         this.columnsUpdatedFromState = true;
         final List<Column<?, JsonObject>> columns = new ArrayList<Column<?, JsonObject>>(getState().columns.size());
         for (final GridColumnState state : getState().columns) {
-            if (!this.columnIdToColumn.containsKey(state.id)) {
-                final CustomGridColumn column = new CustomGridColumn(state);
+            CustomGridColumn column = this.columnIdToColumn.get(state.id);
+            if (column == null) {
+                column = new CustomGridColumn(state);
                 this.columnIdToColumn.put(state.id, column);
                 this.columnOrder.add(state.id);
                 columns.add(column);
+            } else {
+                updateColumnFromState(column, state);
             }
         }
         @SuppressWarnings("unchecked")
         final Column<?, JsonObject>[] columnArray = columns.toArray(new Column[0]);
         getWidget().addColumns(columnArray);
         this.columnsUpdatedFromState = false;
+    }
+
+
+    /**
+     * Updates the column values from a state
+     *
+     * @param column
+     *            The column to update
+     * @param state
+     *            The state to get the data from
+     */
+    @SuppressWarnings("unchecked")
+    private static void updateColumnFromState(CustomGridColumn column,
+            GridColumnState state) {
+        column.setWidth(state.width);
+        column.setMinimumWidth(state.minWidth);
+        column.setMaximumWidth(state.maxWidth);
+        column.setExpandRatio(state.expandRatio);
+
+        assert state.rendererConnector instanceof AbstractRendererConnector : "GridColumnState.rendererConnector is invalid (not subclass of AbstractRendererConnector)";
+        column.setRenderer(
+                (AbstractRendererConnector<Object>) state.rendererConnector);
+
+        column.setSortable(state.sortable);
+
+        column.setResizable(state.resizable);
+
+        column.setHeaderCaption(state.headerCaption);
+
+        column.setHidden(state.hidden);
+        column.setHidable(state.hidable);
+        column.setHidingToggleCaption(state.hidingToggleCaption);
+
+        column.setEditable(state.editable);
+        column.setEditorConnector(
+                (AbstractComponentConnector) state.editorConnector);
     }
 
 

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -1356,23 +1356,6 @@ public class Escalator extends Widget
              */
             if (isAttached()) {
                 paintInsertRows(index, numberOfRows);
-
-                if (rows == numberOfRows) {
-                    /*
-                     * We are inserting the first rows in this container. We
-                     * potentially need to set the widths for the cells for the
-                     * first time.
-                     */
-                    Map<Integer, Double> colWidths = new HashMap<Integer, Double>();
-                    for (int i = 0; i < getColumnConfiguration()
-                            .getColumnCount(); i++) {
-                        Double width = Double.valueOf(
-                                getColumnConfiguration().getColumnWidth(i));
-                        Integer col = Integer.valueOf(i);
-                        colWidths.put(col, width);
-                    }
-                    getColumnConfiguration().setColumnWidths(colWidths);
-                }
             }
         }
 

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -6541,6 +6541,9 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             sinkEvents(events);
         }
         this.columnHider.updateTogglesOrder();
+        refreshHeader();
+        this.header.updateColSpans();
+        this.footer.updateColSpans();
     }
 
 
@@ -9366,15 +9369,5 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         }
         return ((HasUserSelectionAllowed) getSelectionModel())
                 .isUserSelectionAllowed();
-    }
-
-
-    /**
-     * Updates the header row container and the colspans.
-     */
-    public void updateHeaderAndColSpans() {
-        refreshHeader();
-        header.updateColSpans();
-        footer.updateColSpans();
     }
 }

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -6498,10 +6498,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
     private <C extends Column<?, T>> void addColumnsSkipSelectionColumnCheck(Collection<C> columnCollection, int index) {
         int visibleNewColumns = 0;
+        int currentIndex = index;
 
         for (final Column<?, T> column : columnCollection) {
             // Register column with grid
-            this.columns.add(column);
+            this.columns.add(currentIndex++, column);
             this.footer.addColumn(column);
             this.header.addColumn(column);
 

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -7098,7 +7098,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         assert escalator.getBody().getRowCount() == 0;
 
         int size = dataSource.size();
-
+        if (size == -1 && isAttached()) {
+            // Exact size is not yet known, start with some reasonable guess
+            // just to get an initial backend request going
+            size = getEscalator().getMaxVisibleRowCount();
+        }
         if (size > 0) {
             escalator.getBody().insertRows(0, size);
         }

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -4775,10 +4775,9 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         private Grid<T> grid;
 
         /**
-         * Width of column in pixels as {@link #setWidth(double)} has been
-         * called
+         * Width of column in pixels as {@link #setWidth(double)} has been called.
          */
-        private double widthUser = GridConstants.DEFAULT_COLUMN_WIDTH_PX;
+        protected double widthUser = GridConstants.DEFAULT_COLUMN_WIDTH_PX;
 
         /**
          * Renderer for rendering a value into the cell
@@ -4820,9 +4819,20 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
          */
         protected String hidingToggleCaption = null;
 
-        private double minimumWidthPx = GridConstants.DEFAULT_MIN_WIDTH;
-        private double maximumWidthPx = GridConstants.DEFAULT_MAX_WIDTH;
-        private int expandRatio = GridConstants.DEFAULT_EXPAND_RATIO;
+        /**
+         * The minimum width in pixels of this column.
+         */
+        protected double minimumWidthPx = GridConstants.DEFAULT_MIN_WIDTH;
+
+        /**
+         * The maximum width in pixels of this column.
+         */
+        protected double maximumWidthPx = GridConstants.DEFAULT_MAX_WIDTH;
+
+        /**
+         * The expand ratio of this column.
+         */
+        protected int expandRatio = GridConstants.DEFAULT_EXPAND_RATIO;
 
         /**
          * Constructs a new column with a simple TextRenderer.
@@ -6507,7 +6517,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             this.header.addColumn(column);
 
             // Register this grid instance with the column
-            ((Column<?, T>) column).setGrid(this);
+            column.setGrid(this);
 
             if (!column.isHidden()) {
                 visibleNewColumns++;

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -6497,9 +6497,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
 
     private <C extends Column<?, T>> void addColumnsSkipSelectionColumnCheck(Collection<C> columnCollection, int index) {
-//        final Map<Integer, Double> columnWidths = new HashMap<>();
         int visibleNewColumns = 0;
-//        int currentColumnIndex = index;
 
         for (final Column<?, T> column : columnCollection) {
             // Register column with grid
@@ -6512,16 +6510,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
             if (!column.isHidden()) {
                 visibleNewColumns++;
-//                if (column.getWidth() > 0) {
-//                    columnWidths.put(currentColumnIndex, column.getWidth());
-//                }
             }
-//            currentColumnIndex++;
         }
         if (visibleNewColumns > 0) {
             final ColumnConfiguration columnConfiguration = this.escalator.getColumnConfiguration();
             columnConfiguration.insertColumns(index, visibleNewColumns);
-//            columnConfiguration.setColumnWidths(columnWidths);
         }
         for (final Column<?, T> column : columnCollection) {
             // Reapply column width

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -2497,7 +2497,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
     private class CellFocusHandler {
 
-        private RowContainer containerWithFocus = escalator.getHeader();
+        private RowContainer containerWithFocus = escalator.getBody();
         private int rowWithFocus = 0;
         private Range cellFocusRange = Range.withLength(0, 1);
         private int lastFocusedBodyRow = 0;

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -2497,7 +2497,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
     private class CellFocusHandler {
 
-        private RowContainer containerWithFocus = escalator.getBody();
+        private RowContainer containerWithFocus = escalator.getHeader();
         private int rowWithFocus = 0;
         private Range cellFocusRange = Range.withLength(0, 1);
         private int lastFocusedBodyRow = 0;
@@ -4782,19 +4782,40 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
          */
         private Renderer<? super C> bodyRenderer;
 
-        private boolean sortable = false;
+        /**
+         * The sortable state of this column.
+         */
+        protected boolean sortable = false;
 
-        private boolean editable = true;
+        /**
+         * The editable state of this column.
+         */
+        protected boolean editable = true;
 
-        private boolean resizable = true;
+        /**
+         * The resizable state of this column.
+         */
+        protected boolean resizable = true;
 
-        private boolean hidden = false;
+        /**
+         * The hidden state of this column.
+         */
+        protected boolean hidden = false;
 
-        private boolean hidable = false;
+        /**
+         * The hidable state of this column.
+         */
+        protected boolean hidable = false;
 
-        private String headerCaption = "";
+        /**
+         * The header-caption of this column.
+         */
+        protected String headerCaption = "";
 
-        private String hidingToggleCaption = null;
+        /**
+         * The hiding-toggle-caption of this column.
+         */
+        protected String hidingToggleCaption = null;
 
         private double minimumWidthPx = GridConstants.DEFAULT_MIN_WIDTH;
         private double maximumWidthPx = GridConstants.DEFAULT_MAX_WIDTH;
@@ -6419,9 +6440,24 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *            the columns to add
      */
     public void addColumns(Column<?, T>... columns) {
-        int count = getColumnCount();
+        final int count = getColumnCount();
         for (Column<?, T> column : columns) {
-            addColumn(column, count++);
+            checkColumnIsValidToAdd(column, count);
+        }
+        addColumnsSkipSelectionColumnCheck(Arrays.asList(columns), count);
+    }
+
+
+    /**
+     * Checks the given column is valid to add at the given index.
+     */
+    private void checkColumnIsValidToAdd(Column<?, T> column, int index) {
+        if (column == this.selectionColumn) {
+            throw new IllegalArgumentException(
+                    "The selection column many " + "not be added manually");
+        } else if (this.selectionColumn != null && index == 0) {
+            throw new IllegalStateException("A column cannot be inserted "
+                    + "before the selection column");
         }
     }
 
@@ -6451,54 +6487,54 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *             and {@code index} is 0.
      */
     public <C extends Column<?, T>> C addColumn(C column, int index) {
-        if (column == selectionColumn) {
-            throw new IllegalArgumentException(
-                    "The selection column many " + "not be added manually");
-        } else if (selectionColumn != null && index == 0) {
-            throw new IllegalStateException("A column cannot be inserted "
-                    + "before the selection column");
-        }
-
-        addColumnSkipSelectionColumnCheck(column, index);
+        checkColumnIsValidToAdd(column, index);
+        addColumnsSkipSelectionColumnCheck(Arrays.asList(column), index);
         return column;
     }
 
-    private void addColumnSkipSelectionColumnCheck(Column<?, T> column,
-            int index) {
-        // Register column with grid
-        columns.add(index, column);
 
-        header.addColumn(column);
-        footer.addColumn(column);
+    private <C extends Column<?, T>> void addColumnsSkipSelectionColumnCheck(Collection<C> columnCollection, int index) {
+//        final Map<Integer, Double> columnWidths = new HashMap<>();
+        int visibleNewColumns = 0;
+//        int currentColumnIndex = index;
 
-        // Register this grid instance with the column
-        ((Column<?, T>) column).setGrid(this);
+        for (final Column<?, T> column : columnCollection) {
+            // Register column with grid
+            this.columns.add(column);
+            this.footer.addColumn(column);
+            this.header.addColumn(column);
 
-        // Grid knows about hidden columns, Escalator only knows about what is
-        // visible so column indexes do not match
-        if (!column.isHidden()) {
-            int escalatorIndex = index;
-            for (int existingColumn = 0; existingColumn < index; existingColumn++) {
-                if (getColumn(existingColumn).isHidden()) {
-                    escalatorIndex--;
-                }
+            // Register this grid instance with the column
+            ((Column<?, T>) column).setGrid(this);
+
+            if (!column.isHidden()) {
+                visibleNewColumns++;
+//                if (column.getWidth() > 0) {
+//                    columnWidths.put(currentColumnIndex, column.getWidth());
+//                }
             }
-            escalator.getColumnConfiguration().insertColumns(escalatorIndex, 1);
+//            currentColumnIndex++;
         }
-
-        // Reapply column width
-        column.reapplyWidth();
-
-        // Sink all renderer events
-        Set<String> events = new HashSet<String>();
-        events.addAll(getConsumedEventsForRenderer(column.getRenderer()));
-
-        if (column.isHidable()) {
-            columnHider.updateColumnHidable(column);
+        if (visibleNewColumns > 0) {
+            final ColumnConfiguration columnConfiguration = this.escalator.getColumnConfiguration();
+            columnConfiguration.insertColumns(index, visibleNewColumns);
+//            columnConfiguration.setColumnWidths(columnWidths);
         }
+        for (final Column<?, T> column : columnCollection) {
+            // Reapply column width
+            column.reapplyWidth();
+            // Sink all renderer events
+            Set<String> events = new HashSet<String>();
+            events.addAll(getConsumedEventsForRenderer(column.getRenderer()));
 
-        sinkEvents(events);
+            if (column.isHidable()) {
+                this.columnHider.updateColumnHidable(column);
+            }
+
+            sinkEvents(events);
+        }
     }
+
 
     private void sinkEvents(Collection<String> events) {
         assert events != null;
@@ -7054,11 +7090,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         assert escalator.getBody().getRowCount() == 0;
 
         int size = dataSource.size();
-        if (size == -1 && isAttached()) {
-            // Exact size is not yet known, start with some reasonable guess
-            // just to get an initial backend request going
-            size = getEscalator().getMaxVisibleRowCount();
-        }
+
         if (size > 0) {
             escalator.getBody().insertRows(0, size);
         }
@@ -7891,7 +7923,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             cellFocusHandler.offsetRangeBy(1);
             selectionColumn = new SelectionColumn(selectColumnRenderer);
 
-            addColumnSkipSelectionColumnCheck(selectionColumn, 0);
+            addColumnsSkipSelectionColumnCheck(Arrays.asList(selectionColumn), 0);
 
             selectionColumn.setEnabled(isEnabled());
             selectionColumn.initDone();
@@ -9322,5 +9354,15 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         }
         return ((HasUserSelectionAllowed) getSelectionModel())
                 .isUserSelectionAllowed();
+    }
+
+
+    /**
+     * Updates the header row container and the colspans.
+     */
+    public void updateHeaderAndColSpans() {
+        refreshHeader();
+        header.updateColSpans();
+        footer.updateColSpans();
     }
 }

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -4051,7 +4051,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
          */
         private boolean hidingColumn;
 
-        private void updateColumnHidable(final Column<?, T> column) {
+        private void updateColumnHidable(final Column<?, T> column, boolean skipOrdering) {
             if (column.isHidable()) {
                 MenuItem toggle = columnToHidingToggleMap.get(column);
                 if (toggle == null) {
@@ -4062,7 +4062,10 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 sidebar.menuBar
                         .removeItem(columnToHidingToggleMap.remove(column));
             }
-            updateTogglesOrder();
+            if (!skipOrdering) {
+                updateTogglesOrder();
+            }
+
         }
 
         private MenuItem createToggle(final Column<?, T> column) {
@@ -5236,7 +5239,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         public Column<C, T> setHidable(boolean hidable) {
             if (this.hidable != hidable) {
                 this.hidable = hidable;
-                grid.columnHider.updateColumnHidable(this);
+                grid.columnHider.updateColumnHidable(this, false);
             }
             return this;
         }
@@ -6528,11 +6531,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             events.addAll(getConsumedEventsForRenderer(column.getRenderer()));
 
             if (column.isHidable()) {
-                this.columnHider.updateColumnHidable(column);
+                this.columnHider.updateColumnHidable(column, true);
             }
 
             sinkEvents(events);
         }
+        this.columnHider.updateTogglesOrder();
     }
 
 


### PR DESCRIPTION
Make the Grid fast again.

As described in several issues, the Grid render performance is not as good as expected, especially if it's configured with many columns.

This change solves these issues by avoiding loops with multiple calls to the same functions for every column.
This was also introduced in parts by tsuoanttila with https://github.com/vaadin/framework/pull/10579 for Vaadin 8. This change solves these issues in Vaadin 7.7

Additionally removed the column-width calculation in escaltor on paintInsertRows, because the calculation will be anyway scheduled.

Because this is a performance issue, no test classes are provided, instead I provide some benchmark data to show the improvement of this change.

This benchmark was measured with Chrome 67.

[grid-performance.pdf](https://github.com/vaadin/framework/files/2184831/grid-performance.pdf)

As you can see the performance increases significantly.

This is the first change to increase the performance of the Grid in Vaadin 7.7. A second change, which optimizes the automatic column width calculation, will follow in case this pull request will be successfully merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11043)
<!-- Reviewable:end -->
