### PR TITLE
Fix initially selected CheckBox rendering in Safari in v7 compatibili…

### DIFF
--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCheckBox.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCheckBox.java
@@ -16,7 +16,9 @@
 
 package com.vaadin.v7.client.ui;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.DOM;
@@ -105,5 +107,22 @@ public class VCheckBox extends com.google.gwt.user.client.ui.CheckBox
     @Override
     public void setAriaInvalid(boolean invalid) {
         AriaHelper.handleInputInvalid(getCheckBoxElement(), invalid);
+    }
+
+    @Override
+    protected void onAttach() {
+        super.onAttach();
+
+        if (BrowserInfo.get().isSafari()) {
+            /*
+             * Sometimes Safari does not render checkbox correctly when
+             * attaching. Setting the visibility to hidden and a bit later
+             * restoring will make everything just fine.
+             */
+            getElement().getStyle().setVisibility(Style.Visibility.HIDDEN);
+            Scheduler.get().scheduleFinally(() -> {
+                getElement().getStyle().setVisibility(Style.Visibility.VISIBLE);
+            });
+        }
     }
 }


### PR DESCRIPTION
…ty package (#11024)

This fix was already applied to com.vaadin.client.ui.VCheckBox but the committer forgot to apply the same fix to the com.vaadin.v7.client.ui.VCheckBox. Some people are still temporarily using the checkbox from the compatibility package.

Fixes #11024 for those who are using the checkbox from the v7 compatibility package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11456)
<!-- Reviewable:end -->
