### PR TITLE
Add Javadoc to the ScrollTo methods in TreeGrid

### DIFF
--- a/server/src/main/java/com/vaadin/ui/TreeGrid.java
+++ b/server/src/main/java/com/vaadin/ui/TreeGrid.java
@@ -43,6 +43,7 @@ import com.vaadin.event.CollapseEvent.CollapseListener;
 import com.vaadin.event.ExpandEvent;
 import com.vaadin.event.ExpandEvent.ExpandListener;
 import com.vaadin.shared.Registration;
+import com.vaadin.shared.ui.grid.ScrollDestination;
 import com.vaadin.shared.ui.treegrid.FocusParentRpc;
 import com.vaadin.shared.ui.treegrid.FocusRpc;
 import com.vaadin.shared.ui.treegrid.NodeCollapseRpc;
@@ -197,6 +198,46 @@ public class TreeGrid<T> extends Grid<T>
                 getRpcProxy(FocusRpc.class).focusCell(parentIndex, cellIndex);
             }
         });
+    }
+
+    /**
+     * This method is inherited from Grid but should never be called directly
+     * with a TreeGrid
+     */
+    @Override
+    @Deprecated
+    public void scrollTo(int row) throws IllegalArgumentException {
+        super.scrollTo(row);
+    }
+
+    /**
+     * This method is inherited from Grid but should never be called directly
+     * with a TreeGrid
+     */
+    @Deprecated
+    @Override
+    public void scrollTo(int row, ScrollDestination destination) {
+        super.scrollTo(row, destination);
+    }
+
+    /**
+     * This method is inherited from Grid but should never be called directly
+     * with a TreeGrid
+     */
+    @Deprecated
+    @Override
+    public void scrollToEnd() {
+        super.scrollToEnd();
+    }
+
+    /**
+     * This method is inherited from Grid but should never be called directly
+     * with a TreeGrid
+     */
+    @Deprecated
+    @Override
+    public void scrollToStart() {
+        super.scrollToStart();
     }
 
     /**

--- a/server/src/main/java/com/vaadin/ui/TreeGrid.java
+++ b/server/src/main/java/com/vaadin/ui/TreeGrid.java
@@ -221,26 +221,6 @@ public class TreeGrid<T> extends Grid<T>
     }
 
     /**
-     * This method is inherited from Grid but should never be called directly
-     * with a TreeGrid
-     */
-    @Deprecated
-    @Override
-    public void scrollToEnd() {
-        super.scrollToEnd();
-    }
-
-    /**
-     * This method is inherited from Grid but should never be called directly
-     * with a TreeGrid
-     */
-    @Deprecated
-    @Override
-    public void scrollToStart() {
-        super.scrollToStart();
-    }
-
-    /**
      * Adds an ExpandListener to this TreeGrid.
      *
      * @see ExpandEvent


### PR DESCRIPTION
The current `scrollTo` methods don't make sense for TreeGrid, as it can scroll to any place with the same index based on the current Tree state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11399)
<!-- Reviewable:end -->
