### PR TITLE
Removed typo in method , there was an extra ")"

### DIFF
--- a/documentation/articles/SendingEmailFromJavaApplications.asciidoc
+++ b/documentation/articles/SendingEmailFromJavaApplications.asciidoc
@@ -134,7 +134,7 @@ follows:
 HtmlEmail email = new HtmlEmail();
 email.setHostName("localhost");
 email.setSmtpPort(9090);
-email.setAuthentication()"sender@test.com", "password");
+email.setAuthentication("sender@test.com", "password");
 ....
  
 Or if you want to use Gmail:


### PR DESCRIPTION
Fixed a typo in **Sending email from Java Applications** documentation's page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11295)
<!-- Reviewable:end -->
