### PR TITLE
Apply missing v-readonly style to CheckBoxGroup, when component is readOnly

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VCheckBoxGroup.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCheckBoxGroup.java
@@ -137,6 +137,7 @@ public class VCheckBoxGroup extends FocusableFlowPanelComposite
         widget.setValue(
                 item.getBoolean(ListingJsonConstants.JSONKEY_ITEM_SELECTED));
         setOptionEnabled(widget, item);
+        setOptionReadOnly(widget);
         widget.setStyleName(CLASSNAME_OPTION_SELECTED, widget.getValue());
 
         if (requireInitialization) {
@@ -197,6 +198,16 @@ public class VCheckBoxGroup extends FocusableFlowPanelComposite
                 !isEnabled() || !optionEnabled);
     }
 
+    protected void setOptionReadOnly(VCheckBox checkBox) {
+        if (isReadonly()) {
+            checkBox.addStyleName("v-readonly");
+            checkBox.setEnabled(false);
+        } else {
+            checkBox.removeStyleName("v-readonly");
+            checkBox.setEnabled(isEnabled());
+        }
+    }
+
     public boolean isHtmlContentAllowed() {
         return htmlContentAllowed;
     }
@@ -217,7 +228,7 @@ public class VCheckBoxGroup extends FocusableFlowPanelComposite
     public void setReadonly(boolean readonly) {
         if (this.readonly != readonly) {
             this.readonly = readonly;
-            optionsToItems.forEach(this::setOptionEnabled);
+            optionsToItems.keySet().forEach(this::setOptionReadOnly);
         }
     }
 

--- a/client/src/main/java/com/vaadin/client/ui/VCheckBoxGroup.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCheckBoxGroup.java
@@ -137,7 +137,7 @@ public class VCheckBoxGroup extends FocusableFlowPanelComposite
         widget.setValue(
                 item.getBoolean(ListingJsonConstants.JSONKEY_ITEM_SELECTED));
         setOptionEnabled(widget, item);
-        setOptionReadOnly(widget);
+        setOptionReadOnly(widget, item);
         widget.setStyleName(CLASSNAME_OPTION_SELECTED, widget.getValue());
 
         if (requireInitialization) {
@@ -198,13 +198,15 @@ public class VCheckBoxGroup extends FocusableFlowPanelComposite
                 !isEnabled() || !optionEnabled);
     }
 
-    protected void setOptionReadOnly(VCheckBox checkBox) {
+    protected void setOptionReadOnly(VCheckBox checkBox, JsonObject item) {
         if (isReadonly()) {
             checkBox.addStyleName("v-readonly");
             checkBox.setEnabled(false);
         } else {
             checkBox.removeStyleName("v-readonly");
-            checkBox.setEnabled(isEnabled());
+            boolean optionEnabled = !item
+                    .getBoolean(ListingJsonConstants.JSONKEY_ITEM_DISABLED);
+            checkBox.setEnabled(isEnabled() && optionEnabled);
         }
     }
 
@@ -228,7 +230,7 @@ public class VCheckBoxGroup extends FocusableFlowPanelComposite
     public void setReadonly(boolean readonly) {
         if (this.readonly != readonly) {
             this.readonly = readonly;
-            optionsToItems.keySet().forEach(this::setOptionReadOnly);
+            optionsToItems.forEach(this::setOptionReadOnly);
         }
     }
 

--- a/uitest/src/main/java/com/vaadin/tests/components/checkboxgroup/CheckBoxGroupReadOnly.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/checkboxgroup/CheckBoxGroupReadOnly.java
@@ -1,0 +1,30 @@
+package com.vaadin.tests.components.checkboxgroup;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.CheckBoxGroup;
+import com.vaadin.ui.Button;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class CheckBoxGroupReadOnly extends AbstractTestUI {
+    @Override
+    protected void setup(VaadinRequest request) {
+        CheckBoxGroup<Integer> cbg = new CheckBoxGroup<>();
+        cbg.setId("cbg");
+        cbg.setItems(1, 2, 3, 4);
+        cbg.setReadOnly(true);
+        addComponent(cbg);
+
+        Button changeReadOnly = new Button("Change Read-Only", e -> {
+            cbg.setReadOnly(!cbg.isReadOnly());
+        });
+        changeReadOnly.setId("changeReadOnly");
+        Button changeEnabled = new Button("Change Enabled", e -> {
+            cbg.setEnabled(!cbg.isEnabled());
+        });
+        changeEnabled.setId("changeEnabled");
+        addComponent(changeReadOnly);
+        addComponent(changeEnabled);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/checkboxgroup/CheckBoxGroupReadOnlyTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/checkboxgroup/CheckBoxGroupReadOnlyTest.java
@@ -1,0 +1,46 @@
+package com.vaadin.tests.components.checkboxgroup;
+
+import com.vaadin.testbench.elements.CheckBoxGroupElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+public class CheckBoxGroupReadOnlyTest extends MultiBrowserTest {
+
+    @Test
+    public void itemsAreReadOnly() {
+        openTestURL();
+        // Initially components are read-only
+        assertTrue(getSelect().isReadOnly());
+        assertEquals(4, findReadOnlyCheckboxes().size());
+        // Should not contain v-readonly
+        findElement(By.id("changeReadOnly")).click();
+        assertEquals(0, findReadOnlyCheckboxes().size());
+
+        // Should not contain v-readonly
+        findElement(By.id("changeEnabled")).click();
+        assertEquals(0, findReadOnlyCheckboxes().size());
+
+        // make read-only
+        findElement(By.id("changeReadOnly")).click();
+        // enable
+        findElement(By.id("changeEnabled")).click();
+        // Should contain v-readonly
+        assertEquals(4, findReadOnlyCheckboxes().size());
+    }
+
+    protected CheckBoxGroupElement getSelect() {
+        return $(CheckBoxGroupElement.class).first();
+    }
+
+    private List<WebElement> findReadOnlyCheckboxes() {
+        return findElement(By.id("cbg"))
+                .findElements(By.cssSelector("span.v-readonly.v-checkbox"));
+    }
+}


### PR DESCRIPTION
Setting read-only state to CheckBoxGroup should disable adding clicking effect. Missing v-readonly style is added to every CheckBox in the component, if it's set to read-only.

Fixes: https://github.com/vaadin/framework/issues/11113

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11370)
<!-- Reviewable:end -->
