### PR TITLE
Remove objects from ActiveDataHandler that are no longer available in used DataProvider

### DIFF
--- a/server/src/main/java/com/vaadin/data/provider/DataCommunicator.java
+++ b/server/src/main/java/com/vaadin/data/provider/DataCommunicator.java
@@ -140,6 +140,13 @@ public class DataCommunicator<T> extends AbstractExtension {
         }
 
         /**
+         * Marks all currently active data objects to be dropped.
+         */
+        public void dropAllActiveData() {
+            activeData.forEach(this::dropActiveData);
+        }
+        
+        /**
          * Marks a data object identified by given key string to be dropped.
          *
          * @param key
@@ -151,6 +158,19 @@ public class DataCommunicator<T> extends AbstractExtension {
             }
         }
 
+        /**
+         * Returns whether given data object is marked as dropped.
+         *
+         * @param dataObject
+         *            the item to show details for
+         *
+         * @return {@code true} if marked as dropped
+         *         {@code false} if not
+         */
+        public boolean isDropped(T dataObject) {
+            return droppedData.contains(getKeyMapper().key(dataObject));
+        }
+        
         /**
          * Returns all currently active data mapped by their id from
          * DataProvider.
@@ -329,6 +349,10 @@ public class DataCommunicator<T> extends AbstractExtension {
         }
 
         if (initial || reset) {
+            if (reset) {
+                handler.dropAllActiveData();
+            }
+            
             rpc.reset(getDataProviderSize());
         }
 

--- a/server/src/main/java/com/vaadin/data/provider/DataCommunicator.java
+++ b/server/src/main/java/com/vaadin/data/provider/DataCommunicator.java
@@ -159,16 +159,14 @@ public class DataCommunicator<T> extends AbstractExtension {
         }
 
         /**
-         * Returns whether given data object is marked as dropped.
+         * Returns all dropped data mapped by their id from DataProvider.
          *
-         * @param dataObject
-         *            the item to show details for
-         *
-         * @return {@code true} if marked as dropped
-         *         {@code false} if not
+         * @return map of ids to dropped data objects
          */
-        public boolean isDropped(T dataObject) {
-            return droppedData.contains(getKeyMapper().key(dataObject));
+        protected Map<Object, T> getDroppedData() {
+            Function<T, Object> getId = getDataProvider()::getId;
+            return droppedData.stream().map(getKeyMapper()::get)
+                    .collect(Collectors.toMap(getId, i -> i));
         }
 
         /**

--- a/server/src/main/java/com/vaadin/data/provider/DataCommunicator.java
+++ b/server/src/main/java/com/vaadin/data/provider/DataCommunicator.java
@@ -141,6 +141,8 @@ public class DataCommunicator<T> extends AbstractExtension {
 
         /**
          * Marks all currently active data objects to be dropped.
+         *
+         * @since
          */
         public void dropAllActiveData() {
             activeData.forEach(this::dropActiveData);
@@ -162,6 +164,8 @@ public class DataCommunicator<T> extends AbstractExtension {
          * Returns all dropped data mapped by their id from DataProvider.
          *
          * @return map of ids to dropped data objects
+         *
+         * @since
          */
         protected Map<Object, T> getDroppedData() {
             Function<T, Object> getId = getDataProvider()::getId;

--- a/server/src/main/java/com/vaadin/data/provider/DataCommunicator.java
+++ b/server/src/main/java/com/vaadin/data/provider/DataCommunicator.java
@@ -145,7 +145,7 @@ public class DataCommunicator<T> extends AbstractExtension {
         public void dropAllActiveData() {
             activeData.forEach(this::dropActiveData);
         }
-        
+
         /**
          * Marks a data object identified by given key string to be dropped.
          *
@@ -170,7 +170,7 @@ public class DataCommunicator<T> extends AbstractExtension {
         public boolean isDropped(T dataObject) {
             return droppedData.contains(getKeyMapper().key(dataObject));
         }
-        
+
         /**
          * Returns all currently active data mapped by their id from
          * DataProvider.
@@ -352,7 +352,7 @@ public class DataCommunicator<T> extends AbstractExtension {
             if (reset) {
                 handler.dropAllActiveData();
             }
-            
+
             rpc.reset(getDataProviderSize());
         }
 

--- a/server/src/test/java/com/vaadin/data/provider/DataCommunicatorTest.java
+++ b/server/src/test/java/com/vaadin/data/provider/DataCommunicatorTest.java
@@ -227,11 +227,12 @@ public class DataCommunicatorTest {
 
         communicator.beforeClientResponse(false);
 
-        //assert that test object is marked as removed
+        // assert that test object is marked as removed
         assertTrue("Object not marked as dropped",
                 handler.getDroppedData().containsKey(TEST_OBJECT));
 
-        communicator.setPushRows(Range.between(0, communicator.getMinPushSize()));
+        communicator
+                .setPushRows(Range.between(0, communicator.getMinPushSize()));
         communicator.beforeClientResponse(false);
 
         assertFalse("Object still mapped by key mapper",

--- a/server/src/test/java/com/vaadin/data/provider/DataCommunicatorTest.java
+++ b/server/src/test/java/com/vaadin/data/provider/DataCommunicatorTest.java
@@ -228,23 +228,23 @@ public class DataCommunicatorTest {
         communicator.beforeClientResponse(false);
 
         //assert that test object is marked as removed
-        assertTrue("Object not marked as dropped", 
+        assertTrue("Object not marked as dropped",
                 handler.isDropped(TEST_OBJECT));
 
         communicator.setPushRows(Range.between(0, communicator.getMinPushSize()));
         communicator.beforeClientResponse(false);
 
-        assertFalse("Object still mapped by key mapper", 
+        assertFalse("Object still mapped by key mapper",
                 keyMapper.has(TEST_OBJECT));
-        assertTrue("Object not mapped by key mapper", 
+        assertTrue("Object not mapped by key mapper",
                 keyMapper.has(TEST_OBJECT_TWO));
 
-        assertFalse("Object still amongst active data", 
+        assertFalse("Object still amongst active data",
                 handler.getActiveData().containsKey(TEST_OBJECT));
-        assertTrue("Object not amongst active data", 
+        assertTrue("Object not amongst active data",
                 handler.getActiveData().containsKey(TEST_OBJECT_TWO));
     }
-    
+
     @Test
     public void testDestroyData() {
         session.lock();

--- a/server/src/test/java/com/vaadin/data/provider/DataCommunicatorTest.java
+++ b/server/src/test/java/com/vaadin/data/provider/DataCommunicatorTest.java
@@ -229,7 +229,7 @@ public class DataCommunicatorTest {
 
         //assert that test object is marked as removed
         assertTrue("Object not marked as dropped",
-                handler.isDropped(TEST_OBJECT));
+                handler.getDroppedData().containsKey(TEST_OBJECT));
 
         communicator.setPushRows(Range.between(0, communicator.getMinPushSize()));
         communicator.beforeClientResponse(false);


### PR DESCRIPTION
Related to #10471
on behalf of @tomasblahut:


After calling _DataProvider#refreshAll()_, objects, that were previously kept as active by _DataCommunicator.ActiveDataHandler_ (hereafter refered to as "_ActiveDataHandler_"), but are no longer supplied by current _DataProvider_, are not dropped from _ActiveDataHandler_ and stay active. 

Consider a use case where _Grid_ is displaying data from a _ListDataProvider_ and some of its columns use _Components_ in order to render cells content. Then replacing contents of _ListDataProvider#backend_ collection (with objects, for which _DataProvider#getId(object)_ yields a different id than for those previous ones) and calling _DataProvider#refreshAll()_ afterwards results in increasing attached _Component_ count and client side rendering performance drop.

This change causes all active objects inside _ActiveDataHandler_ to be marked as dropped while _DataCommunicator_ is sending data to client with _reset_ field set to `true`. Existing logic for dropping active objects inside _ActiveDataHandler_ prevents objects, requested by client side after reset has occured, from being dropped, even if they are marked that way. Dropping "old no longer available" objects from _ActiveDataHandler_, enables _DataCommunicator_ to destroy them and detach any _Components_ created by e.g. _Grid.Column_ _ValueProviders_.

Bellow is a simple _UI_ describing a way in which this issue can be reproduced. Increasing _Component_ count (_Referenced paintables_ variable using debug window) can be observed with every press of a button.

```java
public class MyUI extends UI {

    private static final int GRID_ROW_COUNT = 20;
    
    private final List<GridRowPojo> gridRowObjects = new ArrayList<>();

    @Override
    protected void init(VaadinRequest vaadinRequest) {
        refreshGridRowObjects();
        setContent(prepareLayout());
    }

    private void refreshGridRowObjects() {
        gridRowObjects.clear();

        for (int index = 0; index < GRID_ROW_COUNT; index++) {
            gridRowObjects.add(new GridRowPojo(UUID.randomUUID().toString()));
        }
    }

    private VerticalLayout prepareLayout() {
        Grid<GridRowPojo> grid = new Grid<>();
        grid.setSizeFull();
        grid.addColumn(source -> {
            TextField textField = new TextField();
            textField.setValue(source.getName());
            return textField;
        }, new ComponentRenderer());
        grid.setDataProvider(DataProvider.ofCollection(gridRowObjects));

        Button btnRefresh = new Button("Refresh [new objects]", event -> {
            refreshGridRowObjects();
            grid.getDataProvider().refreshAll();
        });

        HorizontalLayout layBtns = new HorizontalLayout(btnRefresh);

        VerticalLayout layout = new VerticalLayout(grid, layBtns);
        layout.setSizeFull();
        layout.setExpandRatio(grid, 1.0f);
        return layout;
    }

    @WebServlet(urlPatterns = "/*", name = "MyUIServlet", asyncSupported = true)
    @VaadinServletConfiguration(ui = MyUI.class, productionMode = false)
    public static class MyUIServlet extends VaadinServlet {
    }

    public static class GridRowPojo {

        private final String name;

        public GridRowPojo(String name) {
            this.name = name;
        }

        public String getName() {
            return name;
        }
    }
}

```


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11167)
<!-- Reviewable:end -->
