### PR TITLE
Update version numbers in Release Notes

### DIFF
--- a/all/src/main/templates/release-notes.html
+++ b/all/src/main/templates/release-notes.html
@@ -353,12 +353,12 @@
         </p>
 
         <ul id="supportedservers">
-            <li>Apache Tomcat 7-8</li>
+            <li>Apache Tomcat 7-9</li>
             <li>Apache TomEE 1.7 and 7.0</li>
             <li>Oracle WebLogic Server 12.2</li>
             <li>IBM WebSphere Application Server 9</li>
             <li>JBoss EAP 6</li>
-            <li>Wildfly 8-11</li>
+            <li>Wildfly 8-13</li>
             <li>Jetty 8-9</li>
             <li>Glassfish 4</li>
             <li>Payara Server 164</li>
@@ -381,11 +381,11 @@
         </p>
 
         <ul>
-            <li>Mozilla Firefox (latest version, currently 54)</li>
-            <li>Mozilla Firefox ESR (latest version, currently 52 ESR)</li>
+            <li>Mozilla Firefox 54+</li>
+            <li>Mozilla Firefox ESR 52+</li>
             <li>Internet Explorer 11, Edge (latest version)</li>
             <li>Safari 9+</li>
-            <li>Google Chrome (latest version, currently 59)</li>
+            <li>Google Chrome 59+</li>
         </ul>
 
         <p>

--- a/test/servlet-containers/pom.xml
+++ b/test/servlet-containers/pom.xml
@@ -237,6 +237,8 @@
             <modules>
                 <module>jsp-integration</module>
                 <module>karaf</module>
+                <module>wildfly13</module>
+                <module>wildfly12</module>
                 <module>wildfly11</module>
                 <module>wildfly10</module>
                 <module>wildfly9</module>
@@ -266,6 +268,8 @@
         <profile>
             <id>wildfly</id>
             <modules>
+                <module>wildfly13</module>
+                <module>wildfly12</module>
                 <module>wildfly11</module>
                 <module>wildfly10</module>
                 <module>wildfly9</module>

--- a/test/servlet-containers/wildfly12/pom.xml
+++ b/test/servlet-containers/wildfly12/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-servlet-containers-test</artifactId>
+        <version>8.6-SNAPSHOT</version>
+    </parent>
+    <artifactId>vaadin-test-wildfly12-server</artifactId>
+    <name>Vaadin Wildfly 12 Test</name>
+    <packaging>war</packaging>
+    <properties>
+        <jetty.skip>true</jetty.skip>
+        <wildfly.version>12.0.0.Final</wildfly.version>
+        <server.name>wildfly12</server.name>
+    </properties>
+
+    <dependencies>
+        <!-- UI classes and tests from dependencies -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-test-server-ui</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-test-server-tests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Server configuration -->
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test/servlet-containers/wildfly13/pom.xml
+++ b/test/servlet-containers/wildfly13/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-servlet-containers-test</artifactId>
+        <version>8.6-SNAPSHOT</version>
+    </parent>
+    <artifactId>vaadin-test-wildfly13-server</artifactId>
+    <name>Vaadin Wildfly 13 Test</name>
+    <packaging>war</packaging>
+    <properties>
+        <jetty.skip>true</jetty.skip>
+        <wildfly.version>13.0.0.Final</wildfly.version>
+        <server.name>wildfly13</server.name>
+    </properties>
+
+    <dependencies>
+        <!-- UI classes and tests from dependencies -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-test-server-ui</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-test-server-tests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Server configuration -->
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
This patch also introduces missing tests for newer Wildfly versions.

Addresses #11050

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11062)
<!-- Reviewable:end -->
