### PR TITLE
Revert "Update ComboBox internal state on new item added (#11094)"

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VComboBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VComboBox.java
@@ -16,6 +16,16 @@
 
 package com.vaadin.client.ui;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Logger;
+
 import com.google.gwt.animation.client.AnimationScheduler;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.JavaScriptObject;
@@ -74,15 +84,6 @@ import com.vaadin.client.ui.menubar.MenuItem;
 import com.vaadin.shared.AbstractComponentState;
 import com.vaadin.shared.ui.ComponentStateUtil;
 import com.vaadin.shared.util.SharedUtil;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import java.util.logging.Logger;
 
 /**
  * Client side implementation of the ComboBox component.
@@ -1635,26 +1636,11 @@ public class VComboBox extends Composite implements Field, KeyDownHandler,
             performSelection(selectedKey, oldSuggestionTextMatchTheOldSelection,
                     !isWaitingForFilteringResponse() || popupOpenerClicked);
 
-            // currentSuggestion should be set to match the value of the
-            // ComboBox, especially when a new item is added.
-            resetCurrentSuggestionIfNecessary(selectedKey, selectedCaption,
-                    selectedIconUri);
-
             cancelPendingPostFiltering();
 
             setSelectedCaption(selectedCaption);
 
             setSelectedItemIcon(selectedIconUri);
-        }
-
-        private void resetCurrentSuggestionIfNecessary(String selectedKey,
-                String selectedCaption, String selectedIconUri) {
-            if (currentSuggestion == null
-                    && (selectedKey != null || selectedCaption != null))
-                currentSuggestion = new ComboBoxSuggestion(selectedKey,
-                        selectedCaption, "", selectedIconUri);
-            else if (selectedKey == null && selectedCaption == null)
-                currentSuggestion = null;
         }
 
     }
@@ -2124,7 +2110,6 @@ public class VComboBox extends Composite implements Field, KeyDownHandler,
             currentSuggestion = null; // #13217
             selectedOptionKey = null;
             setText(getEmptySelectionCaption());
-            return;
         }
         // some item selected
         for (ComboBoxSuggestion suggestion : currentSuggestions) {

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -186,23 +186,20 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
         @Override
         public void createNewItem(String itemValue) {
             // New option entered
-            boolean clientSideHandling = false;
+            boolean added = false;
             if (itemValue != null && !itemValue.isEmpty()) {
                 if (getNewItemProvider() != null) {
-                    getNewItemProvider().apply(itemValue).ifPresent(value -> {
-                        // Update state for the newly selected value
-                        setSelectedItem(value, true);
-                        getDataCommunicator().reset();
-                    });
+                    Optional<T> item = getNewItemProvider().apply(itemValue);
+                    added = item.isPresent();
                 } else if (getNewItemHandler() != null) {
                     getNewItemHandler().accept(itemValue);
                     // Up to the user to tell if no item was added.
-                    clientSideHandling = true;
+                    added = true;
                 }
             }
 
-            if (!clientSideHandling) {
-                // New item was maybe added with NewItemHandler
+            if (!added) {
+                // New item was not handled.
                 getRpcProxy(ComboBoxClientRpc.class).newItemNotAdded(itemValue);
             }
         }

--- a/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxAddingSameItemTwoTimesWithItemHandlerReset.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxAddingSameItemTwoTimesWithItemHandlerReset.java
@@ -1,0 +1,5 @@
+package com.vaadin.tests.components.combobox;
+
+public class ComboBoxAddingSameItemTwoTimesWithItemHandlerReset
+        extends ComboBoxSelectingNewItemValueChange {
+}

--- a/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxAddingSameItemTwoTimesWithItemProviderReset.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxAddingSameItemTwoTimesWithItemProviderReset.java
@@ -1,0 +1,5 @@
+package com.vaadin.tests.components.combobox;
+
+public class ComboBoxAddingSameItemTwoTimesWithItemProviderReset
+        extends ComboBoxNewItemProvider {
+}

--- a/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxNewItemProvider.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxNewItemProvider.java
@@ -9,7 +9,7 @@ public class ComboBoxNewItemProvider
     @Override
     protected void configureNewItemHandling() {
         comboBox.setNewItemProvider(text -> {
-            if (Boolean.TRUE.equals(delay.getValue())) {
+            if (delay.getValue()) {
                 try {
                     Thread.sleep(2000);
                 } catch (InterruptedException e1) {
@@ -25,7 +25,7 @@ public class ComboBoxNewItemProvider
                 valueChangeLabel
                         .setValue("adding new item... count: " + items.size());
                 comboBox.getDataProvider().refreshAll();
-                if (Boolean.TRUE.equals(noSelection.getValue())) {
+                if (noSelection.getValue()) {
                     return Optional.empty();
                 }
             }

--- a/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxNewItemProvider.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxNewItemProvider.java
@@ -9,7 +9,7 @@ public class ComboBoxNewItemProvider
     @Override
     protected void configureNewItemHandling() {
         comboBox.setNewItemProvider(text -> {
-            if (delay.getValue()) {
+            if (Boolean.TRUE.equals(delay.getValue())) {
                 try {
                     Thread.sleep(2000);
                 } catch (InterruptedException e1) {
@@ -25,7 +25,7 @@ public class ComboBoxNewItemProvider
                 valueChangeLabel
                         .setValue("adding new item... count: " + items.size());
                 comboBox.getDataProvider().refreshAll();
-                if (noSelection.getValue()) {
+                if (Boolean.TRUE.equals(noSelection.getValue())) {
                     return Optional.empty();
                 }
             }

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxAddingSameItemTwoTimesWithItemHandlerResetTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxAddingSameItemTwoTimesWithItemHandlerResetTest.java
@@ -1,0 +1,24 @@
+package com.vaadin.tests.components.combobox;
+
+public class ComboBoxAddingSameItemTwoTimesWithItemHandlerResetTest
+        extends ComboBoxSelectingNewItemValueChangeTest {
+
+    @Override
+    public void itemHandling(
+            ComboBoxSelectingNewItemValueChangeTest.SelectionType selectionType,
+            String[] inputs) {
+        assertThatSelectedValueIs("");
+
+        // add new item for the first time
+        typeInputAndSelect(inputs[0], selectionType);
+        assertThatSelectedValueIs(inputs[0]);
+        assertValueChange(1);
+
+        reset();
+
+        // add the same item for the 2nd time
+        typeInputAndSelect(inputs[0], selectionType);
+        assertThatSelectedValueIs(inputs[0]);
+        assertValueChange(1);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxAddingSameItemTwoTimesWithItemProviderResetTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxAddingSameItemTwoTimesWithItemProviderResetTest.java
@@ -1,0 +1,6 @@
+package com.vaadin.tests.components.combobox;
+
+public class ComboBoxAddingSameItemTwoTimesWithItemProviderResetTest
+        extends ComboBoxAddingSameItemTwoTimesWithItemHandlerResetTest {
+    // same tests using NewItemProvider instead of NewItemHandler
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
@@ -1,6 +1,6 @@
 package com.vaadin.tests.components.combobox;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.openqa.selenium.Keys;
@@ -190,19 +190,19 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
     }
 
     private void assertValueChange(int count) {
-        assertEquals(String.format(
+        assertTrue(changeLabelElement.getText().equals(String.format(
                 "Value change count: %s Selection change count: %s user originated: true",
-                count, count), changeLabelElement.getText());
+                count, count)));
     }
 
     private void assertRejected(String value) {
-        assertEquals(String.format("item %s discarded", value),
-                changeLabelElement.getText());
+        assertTrue(changeLabelElement.getText()
+                .equals(String.format("item %s discarded", value)));
     }
 
     private void assertItemCount(int count) {
-        assertEquals(String.format("adding new item... count: %s", count),
-                changeLabelElement.getText());
+        assertTrue(changeLabelElement.getText()
+                .equals(String.format("adding new item... count: %s", count)));
     }
 
     private void reject(boolean reject) {

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.tests.components.combobox;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -18,7 +19,7 @@ import com.vaadin.tests.tb3.MultiBrowserTest;
 
 public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
 
-    private enum SelectionType {
+    protected enum SelectionType {
         ENTER, TAB, CLICK_OUT;
     }
 
@@ -134,7 +135,8 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
         assertItemCount(2602);
     }
 
-    private void typeInputAndSelect(String input, SelectionType selectionType) {
+    protected void typeInputAndSelect(String input,
+            SelectionType selectionType) {
         comboBoxElement.clear();
         sendKeysToInput(input);
         switch (selectionType) {
@@ -166,7 +168,7 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
         }
     }
 
-    private void assertThatSelectedValueIs(final String value) {
+    protected void assertThatSelectedValueIs(final String value) {
         waitUntil(new ExpectedCondition<Boolean>() {
             private String actualComboBoxValue;
             private String actualLabelValue;
@@ -189,20 +191,20 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
         });
     }
 
-    private void assertValueChange(int count) {
-        assertTrue(changeLabelElement.getText().equals(String.format(
+    protected void assertValueChange(int count) {
+        assertEquals(String.format(
                 "Value change count: %s Selection change count: %s user originated: true",
-                count, count)));
+                count, count), changeLabelElement.getText());
     }
 
     private void assertRejected(String value) {
-        assertTrue(changeLabelElement.getText()
-                .equals(String.format("item %s discarded", value)));
+        assertEquals(String.format("item %s discarded", value),
+                changeLabelElement.getText());
     }
 
     private void assertItemCount(int count) {
-        assertTrue(changeLabelElement.getText()
-                .equals(String.format("adding new item... count: %s", count)));
+        assertEquals(String.format("adding new item... count: %s", count),
+                changeLabelElement.getText());
     }
 
     private void reject(boolean reject) {
@@ -226,7 +228,7 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
         }
     }
 
-    private void reset() {
+    protected void reset() {
         $(ButtonElement.class).id("reset").click();
     }
 


### PR DESCRIPTION
This reverts commit 56ce91c6160a252ddcd952bca6eb7037120ebf59.

This fix made two extra bugs #11317  and #11320. The related ticket (#11059) should be revisited.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11331)
<!-- Reviewable:end -->
