### PR TITLE
Fix initially selected CheckBox rendering in Safari (#11024)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VCheckBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCheckBox.java
@@ -16,9 +16,12 @@
 
 package com.vaadin.client.ui;
 
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.dom.client.Style.Visibility;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
 import com.vaadin.client.ApplicationConnection;
@@ -103,5 +106,25 @@ public class VCheckBox extends com.google.gwt.user.client.ui.CheckBox
     @Override
     public void setAriaInvalid(boolean invalid) {
         AriaHelper.handleInputInvalid(getCheckBoxElement(), invalid);
+    }
+
+    @Override
+    protected void onAttach() {
+        super.onAttach();
+
+        if (BrowserInfo.get().isSafari()) {
+            /*
+             * Sometimes Safari does not render checkbox correctly when
+             * attaching. Setting the visibility to hidden and a bit later
+             * restoring will make everything just fine.
+             */
+            getElement().getStyle().setVisibility(Visibility.HIDDEN);
+            Scheduler.get().scheduleFinally(new ScheduledCommand() {
+                @Override
+                public void execute() {
+                    getElement().getStyle().setVisibility(Visibility.VISIBLE);
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
Cherry-picked fix for #11024 to 7.7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11047)
<!-- Reviewable:end -->
