### PR TITLE
Eliminate initial double rendering during initial rendering

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/GridConnector.java
@@ -908,74 +908,82 @@ public class GridConnector extends AbstractHasComponentsConnector
     public void onStateChanged(final StateChangeEvent stateChangeEvent) {
         super.onStateChanged(stateChangeEvent);
 
-        // Deferring updates to scheduleFinally, otherwise updates are
-        // performed immediatelly, and again later when state change happens
-        Scheduler.get().scheduleFinally(new ScheduledCommand() {
-            @Override
-            public void execute() {
-                initialChange = stateChangeEvent.isInitialStateChange();
-
-                // Column updates
-                if (stateChangeEvent.hasPropertyChanged("columns")) {
-
-                    // Remove old columns
-                    purgeRemovedColumns();
-
-                    // Add new columns
-                    for (GridColumnState state : getState().columns) {
-                        if (!columnIdToColumn.containsKey(state.id)) {
-                            addColumnFromStateChangeEvent(state);
-                        }
-                        updateColumnFromStateChangeEvent(state);
-                    }
+        initialChange = stateChangeEvent.isInitialStateChange();
+        
+        if (initialChange) {
+            Scheduler.get().scheduleFinally(new ScheduledCommand() {
+                @Override
+                public void execute() {
+                    doUpdateFromStateChangeEvent(stateChangeEvent);
                 }
+            });
+        } else {
+            doUpdateFromStateChangeEvent(stateChangeEvent);
+        }
+    }
 
-                if (stateChangeEvent.hasPropertyChanged("columnOrder")) {
-                    if (orderNeedsUpdate(getState().columnOrder)) {
-                        updateColumnOrderFromState(getState().columnOrder);
-                    }
-                }
+    private void doUpdateFromStateChangeEvent(
+            final StateChangeEvent stateChangeEvent) {
 
-                // Column resize mode
-                if (stateChangeEvent.hasPropertyChanged("columnResizeMode")) {
-                    getWidget().setColumnResizeMode(getState().columnResizeMode);
-                }
+    	// Column updates
+        if (stateChangeEvent.hasPropertyChanged("columns")) {
 
-                // Header and footer
-                if (stateChangeEvent.hasPropertyChanged("header")) {
-                    updateHeaderFromState(getState().header);
-                }
+            // Remove old columns
+            purgeRemovedColumns();
 
-                if (stateChangeEvent.hasPropertyChanged("footer")) {
-                    updateFooterFromState(getState().footer);
+            // Add new columns
+            for (GridColumnState state : getState().columns) {
+                if (!columnIdToColumn.containsKey(state.id)) {
+                    addColumnFromStateChangeEvent(state);
                 }
-
-                // Sorting
-                if (stateChangeEvent.hasPropertyChanged("sortColumns")
-                        || stateChangeEvent.hasPropertyChanged("sortDirs")) {
-                    onSortStateChange();
-                }
-
-                // Editor
-                if (stateChangeEvent.hasPropertyChanged("editorEnabled")) {
-                    getWidget().setEditorEnabled(getState().editorEnabled);
-                }
-
-                // Frozen columns
-                if (stateChangeEvent.hasPropertyChanged("frozenColumnCount")) {
-                    getWidget().setFrozenColumnCount(getState().frozenColumnCount);
-                }
-
-                // Theme features
-                String activeTheme = getConnection().getUIConnector().getActiveTheme();
-                if (lastKnownTheme == null) {
-                    lastKnownTheme = activeTheme;
-                } else if (!lastKnownTheme.equals(activeTheme)) {
-                    getWidget().resetSizesFromDom();
-                    lastKnownTheme = activeTheme;
-                }
+                updateColumnFromStateChangeEvent(state);
             }
-        });
+        }
+        
+        if (stateChangeEvent.hasPropertyChanged("columnOrder")) {
+            if (orderNeedsUpdate(getState().columnOrder)) {
+                updateColumnOrderFromState(getState().columnOrder);
+            }
+        }
+
+        // Column resize mode
+        if (stateChangeEvent.hasPropertyChanged("columnResizeMode")) {
+            getWidget().setColumnResizeMode(getState().columnResizeMode);
+        }
+
+        // Header and footer
+        if (stateChangeEvent.hasPropertyChanged("header")) {
+            updateHeaderFromState(getState().header);
+        }
+
+        if (stateChangeEvent.hasPropertyChanged("footer")) {
+            updateFooterFromState(getState().footer);
+        }
+
+        // Sorting
+        if (stateChangeEvent.hasPropertyChanged("sortColumns")
+                || stateChangeEvent.hasPropertyChanged("sortDirs")) {
+            onSortStateChange();
+        }
+
+        // Editor
+        if (stateChangeEvent.hasPropertyChanged("editorEnabled")) {
+            getWidget().setEditorEnabled(getState().editorEnabled);
+        }
+
+        // Frozen columns
+        if (stateChangeEvent.hasPropertyChanged("frozenColumnCount")) {
+            getWidget().setFrozenColumnCount(getState().frozenColumnCount);
+        }
+
+        // Theme features
+        String activeTheme = getConnection().getUIConnector().getActiveTheme();
+        if (lastKnownTheme == null) {
+            lastKnownTheme = activeTheme;
+        } else if (!lastKnownTheme.equals(activeTheme)) {
+            getWidget().resetSizesFromDom();
+            lastKnownTheme = activeTheme;
+        }
     }
 
     private void updateColumnOrderFromState(List<String> stateColumnOrder) {


### PR DESCRIPTION
Eliminating initial double rendering during initial rendering, which will be improving performance of the Grid dramatically. This is done by deferring calculations triggered by onStateChange to happen later.

This is performance improvement, and hence tests not included, since there is no reliable way to test this improvement. Full test results needs to be analyzed to check there is no regressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11199)
<!-- Reviewable:end -->
