### PR TITLE
Add git config hint to README to allow long paths in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The distribution files can be built by running the standard Maven goal `mvn inst
 1. Run
 <code>git clone https://github.com/vaadin/framework.git</code>
 command or clone the repository your favorite Git tool.
-If using Windows, you might want to add these Git settings: `core.autocrlf=false` and `core.fileMode=false`.
+If using Windows, you might want to add these Git settings: `core.autocrlf=false`, `core.fileMode=false` and `core.longpaths=true`.
 1. Run <code>mvn install</code> in the project root.
 Note that the first compilation takes a while to finish as maven downloads dependencies used in the projects.
 1. Start Eclipse with the workspace you would like to use. It is usually a good idea to use the parent folder of the Git repository as the workspace folder.


### PR DESCRIPTION
Let's add an hint to the README how to configure git to allow long paths. 
**NEW** in README: `core.longpaths=true`

This is needed for windows, because windows paths under NTFS are limited to 255 chars. But in this repository we have very long paths:
`test/servlet-containers/karaf/karaf-run/apache-karaf-4.2.1-minimal/system/org/apache/servicemix/bundles/org.apache.servicemix.bundles.not-yet-commons-ssl/0.3.11_1/org.apache.servicemix.bundles.not-yet-commons-ssl-0.3.11_1.jar: `
> Lenght: 266!

So if we place our git repository in a path wich is longer than 20 chars we can clone the repo but it's not possible to check it out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11443)
<!-- Reviewable:end -->
