### PR TITLE
Remove outdated Designer license instructions

### DIFF
--- a/documentation/addons/addons-cval.asciidoc
+++ b/documentation/addons/addons-cval.asciidoc
@@ -61,7 +61,7 @@ usually with a [literal]#++-D++# option. For example, on the command-line:
 [prompt]#$# [command]#java# -Dvaadin.[replaceable]##<product>##.developer.license=[replaceable]#L1cen5e-c0de# ...
 ----
 
-where the [literal]`<product>` is the product ID, such as `charts`, `spreadsheet`, `designer`, or `testbench`.
+where the [literal]`<product>` is the product ID, such as `charts`, `spreadsheet`, or `testbench`.
 
 [[addons.cval.systemproperty.environments]]
 === Passing License Key in Different Environments
@@ -104,7 +104,7 @@ Apache Maven:: If building the project with Apache Maven, you can pass the licen
 [prompt]#$# [command]#mvn# -Dvaadin.[replaceable]##&lt;product&gt;##.developer.license=[replaceable]##L1cen5e-c0de## package
 ----
 +
-where the [literal]`<product>` is the product ID, such as `charts`, `spreadsheet`, `designer`, or `testbench`.
+where the [literal]`<product>` is the product ID, such as `charts`, `spreadsheet`, or `testbench`.
 
 Continuous Integration Systems:: In CIS systems, you can pass the license key to build runners as a system
 property in the build configuration. However, this only passes it to a runner.


### PR DESCRIPTION
The instructions for applying the license in Designer are wrong and outdated. Remove them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11366)
<!-- Reviewable:end -->
