### PR TITLE
added [source, java] for ComponentRenderer samples

### DIFF
--- a/documentation/components/components-grid.asciidoc
+++ b/documentation/components/components-grid.asciidoc
@@ -586,6 +586,7 @@ the height of all rows in the Grid.
 +
 Use [classname]#Button# in [classname]#Grid#:
 +
+[source, java]
 ----
 grid.addComponentColumn(person -> {
       Button button = new Button("Click me!");
@@ -603,6 +604,7 @@ example on how to achieve this.
 +
 Store a [classname]#TextField# with changed value.
 +
+[source, java]
 ----
 Map<Person, TextField> textFields = new HashMap<>();
 grid.addColumn(person -> {


### PR DESCRIPTION
Java formatting was not applied for example code snippets

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11428)
<!-- Reviewable:end -->
