### PR TITLE
Add lost `getContainerElement()` to `VMenuBar`

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VMenuBar.java
+++ b/client/src/main/java/com/vaadin/client/ui/VMenuBar.java
@@ -316,6 +316,15 @@ public class VMenuBar extends FocusableFlowPanel implements
     }
 
     /**
+     * Returns the containing element of the menu.
+     *
+     * @return containerElement
+     */
+    public com.google.gwt.user.client.Element getContainerElement() {
+        return DOM.asOld(containerElement);
+    }
+
+    /**
      * Add a new item to this menu.
      *
      * @param html


### PR DESCRIPTION
Adds access to the `VMenuBar#containerElement` which was removed in the `VMenuBar` restructuring 
of #10259.  There the `getContainerElement()` was removed because it wasn't mandatory anymore from the parent `SimplePanel`.
But as you can see on the users of the field `containerElement` it's still very handy if you want to add an new element at the first position.

It cotrrect, that `getElement()` is a logical and working alternative with the same function. But isn't better to make it clear what I get?
`getContainerElement()` //Returns the containing element of the menu. **vs**
`getElement()`  // the object's browser element
But it's true, even in the `PopupPanel` the `getContainerElement()` returns `getElement()`. In our case the #10259 was a breaking change, which was easy to fix.
Se yes if its the goal to get rid of the `getContainerElement()` with the same value and breaking changes are no problem, we should close my pull request. 

> Duplicate of [#11442](https://github.com/vaadin/framework/pull/11442) buf with the correct username and mail to sign the CLAs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11446)
<!-- Reviewable:end -->
