### PR TITLE
Add javadoc for validate() call in Binder

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -139,6 +139,11 @@ public class Binder<BEAN> implements Serializable {
          * Validates the field value and returns a {@code ValidationStatus}
          * instance representing the outcome of the validation.
          *
+         * <strong>Note:</strong> Calling this method will not trigger the value
+         * update in the target automatically. As this method will attempt to
+         * temporarily apply all current changes to the target and run full
+         * validation for it. The changes are reverted after target validation.
+         *
          * @see #validate()
          *
          * @param fireEvent

--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -140,11 +140,12 @@ public class Binder<BEAN> implements Serializable {
          * instance representing the outcome of the validation.
          *
          * <strong>Note:</strong> Calling this method will not trigger the value
-         * update in the target automatically. As this method will attempt to
-         * temporarily apply all current changes to the target and run full
-         * validation for it. The changes are reverted after target validation.
+         * update in the bean automatically. This method will attempt to
+         * temporarily apply all current changes to the bean and run full bean
+         * validation for it. The changes are reverted after bean validation.
          *
          * @see #validate()
+         * @see Binder#validate()
          *
          * @param fireEvent
          *            {@code true} to fire status event; {@code false} to not


### PR DESCRIPTION
Adding javadoc to make it clear that: calling `validate()` will not trigger value update in the target when using Binder. 
Fixes #11283

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11318)
<!-- Reviewable:end -->
