### PR TITLE
Force re-updating the resolutions of DateField

### DIFF
--- a/server/src/main/java/com/vaadin/ui/AbstractDateField.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractDateField.java
@@ -111,6 +111,7 @@ public abstract class AbstractDateField<T extends Temporal & TemporalAdjuster & 
                 hasChanges |= !Objects.equals(dateString, newDateString)
                         || !Objects.equals(oldDate, newDate)
                         || parseErrorWasSet;
+
                 if (hasChanges) {
                     dateString = newDateString;
                     currentParseErrorMessage = null;
@@ -139,6 +140,7 @@ public abstract class AbstractDateField<T extends Temporal & TemporalAdjuster & 
                                 dateString = null;
                                 currentParseErrorMessage = parsedDate
                                         .getMessage().orElse("Parsing error");
+
                                 if (!isDifferentValue(null)) {
                                     doSetValue(null);
                                 } else {
@@ -793,6 +795,7 @@ public abstract class AbstractDateField<T extends Temporal & TemporalAdjuster & 
             errorMessage = new UserError(currentParseErrorMessage);
         }
         setComponentError(errorMessage);
+
         updateResolutions();
     }
 

--- a/server/src/main/java/com/vaadin/ui/AbstractDateField.java
+++ b/server/src/main/java/com/vaadin/ui/AbstractDateField.java
@@ -111,7 +111,6 @@ public abstract class AbstractDateField<T extends Temporal & TemporalAdjuster & 
                 hasChanges |= !Objects.equals(dateString, newDateString)
                         || !Objects.equals(oldDate, newDate)
                         || parseErrorWasSet;
-
                 if (hasChanges) {
                     dateString = newDateString;
                     currentParseErrorMessage = null;
@@ -140,7 +139,6 @@ public abstract class AbstractDateField<T extends Temporal & TemporalAdjuster & 
                                 dateString = null;
                                 currentParseErrorMessage = parsedDate
                                         .getMessage().orElse("Parsing error");
-
                                 if (!isDifferentValue(null)) {
                                     doSetValue(null);
                                 } else {
@@ -520,6 +518,7 @@ public abstract class AbstractDateField<T extends Temporal & TemporalAdjuster & 
             Integer defaultValuePart = getValuePart(defaultValue, resolution);
             resolutions.put("default-" + resolutionName, defaultValuePart);
         }
+        updateDiffstate("resolutions", Json.createObject());
     }
 
     private Integer getValuePart(T date, R resolution) {
@@ -794,7 +793,6 @@ public abstract class AbstractDateField<T extends Temporal & TemporalAdjuster & 
             errorMessage = new UserError(currentParseErrorMessage);
         }
         setComponentError(errorMessage);
-
         updateResolutions();
     }
 

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListener.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListener.java
@@ -6,6 +6,7 @@ import com.vaadin.ui.Button;
 import com.vaadin.ui.DateField;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 
 public class DateFieldResetValueWithinListener extends AbstractTestUI {
 
@@ -19,6 +20,7 @@ public class DateFieldResetValueWithinListener extends AbstractTestUI {
         df.setDateFormat("d.M.yyyy");
         df.setId("dateField1");
         df.setValue(initialValue);
+        df.setZoneId(ZoneId.of("Europe/Helsinki"));
         df.addValueChangeListener(evt -> {
             if (evt.getValue().isAfter(initialValue)) {
                 df.setValue(beforeInitialValue);

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListener.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListener.java
@@ -6,7 +6,7 @@ import com.vaadin.ui.Button;
 import com.vaadin.ui.DateField;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
+import java.util.Locale;
 
 public class DateFieldResetValueWithinListener extends AbstractTestUI {
 
@@ -20,7 +20,7 @@ public class DateFieldResetValueWithinListener extends AbstractTestUI {
         df.setDateFormat("d.M.yyyy");
         df.setId("dateField1");
         df.setValue(initialValue);
-        df.setZoneId(ZoneId.of("Europe/Helsinki"));
+        df.setLocale(Locale.ENGLISH);
         df.addValueChangeListener(evt -> {
             if (evt.getValue().isAfter(initialValue)) {
                 df.setValue(beforeInitialValue);

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListener.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListener.java
@@ -9,22 +9,26 @@ import java.time.LocalDate;
 
 public class DateFieldResetValueWithinListener extends AbstractTestUI {
 
+    public static LocalDate initialValue = LocalDate.of(2018, 8, 4);
+    public static LocalDate beforeInitialValue = LocalDate.of(2018, 7, 13);
+
     @Override
     protected void setup(VaadinRequest request) {
-        LocalDate sourceDate = LocalDate.now();
-        DateField df = new DateField("Date: ");
+        LocalDate defaultDate = LocalDate.of(2018, 9, 4);
+        DateField df = new DateField("Date: ", defaultDate);
         df.setDateFormat("d.M.yyyy");
         df.setId("dateField1");
-        df.setValue(sourceDate);
+        df.setValue(initialValue);
         df.addValueChangeListener(evt -> {
-            if (evt.getValue().isAfter(sourceDate)) {
-                df.setValue(LocalDate.now());
+            if (evt.getValue().isAfter(initialValue)) {
+                df.setValue(beforeInitialValue);
             }
         });
 
         addComponent(df);
         Button setV = new Button("Set date after the current", e -> {
-            df.setValue(LocalDate.now().plusDays(5));
+            LocalDate afterButtonPress = LocalDate.of(2018, 9, 12);
+            df.setValue(afterButtonPress);
         });
         setV.setId("setValueButton");
         addComponent(setV);

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListener.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListener.java
@@ -1,0 +1,32 @@
+package com.vaadin.tests.components.datefield;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.DateField;
+
+import java.time.LocalDate;
+
+public class DateFieldResetValueWithinListener extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        LocalDate sourceDate = LocalDate.now();
+        DateField df = new DateField("Date: ");
+        df.setDateFormat("d.M.yyyy");
+        df.setId("dateField1");
+        df.setValue(sourceDate);
+        df.addValueChangeListener(evt -> {
+            if (evt.getValue().isAfter(sourceDate)) {
+                df.setValue(LocalDate.now());
+            }
+        });
+
+        addComponent(df);
+        Button setV = new Button("Set date after the current", e -> {
+            df.setValue(LocalDate.now().plusDays(5));
+        });
+        setV.setId("setValueButton");
+        addComponent(setV);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListenerTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListenerTest.java
@@ -1,0 +1,25 @@
+package com.vaadin.tests.components.datefield;
+
+import com.vaadin.testbench.By;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.Assert.assertEquals;
+
+public class DateFieldResetValueWithinListenerTest extends MultiBrowserTest {
+
+    @Test
+    public void testValueReassigned() {
+        openTestURL();
+        // Click button to change the value to be 5 days ahead. It should cause
+        // dateField to reset the value to today
+        findElement(By.id("setValueButton")).click();
+        String text = findElement(By.tagName("input")).getAttribute("value");
+        assertEquals(
+                LocalDate.now().format(DateTimeFormatter.ofPattern("d.M.yyyy")),
+                text);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListenerTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListenerTest.java
@@ -14,12 +14,19 @@ public class DateFieldResetValueWithinListenerTest extends MultiBrowserTest {
     @Test
     public void testValueReassigned() {
         openTestURL();
-        // Click button to change the value to be 5 days ahead. It should cause
-        // dateField to reset the value to today
-        findElement(By.id("setValueButton")).click();
-        String text = findElement(By.tagName("input")).getAttribute("value");
+
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("d.M.yyyy");
+        String textBefore = findElement(By.tagName("input"))
+                .getAttribute("value");
         assertEquals(
-                LocalDate.now().format(DateTimeFormatter.ofPattern("d.M.yyyy")),
-                text);
+                DateFieldResetValueWithinListener.initialValue.format(format),
+                textBefore);
+
+        findElement(By.id("setValueButton")).click();
+
+        String textAfter = findElement(By.tagName("input"))
+                .getAttribute("value");
+        assertEquals(DateFieldResetValueWithinListener.beforeInitialValue
+                .format(format), textAfter);
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListenerTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldResetValueWithinListenerTest.java
@@ -4,8 +4,8 @@ import com.vaadin.testbench.By;
 import com.vaadin.tests.tb3.MultiBrowserTest;
 import org.junit.Test;
 
-import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
@@ -15,7 +15,8 @@ public class DateFieldResetValueWithinListenerTest extends MultiBrowserTest {
     public void testValueReassigned() {
         openTestURL();
 
-        DateTimeFormatter format = DateTimeFormatter.ofPattern("d.M.yyyy");
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("d.M.yyyy",
+                Locale.ENGLISH);
         String textBefore = findElement(By.tagName("input"))
                 .getAttribute("value");
         assertEquals(


### PR DESCRIPTION
When value in the DF is changed on the client and as the response to ValueChangeEvent value is changed back on server, the change is not propagated to the client.
Through the value is correctly updated on the server
Fix https://github.com/vaadin/framework/issues/11099

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11159)
<!-- Reviewable:end -->
