### PR TITLE
Reset internal parameter when dataProvider is refreshed

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/combobox/ComboBoxConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/combobox/ComboBoxConnector.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.client.ui.combobox;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.logging.Logger;
@@ -69,6 +70,7 @@ public class ComboBoxConnector extends AbstractListingConnector
         registerRpc(ComboBoxClientRpc.class, new ComboBoxClientRpc() {
             @Override
             public void newItemNotAdded(String itemValue) {
+
                 if (itemValue != null && itemValue.equals(pendingNewItemValue)
                         && isNewItemStillPending()) {
                     // handled but not added, perform (de-)selection handling
@@ -335,7 +337,6 @@ public class ComboBoxConnector extends AbstractListingConnector
 
     private void refreshData() {
         updateCurrentPage();
-
         int start = getWidget().currentPage * getWidget().pageLength;
         int end = getWidget().pageLength > 0 ? start + getWidget().pageLength
                 : getDataSource().size();
@@ -360,6 +361,7 @@ public class ComboBoxConnector extends AbstractListingConnector
         updateSuggestions(start, end);
         getWidget().setTotalSuggestions(getDataSource().size());
 
+        getWidget().lastNewItemString = null;
         getDataReceivedHandler().dataReceived();
     }
 

--- a/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxNewItemAdd2ndTime.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxNewItemAdd2ndTime.java
@@ -1,0 +1,54 @@
+package com.vaadin.tests.components.combobox;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.data.provider.ListDataProvider;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.tests.widgetset.TestingWidgetSet;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.ComboBox;
+import com.vaadin.ui.VerticalLayout;
+
+public class ComboBoxNewItemAdd2ndTime extends AbstractTestUI {
+    @Override
+    protected void setup(VaadinRequest request) {
+        VerticalLayout mainLayout = new VerticalLayout();
+
+        List<String> items = new ArrayList<>(
+                Arrays.asList("blue", "red", "green"));
+        ListDataProvider<String> dataProvider = new ListDataProvider<>(items);
+
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setDataProvider(dataProvider);
+        comboBox.setNewItemProvider(value -> {
+            items.add(value);
+            dataProvider.refreshItem(value);
+            return Optional.ofNullable(value);
+        });
+        mainLayout.addComponent(comboBox);
+
+        Button reloadDataProviderButton = new Button("Reload Data Provider");
+        reloadDataProviderButton.addClickListener(event1 -> {
+            items.clear();
+            items.addAll(Arrays.asList("blue", "red", "green"));
+            dataProvider.refreshAll();
+        });
+        mainLayout.addComponent(reloadDataProviderButton);
+
+        Button getValueButton = new Button("Get Value");
+        getValueButton.addClickListener(
+                event1 -> event1.getButton().setCaption(comboBox.getValue()));
+        mainLayout.addComponent(getValueButton);
+        addComponent(mainLayout);
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 11317;
+    }
+}

--- a/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxNewItemProvider.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxNewItemProvider.java
@@ -17,12 +17,12 @@ public class ComboBoxNewItemProvider
                 }
             }
             if (Boolean.TRUE.equals(reject.getValue())) {
-                valueChangeLabel.setValue("item " + text + " discarded");
+                valueStateLabel.setValue("item " + text + " discarded");
                 return Optional.empty();
             } else {
                 items.add(text);
                 Collections.sort(items);
-                valueChangeLabel
+                valueStateLabel
                         .setValue("adding new item... count: " + items.size());
                 comboBox.getDataProvider().refreshAll();
                 if (noSelection.getValue()) {

--- a/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChange.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChange.java
@@ -31,6 +31,7 @@ public class ComboBoxSelectingNewItemValueChange extends ComboBoxSelecting {
     int valueChangeEventCount = 0;
     int selectionChangeEventCount = 0;
     Label valueLabel = new Label();
+    Label valueStateLabel = new Label(null, ContentMode.HTML);
     Label valueChangeLabel = new Label(null, ContentMode.HTML);
     CheckBox delay = new CheckBox("Slow adding process", false);
     CheckBox reject = new CheckBox("Reject new values", false);
@@ -73,20 +74,21 @@ public class ComboBoxSelectingNewItemValueChange extends ComboBoxSelecting {
             initItems();
             comboBox.getDataProvider().refreshAll();
             valueLabel.setValue("");
-            valueChangeLabel.setValue("Reset");
+            valueStateLabel.setValue("Reset");
             valueChangeEventCount = 0;
             selectionChangeEventCount = 0;
         });
 
         valueLabel.setId("value");
+        valueStateLabel.setId("state");
         valueChangeLabel.setId("change");
         delay.setId("delay");
         reject.setId("reject");
         noSelection.setId("noSelection");
         resetButton.setId("reset");
 
-        addComponents(comboBox, valueLabel, valueChangeLabel, checkButton,
-                resetButton, delay, reject, noSelection);
+        addComponents(comboBox, valueLabel, valueStateLabel, valueChangeLabel,
+                checkButton, resetButton, delay, reject, noSelection);
     }
 
     @SuppressWarnings("deprecation")
@@ -100,12 +102,12 @@ public class ComboBoxSelectingNewItemValueChange extends ComboBoxSelecting {
                 }
             }
             if (Boolean.TRUE.equals(reject.getValue())) {
-                valueChangeLabel.setValue("item " + text + " discarded");
+                valueStateLabel.setValue("item " + text + " discarded");
                 comboBox.getComboBoxClientRpc().newItemNotAdded(text);
             } else {
                 items.add(text);
                 Collections.sort(items);
-                valueChangeLabel
+                valueStateLabel
                         .setValue("adding new item... count: " + items.size());
                 if (Boolean.TRUE.equals(noSelection.getValue())) {
                     comboBox.getComboBoxClientRpc().newItemNotAdded(text);
@@ -125,9 +127,10 @@ public class ComboBoxSelectingNewItemValueChange extends ComboBoxSelecting {
     }
 
     private void updateLabel(boolean userOriginated) {
-        valueChangeLabel.setValue("Value change count: " + valueChangeEventCount
-                + "\nSelection change count: " + selectionChangeEventCount
-                + "\nuser originated: " + userOriginated);
+        valueChangeLabel.setValue("Value change count: "
+                + valueChangeEventCount + "\nSelection change count: "
+                + selectionChangeEventCount + "\nuser originated: "
+                + userOriginated);
     }
 
     @Override

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxNewItemAdd2ndTimeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxNewItemAdd2ndTimeTest.java
@@ -1,0 +1,51 @@
+package com.vaadin.tests.components.combobox;
+
+import org.junit.Test;
+import org.openqa.selenium.interactions.Actions;
+
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.ComboBoxElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+import com.vaadin.ui.Button;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ComboBoxNewItemAdd2ndTimeTest extends SingleBrowserTest {
+
+    private ComboBoxElement comboBox;
+
+    @Test
+    public void addItem_reloadDataProvider_addSameItem() {
+        openTestURL();
+        String sample = new String("hello");
+
+        comboBox = $(ComboBoxElement.class).first();
+
+        ButtonElement reloadButton = $(ButtonElement.class)
+                .caption("Reload Data Provider").first();
+        ButtonElement value = $(ButtonElement.class).caption("Get Value")
+                .first();
+
+        assertEquals("", comboBox.getValue());
+
+        sendKeysToInput(sample);
+        value.click();
+        assertEquals(sample, value.getCaption());
+
+        comboBox.clear();
+        value.click();
+        assertEquals("", value.getCaption());
+
+        reloadButton.click();
+        sendKeysToInput(sample);
+        value.click();
+        assertEquals(sample, value.getCaption());
+    }
+
+    private void sendKeysToInput(CharSequence... keys) {
+        // ensure mouse is located over the ComboBox to avoid hover issues
+        new Actions(getDriver()).moveToElement(comboBox).perform();
+        comboBox.sendKeys(keys);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxNewItemAdd2ndTimeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxNewItemAdd2ndTimeTest.java
@@ -31,15 +31,18 @@ public class ComboBoxNewItemAdd2ndTimeTest extends SingleBrowserTest {
 
         sendKeysToInput(sample);
         value.click();
+        sleep(100);
         assertEquals(sample, value.getCaption());
 
         comboBox.clear();
         value.click();
+        sleep(100);
         assertEquals("", value.getCaption());
 
         reloadButton.click();
         sendKeysToInput(sample);
         value.click();
+        sleep(100);
         assertEquals(sample, value.getCaption());
     }
 

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxNewItemAdd2ndTimeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxNewItemAdd2ndTimeTest.java
@@ -31,18 +31,18 @@ public class ComboBoxNewItemAdd2ndTimeTest extends SingleBrowserTest {
 
         sendKeysToInput(sample);
         value.click();
-        sleep(100);
+        sleep(1000);
         assertEquals(sample, value.getCaption());
 
         comboBox.clear();
         value.click();
-        sleep(100);
+        sleep(1000);
         assertEquals("", value.getCaption());
 
         reloadButton.click();
         sendKeysToInput(sample);
         value.click();
-        sleep(100);
+        sleep(1000);
         assertEquals(sample, value.getCaption());
     }
 

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxNewItemAdd2ndTimeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxNewItemAdd2ndTimeTest.java
@@ -31,18 +31,18 @@ public class ComboBoxNewItemAdd2ndTimeTest extends SingleBrowserTest {
 
         sendKeysToInput(sample);
         value.click();
-        sleep(1000);
+        sleep(100);
         assertEquals(sample, value.getCaption());
 
         comboBox.clear();
         value.click();
-        sleep(1000);
+        sleep(100);
         assertEquals("", value.getCaption());
 
         reloadButton.click();
         sendKeysToInput(sample);
         value.click();
-        sleep(1000);
+        sleep(100);
         assertEquals(sample, value.getCaption());
     }
 

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
@@ -143,7 +143,7 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
             break;
         case TAB:
             sendKeysToInput(Keys.TAB);
-            sleep(100);
+            sleep(3000);
             break;
         case CLICK_OUT:
             new Actions(getDriver()).moveToElement(comboBoxElement, 10, 10)
@@ -191,7 +191,7 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
     }
 
     private void assertValueChange(int count) {
-        sleep(100);
+        sleep(3000);
         assertEquals(String.format(
                 "Value change count: %s Selection change count: %s user originated: true",
                 count, count), changeLabelElement.getText());
@@ -203,7 +203,7 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
     }
 
     private void assertItemCount(int count) {
-        sleep(100);
+        sleep(3000);
         assertEquals(String.format("adding new item... count: %s", count),
                 changeLabelElement.getText());
     }

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
@@ -25,6 +25,7 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
     private ComboBoxElement comboBoxElement;
     private LabelElement valueLabelElement;
     private LabelElement changeLabelElement;
+    private LabelElement valueStateElement;
     private String[] defaultInputs = new String[] { "foo", "bar", "baz",
             "fie" };
     private String[] shortInputs = new String[] { "a", "b", "c", "d" };
@@ -37,6 +38,7 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
         waitForElementPresent(By.className("v-filterselect"));
         comboBoxElement = $(ComboBoxElement.class).first();
         valueLabelElement = $(LabelElement.class).id("value");
+        valueStateElement = $(LabelElement.class).id("state");
         changeLabelElement = $(LabelElement.class).id("change");
     }
 
@@ -143,7 +145,6 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
             break;
         case TAB:
             sendKeysToInput(Keys.TAB);
-            sleep(3000);
             break;
         case CLICK_OUT:
             new Actions(getDriver()).moveToElement(comboBoxElement, 10, 10)
@@ -191,7 +192,7 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
     }
 
     private void assertValueChange(int count) {
-        sleep(3000);
+
         assertEquals(String.format(
                 "Value change count: %s Selection change count: %s user originated: true",
                 count, count), changeLabelElement.getText());
@@ -199,13 +200,12 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
 
     private void assertRejected(String value) {
         assertEquals(String.format("item %s discarded", value),
-                changeLabelElement.getText());
+                valueStateElement.getText());
     }
 
     private void assertItemCount(int count) {
-        sleep(3000);
         assertEquals(String.format("adding new item... count: %s", count),
-                changeLabelElement.getText());
+                valueStateElement.getText());
     }
 
     private void reject(boolean reject) {

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
@@ -190,6 +190,7 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
     }
 
     private void assertValueChange(int count) {
+        sleep(100);
         assertEquals(String.format(
                 "Value change count: %s Selection change count: %s user originated: true",
                 count, count), changeLabelElement.getText());
@@ -201,6 +202,7 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
     }
 
     private void assertItemCount(int count) {
+        sleep(100);
         assertEquals(String.format("adding new item... count: %s", count),
                 changeLabelElement.getText());
     }

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
@@ -143,6 +143,7 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
             break;
         case TAB:
             sendKeysToInput(Keys.TAB);
+            sleep(100);
             break;
         case CLICK_OUT:
             new Actions(getDriver()).moveToElement(comboBoxElement, 10, 10)


### PR DESCRIPTION
Explained in the original ticket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11323)
<!-- Reviewable:end -->
