### PR TITLE
If doCometSupport returns Action.CANCELLED HTTP 200 is not correct 

### DIFF
--- a/server/src/main/java/com/vaadin/server/communication/PushRequestHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushRequestHandler.java
@@ -25,6 +25,7 @@ import javax.servlet.ServletException;
 
 import org.atmosphere.cache.UUIDBroadcasterCache;
 import org.atmosphere.client.TrackMessageSizeInterceptor;
+import org.atmosphere.cpr.Action
 import org.atmosphere.cpr.ApplicationConfig;
 import org.atmosphere.cpr.AtmosphereFramework;
 import org.atmosphere.cpr.AtmosphereFramework.AtmosphereHandlerWrapper;
@@ -231,11 +232,15 @@ public class PushRequestHandler implements SessionExpiredHandler {
                 return true;
             }
             try {
-                atmosphere.doCometSupport(
+                Action action = atmosphere.doCometSupport(
                         AtmosphereRequestImpl
                                 .wrap((VaadinServletRequest) request),
                         AtmosphereResponseImpl
                                 .wrap((VaadinServletResponse) response));
+                if (action == Action.CANCELLED) {
+                    response.sendError(400,"Cancelled. No push available.");
+                    return true;
+                }
             } catch (ServletException e) {
                 // TODO PUSH decide how to handle
                 throw new RuntimeException(e);

--- a/server/src/main/java/com/vaadin/server/communication/PushRequestHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushRequestHandler.java
@@ -25,7 +25,7 @@ import javax.servlet.ServletException;
 
 import org.atmosphere.cache.UUIDBroadcasterCache;
 import org.atmosphere.client.TrackMessageSizeInterceptor;
-import org.atmosphere.cpr.Action
+import org.atmosphere.cpr.Action;
 import org.atmosphere.cpr.ApplicationConfig;
 import org.atmosphere.cpr.AtmosphereFramework;
 import org.atmosphere.cpr.AtmosphereFramework.AtmosphereHandlerWrapper;


### PR DESCRIPTION
This patch will change handleRequest return HTTP 400 instead of 200 in case doCometSupport returns Action.CANCELLED

See also discussion here: https://stackoverflow.com/questions/46234679/what-is-the-correct-http-status-code-for-a-cancelled-request

According to Atmosphere code https://github.com/Atmosphere/atmosphere/blob/master/modules/runtime/src/main/java/org/atmosphere/runtime/AtmosphereFramework.java#L2267 it is always failure when value Action.CANCELLED is returned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11410)
<!-- Reviewable:end -->
