### PR TITLE
Revert change to fix issue on removing Grid with components

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/grid/ComponentRendererConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/ComponentRendererConnector.java
@@ -25,7 +25,6 @@ import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.client.ComponentConnector;
 import com.vaadin.client.ConnectorMap;
-import com.vaadin.client.ServerConnector;
 import com.vaadin.client.renderers.Renderer;
 import com.vaadin.client.renderers.WidgetRenderer;
 import com.vaadin.client.ui.AbstractComponentConnector;
@@ -44,16 +43,10 @@ import com.vaadin.ui.renderers.ComponentRenderer;
  */
 @Connect(ComponentRenderer.class)
 public class ComponentRendererConnector
-        extends AbstractGridRendererConnector<String> {
+    extends AbstractGridRendererConnector<String> {
 
     private HashSet<String> knownConnectors = new HashSet<>();
     private HandlerRegistration handlerRegistration;
-
-    @Override
-    public void setParent(ServerConnector parent) {
-        super.setParent(parent);
-        createConnectorHierarchyChangeHandler();
-    }
 
     @Override
     protected Renderer<String> createRenderer() {
@@ -68,12 +61,12 @@ public class ComponentRendererConnector
 
             @Override
             public void render(RendererCellReference cell, String connectorId,
-                    SimplePanel widget) {
-                assert handlerRegistration != null : "HirarchyChangeHandler should not be null when rendering.";
+                               SimplePanel widget) {
+                createConnectorHierarchyChangeHandler();
                 Widget connectorWidget = null;
                 if (connectorId != null) {
                     ComponentConnector connector = (ComponentConnector) ConnectorMap
-                            .get(getConnection()).getConnector(connectorId);
+                        .get(getConnection()).getConnector(connectorId);
                     if (connector != null) {
                         connectorWidget = connector.getWidget();
                         knownConnectors.add(connectorId);
@@ -102,26 +95,23 @@ public class ComponentRendererConnector
 
     /**
      * Adds a listener for grid hierarchy changes to find detached connectors
-     * previously handled by this renderer in order to detach from DOM their
-     * widgets before {@link AbstractComponentConnector#onUnregister()} is
-     * invoked otherwise an error message is logged.
+     * previously handled by this renderer in order to detach from DOM their widgets
+     * before {@link AbstractComponentConnector#onUnregister()} is invoked
+     * otherwise an error message is logged.
      */
     private void createConnectorHierarchyChangeHandler() {
-        assert handlerRegistration == null : "Trying to re-initialize HierarchyChangeHandler";
-        handlerRegistration = getGridConnector()
-                .addConnectorHierarchyChangeHandler(event -> {
-                    Iterator<String> iterator = knownConnectors.iterator();
-                    while (iterator.hasNext()) {
-                        ComponentConnector connector = (ComponentConnector) ConnectorMap
-                                .get(getConnection())
-                                .getConnector(iterator.next());
-                        if (connector != null
-                                && connector.getParent() == null) {
-                            connector.getWidget().removeFromParent();
-                            iterator.remove();
-                        }
+        if (handlerRegistration == null) {
+            handlerRegistration = getGridConnector().addConnectorHierarchyChangeHandler(event -> {
+                Iterator<String> iterator = knownConnectors.iterator();
+                while (iterator.hasNext()) {
+                    ComponentConnector connector = (ComponentConnector) ConnectorMap.get(getConnection()).getConnector(iterator.next());
+                    if (connector != null && connector.getParent() == null) {
+                        connector.getWidget().removeFromParent();
+                        iterator.remove();
                     }
-                });
+                }
+            });
+        }
     }
 
     private void unregisterHierarchyHandler() {

--- a/server/src/main/java/com/vaadin/ui/components/grid/GridMultiSelect.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/GridMultiSelect.java
@@ -84,7 +84,7 @@ public class GridMultiSelect<T> implements MultiSelect<T> {
     /**
      * Selects the given item. If another item was already selected, that item
      * is deselected.
-     *
+     * 
      * @param item
      *            the item to select
      */

--- a/server/src/main/java/com/vaadin/ui/components/grid/GridSingleSelect.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/GridSingleSelect.java
@@ -211,7 +211,7 @@ public class GridSingleSelect<T> implements SingleSelect<T> {
     /**
      * Selects the given item. If another item was already selected, that item
      * is deselected.
-     *
+     * 
      * @param item
      *            the item to select
      */

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridComponentsVisibility.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridComponentsVisibility.java
@@ -24,9 +24,9 @@ public class GridComponentsVisibility extends AbstractTestUIWithLog {
     protected void setup(VaadinRequest request) {
         Grid<String> grid = new Grid<>();
         grid.addColumn(string -> new Label(string), new ComponentRenderer())
-                .setId("label").setCaption("Column 0");
+            .setId("label").setCaption("Column 0");
         grid.getDefaultHeaderRow().getCell("label")
-                .setComponent(new Label("Label"));
+            .setComponent(new Label("Label"));
         grid.addComponentColumn(string -> {
             if (textFields.containsKey(string)) {
                 log("Reusing old text field for: " + string);
@@ -41,7 +41,7 @@ public class GridComponentsVisibility extends AbstractTestUIWithLog {
         grid.addColumn(string -> {
 
             Button button = new Button("Click Me!",
-                    event -> toggleFieldVisibility(string));
+                event -> toggleFieldVisibility(string));
             button.setId(string.replace(' ', '_').toLowerCase(Locale.ROOT));
             return button;
         }, new ComponentRenderer()).setId("button").setCaption("Button");
@@ -49,13 +49,13 @@ public class GridComponentsVisibility extends AbstractTestUIWithLog {
         grid.setRowHeight(40);
 
         grid.getDefaultHeaderRow().join("textField", "button")
-                .setText("Other Components");
+            .setText("Other Components");
 
         addComponent(grid);
         grid.setSizeFull();
 
         grid.setItems(IntStream.range(0, 5).boxed()
-                .map(i -> "Row " + (i + (counter * 1000))));
+            .map(i -> "Row " + (i + (counter * 1000))));
 
     }
 

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/RemoveGridWithComponent.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/RemoveGridWithComponent.java
@@ -1,0 +1,29 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.VerticalLayout;
+
+/**
+ * @author Vaadin Ltd
+ *
+ */
+public class RemoveGridWithComponent extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        VerticalLayout layout = new VerticalLayout();
+        addComponent(layout);
+        Grid<String> grid = new Grid<>();
+        grid.setId("grid-with-component");
+        grid.addComponentColumn(text -> new Label(text));
+        grid.setItems("item 1", "item 2");
+        Button button = new Button("remove grid",
+                event -> layout.removeComponent(grid));
+        button.setId("remove-grid");
+        layout.addComponents(grid, button);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridComponentsVisibilityTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridComponentsVisibilityTest.java
@@ -23,8 +23,7 @@ public class GridComponentsVisibilityTest extends MultiBrowserTest {
 
     @Test
     public void changingVisibilityOfComponentShouldNotThrowClientSideExceptions() {
-        testHideComponent(grid -> ThreadLocalRandom.current().nextInt(1,
-                (int) grid.getRowCount() - 1));
+        testHideComponent(grid -> ThreadLocalRandom.current().nextInt(1, (int) grid.getRowCount() - 1));
     }
 
     @Test
@@ -32,13 +31,12 @@ public class GridComponentsVisibilityTest extends MultiBrowserTest {
         testHideComponent(grid -> (int) grid.getRowCount() - 1);
     }
 
-    private void testHideComponent(
-            Function<GridElement, Integer> rowUnderTestSupplier) {
+    private void testHideComponent(Function<GridElement, Integer> rowUnderTestSupplier) {
         openTestURL("debug");
         GridElement grid = $(GridElement.class).first();
         int rowUnderTest = rowUnderTestSupplier.apply(grid);
         assertTrue("Text field should be visible", grid.getCell(rowUnderTest, 1)
-                .isElementPresent(TextFieldElement.class));
+            .isElementPresent(TextFieldElement.class));
         assertOtherConnectorsArePresent(grid, rowUnderTest);
 
         clearDebugMessages();
@@ -59,40 +57,34 @@ public class GridComponentsVisibilityTest extends MultiBrowserTest {
         clickVisibilityToggleButton(grid, rowUnderTest);
     }
 
-    private void assertOnlyTextFieldOnTestedRowIsNotPresent(GridElement grid,
-            int rowUnderTest) {
-        assertFalse("Text field should not be visible",
-                grid.getCell(rowUnderTest, 1)
-                        .isElementPresent(TextFieldElement.class));
+    private void assertOnlyTextFieldOnTestedRowIsNotPresent(GridElement grid, int rowUnderTest) {
+        assertFalse("Text field should not be visible", grid.getCell(rowUnderTest, 1)
+            .isElementPresent(TextFieldElement.class));
         assertOtherConnectorsArePresent(grid, rowUnderTest);
     }
 
-    private void assertAllTextFieldsArePresent(GridElement grid,
-            int rowUnderTest) {
+    private void assertAllTextFieldsArePresent(GridElement grid, int rowUnderTest) {
         assertTrue("Text field should be visible", grid.getCell(rowUnderTest, 1)
-                .isElementPresent(TextFieldElement.class));
+            .isElementPresent(TextFieldElement.class));
         assertOtherConnectorsArePresent(grid, rowUnderTest);
     }
 
     private void assertNotClientSideErrors() {
         assertNoErrorNotifications();
-        // Should not log "Widget is still attached to the DOM ..." error
-        // message
+        // Should not log "Widget is still attached to the DOM ..." error message
         assertNoDebugMessage(Level.SEVERE);
     }
 
-    private void clickVisibilityToggleButton(GridElement grid,
-            int rowUnderTest) {
-        grid.getRow(rowUnderTest).getCell(2)
-                .findElement(By.className("v-button")).click();
+    private void clickVisibilityToggleButton(GridElement grid, int rowUnderTest) {
+        grid.getRow(rowUnderTest).getCell(2).findElement(By.className("v-button")).click();
     }
 
-    private void assertOtherConnectorsArePresent(GridElement grid,
-            int rowUnderTest) {
+    private void assertOtherConnectorsArePresent(GridElement grid, int rowUnderTest) {
         IntStream.range(1, (int) grid.getRowCount())
-                .filter(row -> row != rowUnderTest)
-                .forEach(row -> assertTrue("Text field should be visible",
-                        grid.getCell(row, 1)
-                                .isElementPresent(TextFieldElement.class)));
+            .filter(row -> row != rowUnderTest)
+            .forEach(row ->
+                assertTrue("Text field should be visible", grid.getCell(row, 1)
+                    .isElementPresent(TextFieldElement.class))
+            );
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/RemoveGridWithComponentTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/RemoveGridWithComponentTest.java
@@ -1,0 +1,26 @@
+package com.vaadin.tests.components.grid;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.GridElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+/**
+ * @author Vaadin Ltd
+ */
+public class RemoveGridWithComponentTest extends SingleBrowserTest {
+
+    private GridElement grid;
+
+    @Test
+    public void RemoveGrid_CheckGridNotPresent() {
+        openTestURL();
+
+        grid = $(GridElement.class).id("grid-with-component");
+        ButtonElement button = $(ButtonElement.class).id("remove-grid");
+        button.click();
+        assertElementNotPresent(By.id("grid-with-component"));
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/RemoveGridWithComponentTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/RemoveGridWithComponentTest.java
@@ -12,13 +12,10 @@ import com.vaadin.tests.tb3.SingleBrowserTest;
  */
 public class RemoveGridWithComponentTest extends SingleBrowserTest {
 
-    private GridElement grid;
-
     @Test
     public void RemoveGrid_CheckGridNotPresent() {
         openTestURL();
 
-        grid = $(GridElement.class).id("grid-with-component");
         ButtonElement button = $(ButtonElement.class).id("remove-grid");
         button.click();
         assertElementNotPresent(By.id("grid-with-component"));

--- a/uitest/src/test/java/com/vaadin/tests/push/BasicPushTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/push/BasicPushTest.java
@@ -70,13 +70,14 @@ public abstract class BasicPushTest extends MultiBrowserTest {
 
     protected void waitUntilClientCounterChanges(final int expectedValue) {
         waitUntil(input -> {
-            try {
-                return BasicPushTest
-                        .getClientCounter(BasicPushTest.this) == expectedValue;
-            } catch (NoSuchElementException e) {
-                return false;
-            }
-        }, 10);
+                    try {
+                        return BasicPushTest
+                                .getClientCounter(BasicPushTest.this) == expectedValue;
+                    } catch (NoSuchElementException e) {
+                        return false;
+                    }
+                },
+                10);
     }
 
     protected void waitUntilServerCounterChanges() {


### PR DESCRIPTION
Add test case to address the issue with removing gird with components;
Current situation: the grid cannot be removed and client-side throw an error. 
fixes: Revert the corresponding change, as it didn't address any issue which was fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11224)
<!-- Reviewable:end -->
