### PR TITLE
Ensure that HeaderRow is not null in Grid

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -3411,6 +3411,8 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
             // Make SelectAllCheckbox visible
             getSelectionColumn().ifPresent(col -> {
+                if (getDefaultHeaderRow() == null)
+                    return;
                 HeaderCell headerCell = getDefaultHeaderRow().getCell(col);
                 if (headerCell.getType().equals(GridStaticCellType.WIDGET)) {
                     // SelectAllCheckbox is present already

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridColumnWidthWithoutHeader.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridColumnWidthWithoutHeader.java
@@ -1,0 +1,22 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.data.ValueProvider;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Grid;
+
+public class GridColumnWidthWithoutHeader extends AbstractTestUI {
+    @Override
+    protected void setup(VaadinRequest request) {
+        Grid<String> grid = new Grid<>();
+        grid.addColumn(ValueProvider.identity()).setExpandRatio(1)
+                .setMinimumWidth(250);
+        grid.addColumn(String::valueOf).setWidth(150);
+        grid.setItems("a", "b");
+        grid.setSelectionMode(Grid.SelectionMode.MULTI);
+        grid.setSizeFull();
+
+        grid.removeHeaderRow(0);
+        addComponent(grid);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridColumnWidthWithoutHeaderTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridColumnWidthWithoutHeaderTest.java
@@ -1,14 +1,13 @@
 package com.vaadin.tests.components.grid;
 
 import com.vaadin.testbench.elements.GridElement;
-import com.vaadin.tests.tb3.MultiBrowserTest;
+import com.vaadin.tests.tb3.SingleBrowserTest;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
 import static org.junit.Assert.assertTrue;
 
-public class GridColumnWidthWithoutHeaderTest extends MultiBrowserTest {
-    public static final int THREASHOLD = 3;
+public class GridColumnWidthWithoutHeaderTest extends SingleBrowserTest {
+    public static final int THRESHOLD = 3;
 
     @Test
     public void testWidthWithoutHeader() {
@@ -17,7 +16,7 @@ public class GridColumnWidthWithoutHeaderTest extends MultiBrowserTest {
         GridElement grid = $(GridElement.class).first();
         int columnsWidth = getColWidthsRounded(grid);
         assertTrue(Math
-                .abs(columnsWidth - grid.getSize().getWidth()) <= THREASHOLD);
+                .abs(columnsWidth - grid.getSize().getWidth()) <= THRESHOLD);
     }
 
     private int getColWidthsRounded(GridElement grid) {

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridColumnWidthWithoutHeaderTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridColumnWidthWithoutHeaderTest.java
@@ -8,7 +8,7 @@ import org.openqa.selenium.By;
 import static org.junit.Assert.assertTrue;
 
 public class GridColumnWidthWithoutHeaderTest extends MultiBrowserTest {
-    public static final int THREASHOLD = 2;
+    public static final int THREASHOLD = 3;
 
     @Test
     public void testWidthWithoutHeader() {
@@ -16,10 +16,6 @@ public class GridColumnWidthWithoutHeaderTest extends MultiBrowserTest {
 
         GridElement grid = $(GridElement.class).first();
         int columnsWidth = getColWidthsRounded(grid);
-        // int gridWrapperWidth=
-        // getDriver().findElement(By.className("v-grid-tablewrapper")).getSize().getWidth();
-        System.out.println(grid.getSize().getWidth());
-        System.out.println(columnsWidth);
         assertTrue(Math
                 .abs(columnsWidth - grid.getSize().getWidth()) <= THREASHOLD);
     }
@@ -27,7 +23,7 @@ public class GridColumnWidthWithoutHeaderTest extends MultiBrowserTest {
     private int getColWidthsRounded(GridElement grid) {
         GridElement.GridRowElement firstRow = grid.getRow(0);
         int width = 0;
-        for (int i = 0; i < 2; i++) {
+        for (int i = 0; i < 3; i++) {
             width = width + firstRow.getCell(i).getSize().getWidth();
         }
         return width;

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridColumnWidthWithoutHeaderTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridColumnWidthWithoutHeaderTest.java
@@ -1,0 +1,35 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.testbench.elements.GridElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import static org.junit.Assert.assertTrue;
+
+public class GridColumnWidthWithoutHeaderTest extends MultiBrowserTest {
+    public static final int THREASHOLD = 2;
+
+    @Test
+    public void testWidthWithoutHeader() {
+        openTestURL();
+
+        GridElement grid = $(GridElement.class).first();
+        int columnsWidth = getColWidthsRounded(grid);
+        // int gridWrapperWidth=
+        // getDriver().findElement(By.className("v-grid-tablewrapper")).getSize().getWidth();
+        System.out.println(grid.getSize().getWidth());
+        System.out.println(columnsWidth);
+        assertTrue(Math
+                .abs(columnsWidth - grid.getSize().getWidth()) <= THREASHOLD);
+    }
+
+    private int getColWidthsRounded(GridElement grid) {
+        GridElement.GridRowElement firstRow = grid.getRow(0);
+        int width = 0;
+        for (int i = 0; i < 2; i++) {
+            width = width + firstRow.getCell(i).getSize().getWidth();
+        }
+        return width;
+    }
+}


### PR DESCRIPTION
Fix #10485

If header row is not present, than there is no need to make SelectAllCheckbox visible. Otherwise, NPE is thrown on the client side and widths is not applied properly.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11165)
<!-- Reviewable:end -->
