### PR TITLE
Fixes #11369 in 7.x

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/window/WindowConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/window/WindowConnector.java
@@ -339,6 +339,22 @@ public class WindowConnector extends AbstractSingleComponentContainerConnector
                 }
                 return newEl;
             }
+            if ("iframe".equalsIgnoreCase(old.getTagName()) && old
+                    .hasAttribute("src") && old.getAttribute("src")
+                    .contains("APP/connector")) {
+                // an iframe reloads when reattached to the DOM, but
+                // unfortunately, when newEl is reattached, server-side
+                // resource (e.g. generated PDF) is already gone, so this will
+                // end up with 404, which might be undesirable.
+                // Instead of the resource that is not available anymore,
+                // let's just use empty iframe.
+                // See
+                // https://github.com/vaadin/framework/issues/11369
+                // for details of the issue this works around
+                Element newEl = old.cloneNode(false).cast();
+                newEl.setAttribute("src", "about:blank");
+                return newEl;
+            }
         }
         Node res = node.cloneNode(false);
         if (node.hasChildNodes()) {


### PR DESCRIPTION
Clear contents of iframe clone that is in a Window so that when it's reattached to DOM we don't get 404

Fixes  #11369

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11402)
<!-- Reviewable:end -->
