### PR TITLE
add note about JRE9+ not being supported in release notes

### DIFF
--- a/all/src/main/templates/release-notes.html
+++ b/all/src/main/templates/release-notes.html
@@ -404,8 +404,9 @@
         <h2 id="supportedversions">Supported Technologies</h2>
 
         <p>
-            Vaadin 7 is compatible with <b>Java 6</b> and newer. Vaadin
-            7 is especially supported on the following <b>operating
+            Vaadin 7 is compatible with <b>Java 6</b> and newer up to <b>Java 8</b>. 
+            <b>Java 9 and above are explicitly not supported.</b>
+            Vaadin 7 is especially supported on the following <b>operating
                 systems</b>:
         </p>
 


### PR DESCRIPTION
Updated release notes about Java 9+ not being supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11311)
<!-- Reviewable:end -->
