### PR TITLE
Fix ComboBoxElement clear method

### DIFF
--- a/testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
+++ b/testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
@@ -52,9 +52,8 @@ public class ComboBoxElement extends AbstractSingleSelectElement {
             selectByTextFromPopup(text);
             return;
         }
-        getInputField().clear();
-        getInputField().sendKeys(text);
-
+        clear();
+        sendKeys(text);
         selectSuggestion(text);
     }
 
@@ -85,7 +84,7 @@ public class ComboBoxElement extends AbstractSingleSelectElement {
 
     private boolean selectSuggestion(String text) {
         for (WebElement suggestion : getPopupSuggestionElements()) {
-            if (text.equals(suggestion.getText())) {
+            if (text.equalsIgnoreCase(suggestion.getText())) {
                 clickElement(suggestion);
                 return true;
             }
@@ -231,6 +230,11 @@ public class ComboBoxElement extends AbstractSingleSelectElement {
     @Override
     public void clear() {
         getInputField().clear();
+        String value = getText();
+        if (value != null && !value.isEmpty()) {
+            ((JavascriptExecutor) getDriver())
+                    .executeScript("arguments[0].value = ''", getInputField());
+        }
     }
 
     @Override

--- a/testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
+++ b/testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
@@ -84,7 +84,7 @@ public class ComboBoxElement extends AbstractSingleSelectElement {
 
     private boolean selectSuggestion(String text) {
         for (WebElement suggestion : getPopupSuggestionElements()) {
-            if (text.equalsIgnoreCase(suggestion.getText())) {
+            if (text.equals(suggestion.getText())) {
                 clickElement(suggestion);
                 return true;
             }

--- a/uitest/src/test/java/com/vaadin/tests/components/ErrorLevelsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ErrorLevelsTest.java
@@ -147,10 +147,8 @@ public class ErrorLevelsTest extends SingleBrowserTest {
     }
 
     private void selectErrorLevel(ErrorLevel errorLevel) {
-        errorLevelSelector.clear();
         errorLevelSelector
-                .sendKeys(errorLevel.toString().toLowerCase(Locale.ROOT));
-        errorLevelSelector.sendKeys(getReturn());
+                .selectByText(errorLevel.toString().toLowerCase(Locale.ROOT));
     }
 
     private Keys getReturn() {

--- a/uitest/src/test/java/com/vaadin/tests/components/ErrorLevelsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ErrorLevelsTest.java
@@ -148,14 +148,7 @@ public class ErrorLevelsTest extends SingleBrowserTest {
 
     private void selectErrorLevel(ErrorLevel errorLevel) {
         errorLevelSelector
-                .selectByText(errorLevel.toString().toLowerCase(Locale.ROOT));
+                .selectByText(errorLevel.toString().toUpperCase(Locale.ROOT));
     }
 
-    private Keys getReturn() {
-        if (BrowserUtil.isPhantomJS(getDesiredCapabilities())) {
-            return Keys.ENTER;
-        } else {
-            return Keys.RETURN;
-        }
-    }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
@@ -137,7 +137,9 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
 
     protected void typeInputAndSelect(String input,
             SelectionType selectionType) {
-        comboBoxElement.clear();
+        // clear() would cause an additional value change in chrome 70+
+        // since it always makes blur after clear()
+        comboBoxElement.sendKeys(Keys.BACK_SPACE, Keys.BACK_SPACE, Keys.BACK_SPACE);
         sendKeysToInput(input);
         switch (selectionType) {
         case ENTER:


### PR DESCRIPTION
Explicitly reset the value in case if it was cleared.
Ignore the case for selecting a suggestion.

Fixes https://github.com/vaadin/testbench/issues/1122

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11430)
<!-- Reviewable:end -->
