### PR TITLE
Fix Grid resetting row height on resize

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -9146,9 +9146,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
 
             if (getEscalatorInnerHeight() != autoColumnWidthsRecalculator.lastCalculatedInnerHeight) {
-                RowContainer.BodyRowContainer body = getEscalator().getBody();
-                // Trigger re-calculation of all row positions.
-                body.setDefaultRowHeight(body.getDefaultRowHeight());
+                Scheduler.get().scheduleFinally(() -> {
+                    // Trigger re-calculation of all row positions.
+                    RowContainer.BodyRowContainer body = getEscalator()
+                            .getBody();
+                    body.setDefaultRowHeight(body.getDefaultRowHeight());
+                });
             }
 
             // Vertical resizing could make editor positioning invalid so it

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -9146,7 +9146,9 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
 
             if (getEscalatorInnerHeight() != autoColumnWidthsRecalculator.lastCalculatedInnerHeight) {
-                resetSizesFromDom();
+                RowContainer.BodyRowContainer body = getEscalator().getBody();
+                // Trigger re-calculation of all row positions.
+                body.setDefaultRowHeight(body.getDefaultRowHeight());
             }
 
             // Vertical resizing could make editor positioning invalid so it


### PR DESCRIPTION
This patch improves the initial fix in #11046 making it work with Grid row height

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11056)
<!-- Reviewable:end -->
