### PR TITLE
Change documentation code samples to produce expected output

### DIFF
--- a/documentation/datamodel/datamodel-items.asciidoc
+++ b/documentation/datamodel/datamodel-items.asciidoc
@@ -72,9 +72,11 @@ almost any POJOs with minimal requirements.
 
 ----
 // Here is a bean (or more exactly a POJO)
-class Person {
+public class Person {
     String name;
-    int    age;
+    int    yearOfBirth;
+
+    // Constructors omitted
     
     public String getName() {
         return name;
@@ -84,12 +86,12 @@ class Person {
         this.name = name;
     }
     
-    public Integer getAge() {
-        return age;
+    public Integer getYearOfBirth() {
+        return yearOfBirth;
     }
     
-    public void setAge(Integer age) {
-        this.age = age.intValue();
+    public void setYearOfBirth(Integer yearOfBirth) {
+        this.yearOfBirth = yearOfBirth.intValue();
     }
 }
 
@@ -156,7 +158,7 @@ item.addItemProperty("discoverername",
 // The other way is to use regular MethodProperty.
 item.addItemProperty("discovererborn",
      new MethodProperty<Person>(planet.getDiscoverer(),
-                                "born"));
+                                "yearOfBirth"));
 ----
 
 The difference is that [classname]#NestedMethodProperty# does not access the

--- a/documentation/datamodel/datamodel-items.asciidoc
+++ b/documentation/datamodel/datamodel-items.asciidoc
@@ -74,9 +74,12 @@ almost any POJOs with minimal requirements.
 // Here is a bean (or more exactly a POJO)
 public class Person {
     String name;
-    int    yearOfBirth;
+    int yearOfBirth;
 
-    // Constructors omitted
+    public Person(String name, int yearOfBirth) {
+        this.name = name;
+        this.yearOfBirth = yearOfBirth;
+    }
     
     public String getName() {
         return name;
@@ -86,12 +89,12 @@ public class Person {
         this.name = name;
     }
     
-    public Integer getYearOfBirth() {
+    public int getYearOfBirth() {
         return yearOfBirth;
     }
     
-    public void setYearOfBirth(Integer yearOfBirth) {
-        this.yearOfBirth = yearOfBirth.intValue();
+    public void setYearOfBirth(int yearOfBirth) {
+        this.yearOfBirth = yearOfBirth;
     }
 }
 


### PR DESCRIPTION
I used ```yearOfBirth``` field name used in Vaadin 8 documentation sample, which fits more nicely than ```age```.
Also, when trying to create property from said field, wrong ```born``` field name is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11093)
<!-- Reviewable:end -->
