### PR TITLE
copied waitUntil to selectMenuPath from FW8

### DIFF
--- a/uitest/src/test/java/com/vaadin/tests/tb3/AbstractTB3Test.java
+++ b/uitest/src/test/java/com/vaadin/tests/tb3/AbstractTB3Test.java
@@ -1057,6 +1057,15 @@ public abstract class AbstractTB3Test extends ParallelTest {
     protected void selectMenuPath(String... menuCaptions) {
         selectMenu(menuCaptions[0], true);
 
+        // Make sure menu popup is opened.
+        waitUntil(new ExpectedCondition<Boolean>() {
+            @Override
+            public Boolean apply(WebDriver webDriver) {
+                return isElementPresent(By.className("gwt-MenuBarPopup"))
+                        || isElementPresent(By.className("v-menubar-popup"));
+            }
+        });
+        
         // Move to the menu item opened below the menu bar.
         new Actions(getDriver())
                 .moveByOffset(0,


### PR DESCRIPTION
Lots of Firefox UI tests are failing at the `selectMenuPath` method of AbstractTB3Test class. FW8 has a `waitUntil` there to make sure the menu is present, used a similar approach here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11415)
<!-- Reviewable:end -->
