### PR TITLE
Fix vaadin-server/bnd.bnd file so it is compatible with Liferay 7.0 and 7.1. (#11156)

### DIFF
--- a/server/bnd.bnd
+++ b/server/bnd.bnd
@@ -4,7 +4,7 @@ Bundle-Version: ${osgi.bundle.version}
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
 Import-Package: com.vaadin.sass.*;resolution:=optional,\
-  com.liferay.portal.kernel.util;resolution:=optional,\
+  com.liferay.portal.kernel.util;resolution:=optional;version='[7.0.0,9.0.0)',\
   javax.portlet*;resolution:=optional,\
   javax.validation*;resolution:=optional;version='${javax.validation.version}',\
   org.atmosphere*;resolution:=optional;version='${atmosphere.runtime.version}',\


### PR DESCRIPTION
* This the range might be necessary to increase when Liferay 7.2 or
newer has been released.
* Change is only affecting the vaadin-server/bnd.bnd file by defining larger range so it will cover both Liferay 7.0 and 7.1 for ``com.liferay.portal.kernel.util`` package.

Thanks for submitting a pull request!
Please confirm that your pull request follows our guidelines found in CONTRIBUTING and that you provide enough information so that we can review your pull request.

<Description of pull request, e.g. "Fix Grid Column not sortable with backend data and sort property">

Fixes #11156 

**Check when you have completed**
[ ] Valid tests for the pull request
[ ] Contributing guidelines implemented

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11360)
<!-- Reviewable:end -->
