### PR TITLE
Increase max treegrid depth

### DIFF
--- a/themes/src/main/themes/VAADIN/themes/valo/components/_treegrid.scss
+++ b/themes/src/main/themes/VAADIN/themes/valo/components/_treegrid.scss
@@ -55,7 +55,7 @@ $v-treegrid-class-depth: depth !default;
 
   // Hierarchy depth styling
   .#{$primary-stylename}-node {
-    @for $i from 0 through 15 {
+    @for $i from 0 through 31 {
       &.#{$v-treegrid-class-depth}-#{$i} {
         padding-left: $v-treegrid-indent * $i;
       }


### PR DESCRIPTION
Currently, rows deeper than 16 won't get indented. This fix updates the max depth to 32.

Fixes https://github.com/vaadin/framework/issues/11358

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11375)
<!-- Reviewable:end -->
