### PR TITLE
Fix colorPicker tests

### DIFF
--- a/uitest/src/test/java/com/vaadin/tests/components/colorpicker/ColorPickerUserColorChangeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/colorpicker/ColorPickerUserColorChangeTest.java
@@ -14,7 +14,7 @@ public class ColorPickerUserColorChangeTest extends MultiBrowserTest {
         openTestURL();
         // Open colorPicker
         findElement(By.className("v-button-v-colorpicker ")).click();
-        sleep(100);
+        sleep(2000);
         // click somewhere inside the gradient layer
         findElement(By.className("v-colorpicker-gradient-clicklayer")).click();
         // confirm selection by clicking "OK" button

--- a/uitest/src/test/java/com/vaadin/tests/components/colorpicker/ColorPickerUserColorChangeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/colorpicker/ColorPickerUserColorChangeTest.java
@@ -14,7 +14,7 @@ public class ColorPickerUserColorChangeTest extends MultiBrowserTest {
         openTestURL();
         // Open colorPicker
         findElement(By.className("v-button-v-colorpicker ")).click();
-        sleep(2000);
+        sleep(500);
         // click somewhere inside the gradient layer
         findElement(By.className("v-colorpicker-gradient-clicklayer")).click();
         // confirm selection by clicking "OK" button


### PR DESCRIPTION
In IE11, the click-layer needs longer time to load.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11312)
<!-- Reviewable:end -->
