### PR TITLE
Fix for setting default row height for a Grid with details row(s) open.

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -3925,13 +3925,22 @@ public class Escalator extends Widget
             Profiler.enter(
                     "Escalator.BodyRowContainer.reapplyDefaultRowHeights");
 
+            double spacerHeights = 0;
+
             /* step 1: resize and reposition rows */
             for (int i = 0; i < visualRowOrder.size(); i++) {
                 TableRowElement tr = visualRowOrder.get(i);
                 reapplyRowHeight(tr, getDefaultRowHeight());
 
                 final int logicalIndex = getTopRowLogicalIndex() + i;
-                setRowPosition(tr, 0, logicalIndex * getDefaultRowHeight());
+                setRowPosition(tr, 0,
+                        logicalIndex * getDefaultRowHeight() + spacerHeights);
+
+                com.vaadin.client.widgets.Escalator.SpacerContainer.SpacerImpl spacer = body.spacerContainer
+                        .getSpacer(i);
+                if (spacer != null && spacer.getHeight() > 0) {
+                    spacerHeights += spacer.getHeight();
+                }
             }
 
             /*

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridWithInitiallyOpenDetails.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridWithInitiallyOpenDetails.java
@@ -1,0 +1,57 @@
+package com.vaadin.tests.components.grid;
+
+import java.util.List;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.data.bean.Person;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.Grid.ItemClick;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.components.grid.ItemClickListener;
+
+public class GridWithInitiallyOpenDetails extends SimpleGridUI {
+    private List<Person> persons;
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        addComponent(createGrid());
+    }
+
+    @Override
+    protected List<Person> createPersons() {
+        persons = super.createPersons();
+        return persons;
+    }
+
+    @Override
+    protected Grid<Person> createGrid() {
+        Grid<Person> grid = super.createGrid();
+
+        grid.setDetailsGenerator(
+                row -> new Label("details for " + row.getFirstName()));
+
+        for (Person person : persons) {
+            grid.setDetailsVisible(person, true);
+        }
+
+        grid.addItemClickListener(new ItemClickListener<Person>() {
+            @Override
+            public void itemClick(ItemClick<Person> event) {
+                grid.setDetailsVisible(event.getItem(),
+                        !grid.isDetailsVisible(event.getItem()));
+            }
+        });
+
+        return grid;
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Initially open details rows should be taken into account in row positioning.";
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 11325;
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridWithInitiallyOpenDetailsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridWithInitiallyOpenDetailsTest.java
@@ -1,0 +1,34 @@
+package com.vaadin.tests.components.grid;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.testbench.elements.GridElement;
+import com.vaadin.testbench.elements.GridElement.GridRowElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class GridWithInitiallyOpenDetailsTest extends MultiBrowserTest {
+
+    @Test
+    public void testRowPositions() {
+        openTestURL();
+
+        GridElement grid = $(GridElement.class).first();
+        GridRowElement row0 = grid.getRow(0);
+        GridRowElement row1 = grid.getRow(1);
+        GridRowElement row2 = grid.getRow(2);
+
+        waitForElementPresent(By.className("v-grid-spacer"));
+
+        assertThat("Incorrect Y-position for second row.",
+                row1.getLocation().getY(), greaterThan(row0.getLocation().getY()
+                        + row0.getSize().height + 10));
+        assertThat("Incorrect Y-position for third row.",
+                row2.getLocation().getY(), greaterThan(row1.getLocation().getY()
+                        + row1.getSize().height + 10));
+    }
+
+}


### PR DESCRIPTION
- Details row(s) should be taken into account when the rows are
re-positioned after getting new heights.

Fixes #11325

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11326)
<!-- Reviewable:end -->
