### PR TITLE
Update time in ReadOnly state of DateTimeCalendar

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VDateTimeCalendarPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VDateTimeCalendarPanel.java
@@ -119,6 +119,9 @@ public class VDateTimeCalendarPanel
                 sec.addChangeHandler(this);
             }
 
+            // Update times
+            updateTimes();
+
             final String delimiter = getDateTimeService().getClockDelimeter();
             if (isReadonly()) {
                 int h = 0;
@@ -170,9 +173,6 @@ public class VDateTimeCalendarPanel
             if (isReadonly()) {
                 return;
             }
-
-            // Update times
-            updateTimes();
 
             ListBox lastDropDown = getLastDropDown();
             lastDropDown.addKeyDownHandler(event -> {

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/InlineDateFieldReadOnly.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/InlineDateFieldReadOnly.java
@@ -1,0 +1,41 @@
+package com.vaadin.tests.components.datefield;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.shared.ui.datefield.DateTimeResolution;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.InlineDateTimeField;
+
+import java.time.LocalDateTime;
+import java.util.Locale;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class InlineDateFieldReadOnly extends AbstractTestUI {
+    public static final int SEC = 33;
+    public static final int MIN = 15;
+    public static final int HOUR = 14;
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        final InlineDateTimeField timeField = new InlineDateTimeField(
+                "A read-only datefield");
+        timeField.setResolution(DateTimeResolution.SECOND);
+        timeField.setLocale(new Locale("fi"));
+        timeField.setId("dF");
+        // Set date so that test always has same time
+        timeField.setValue(LocalDateTime.of(2018, 9, 15, HOUR, MIN, SEC));
+        timeField.setReadOnly(true);
+
+        addComponent(timeField);
+
+        Button b = new Button("Switch read-only");
+        b.addClickListener(event -> {
+            timeField.setReadOnly(!timeField.isReadOnly());
+        });
+        b.setId("readOnlySwitch");
+
+        addComponent(b);
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/InlineDateFieldReadOnlyTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/InlineDateFieldReadOnlyTest.java
@@ -1,0 +1,42 @@
+package com.vaadin.tests.components.datefield;
+
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+
+public class InlineDateFieldReadOnlyTest extends MultiBrowserTest {
+
+    @Test
+    public void minutesAndSecondsAreRenderedCorrectly() {
+        openTestURL();
+        WebElement divTime = findElement(By.className("v-datefield-time"));
+        List<WebElement> labels = divTime.findElements(By.className("v-label"));
+        assertEquals(5, labels.size());
+
+        // At positions 1 and 3 the delimeter label is set
+        assertEquals(InlineDateFieldReadOnly.HOUR,
+                convertToInt(labels.get(0).getText()));
+        assertEquals(InlineDateFieldReadOnly.MIN,
+                convertToInt(labels.get(2).getText()));
+        assertEquals(InlineDateFieldReadOnly.SEC,
+                convertToInt(labels.get(4).getText()));
+    }
+
+    private int convertToInt(String value) {
+        int converted = -1;
+        try {
+            converted = Integer.valueOf(value).intValue();
+        } catch (NumberFormatException e) {
+            assertFalse(
+                    "NumberFormatException is thrown! Conversion was not possible",
+                    e instanceof NumberFormatException);
+        }
+        return converted;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/vaadin/framework/issues/11268

```buildTime()``` function re-initializes ListBoxes for hours,minutes and seconds values. We need to set correct values in those ListBoxes, before assigning value to the labels displayed instead of those ListBoxes in ReadOnly state, as , otherwise, the selectedItemIndex returns 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11269)
<!-- Reviewable:end -->
