### PR TITLE
Fix Grid's frozen columns not being set

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -3082,7 +3082,21 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
                     "count must be between -1 and the current number of columns ("
                             + columnSet.size() + "): " + numberOfColumns);
         }
-
+        int currentFrozenColumnState = getState(false).frozenColumnCount;
+        /*
+         * we remove the current value from the state so that setting frozen
+         * columns will always happen after this call. This is so that the value
+         * will be set also in the widget even if it happens to seem to be the
+         * same as this current value we're setting.
+         */
+        if (currentFrozenColumnState != numberOfColumns) {
+            final String diffStateKey = "frozenColumnCount";
+            UI ui = getUI();
+            if (ui != null) {
+                ui.getConnectorTracker().getDiffState(Grid.this)
+                        .remove(diffStateKey);
+            }
+        }
         getState().frozenColumnCount = numberOfColumns;
     }
 

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridFrozenColumnReset.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridFrozenColumnReset.java
@@ -1,0 +1,57 @@
+package com.vaadin.tests.components.grid;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.data.bean.Person;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.renderers.NumberRenderer;
+
+public class GridFrozenColumnReset extends SimpleGridUI {
+
+    private Grid<Person> grid;
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        grid = new Grid<Person>();
+        grid.setSizeFull();
+        init();
+        getLayout().addComponent(grid);
+
+        Button button = new Button("change frozen count");
+        button.addClickListener(event -> {
+            reInit();
+        });
+        getLayout().addComponent(button);
+    }
+
+    @Override
+    protected List<Person> createPersons() {
+        List<Person> persons = new ArrayList<>();
+        for (int i = 0; i < 10; ++i) {
+            Person person = new Person();
+            person.setFirstName("First " + i);
+            person.setLastName("Last" + i);
+            person.setAge(i);
+            persons.add(person);
+        }
+        return persons;
+    }
+
+    protected void init() {
+        grid.addColumn(Person::getFirstName);
+        grid.addColumn(Person::getLastName);
+        grid.addColumn(Person::getAge, new NumberRenderer());
+
+        grid.setItems(createPersons());
+        grid.setFrozenColumnCount(2);
+    }
+
+    protected void reInit() {
+        grid.removeAllColumns();
+        init();
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridFrozenColumnResetTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridFrozenColumnResetTest.java
@@ -1,0 +1,26 @@
+package com.vaadin.tests.components.grid;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.GridElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class GridFrozenColumnResetTest extends MultiBrowserTest {
+
+    @Test
+    public void testFrozenColumnReset() {
+        openTestURL();
+        GridElement grid = $(GridElement.class).first();
+
+        assertTrue(grid.getCell(0, 1).isFrozen());
+
+        ButtonElement button = $(ButtonElement.class).first();
+        button.click();
+
+        assertTrue(grid.getCell(0, 1).isFrozen());
+    }
+
+}


### PR DESCRIPTION
In certain cases setting the frozen columns didn't produce the expected result in the client side widget state. This happened if the frozen columns value was set to be the same it was before removeAllColumns was called.

This fix removes the frozen column value from the diff state so that the value gets properly set in the client side.

Fixes #10653

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11346)
<!-- Reviewable:end -->
