### PR TITLE
V8: Corrected method name TreeDataProvider#getTreeData

### DIFF
--- a/documentation/components/components-treegrid.asciidoc
+++ b/documentation/components/components-treegrid.asciidoc
@@ -56,7 +56,7 @@ an [classname]#TreeDataProvider# with [classname]#TreeData# is used. If at any t
 ----
 TreeDataProvider<Project> dataProvider = (TreeDataProvider<Project>) treeGrid.getDataProvider();
 
-TreeData<Project> data = dataProvider.getData();
+TreeData<Project> data = dataProvider.getTreeData();
 // add new items
 data.addItem(null, newProject);
 data.addItems(newProject, newProject.getChildren());


### PR DESCRIPTION
The method name was incorrect in the documentation - was showing `getData()` but should be [`getTreeData()`](https://vaadin.com/api/framework/8.6.0/com/vaadin/data/provider/TreeDataProvider.html#getTreeData--). Note that this for the Vaadin 8 docs.

Thanks for submitting a pull request!
Please confirm that your pull request follows our guidelines found in CONTRIBUTING and that you provide enough information so that we can review your pull request.

<Description of pull request, e.g. "Fix Grid Column not sortable with backend data and sort property">

Fixes #<replace with an issue number>

**Check when you have completed**
[ ] Valid tests for the pull request
[ ] Contributing guidelines implemented

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11286)
<!-- Reviewable:end -->
