### PR TITLE
Issue #11459: Provide extensive error information on GridLayout.OutOfBoundsException and IllegalArgumentException

### DIFF
--- a/server/src/main/java/com/vaadin/ui/GridLayout.java
+++ b/server/src/main/java/com/vaadin/ui/GridLayout.java
@@ -204,7 +204,8 @@ public class GridLayout extends AbstractLayout
         // Checks the validity of the coordinates
         if (column2 < column1 || row2 < row1) {
             throw new IllegalArgumentException(
-                    "Illegal coordinates for the component");
+                    "Illegal coordinates for the component: " + column1 + "=<"
+                            + column2 + ", " + row1 + "=<" + row2);
         }
         if (column1 < 0 || row1 < 0 || column2 >= getColumns()
                 || row2 >= getRows()) {

--- a/server/src/main/java/com/vaadin/ui/GridLayout.java
+++ b/server/src/main/java/com/vaadin/ui/GridLayout.java
@@ -203,9 +203,9 @@ public class GridLayout extends AbstractLayout
 
         // Checks the validity of the coordinates
         if (column2 < column1 || row2 < row1) {
-            throw new IllegalArgumentException(
-                    "Illegal coordinates for the component: " + column1 + "=<"
-                            + column2 + ", " + row1 + "=<" + row2);
+            throw new IllegalArgumentException(String.format(
+                    "Illegal coordinates for the component: %s!<=%s, %s!<=%s",
+                    column1, column2, row1, row2));
         }
         if (column1 < 0 || row1 < 0 || column2 >= getColumns()
                 || row2 >= getRows()) {
@@ -612,6 +612,11 @@ public class GridLayout extends AbstractLayout
             return childData.row2;
         }
 
+        @Override
+        public String toString() {
+            return String.format("Area{%s,%s - %s,%s}", getColumn1(), getRow1(),
+                    getColumn2(), getRow2());
+        }
     }
 
     private static boolean componentsOverlap(ChildComponentData a,
@@ -695,6 +700,8 @@ public class GridLayout extends AbstractLayout
          * @param areaOutOfBounds
          */
         public OutOfBoundsException(Area areaOutOfBounds) {
+            super(String.format("%s, layout dimension: %sx%s", areaOutOfBounds,
+                    getColumns(), getRows()));
             this.areaOutOfBounds = areaOutOfBounds;
         }
 

--- a/server/src/test/java/com/vaadin/tests/server/component/gridlayout/GridLayoutTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/gridlayout/GridLayoutTest.java
@@ -118,7 +118,7 @@ public class GridLayoutTest {
             grid.addComponent(new Label(), 3, 3, 2, 2);
             fail("Should have failed");
         } catch (IllegalArgumentException ex) {
-            assertEquals("Illegal coordinates for the component: 3=<2, 3=<2",
+            assertEquals("Illegal coordinates for the component: 3!<=2, 3!<=2",
                     ex.getMessage());
         }
     }

--- a/server/src/test/java/com/vaadin/tests/server/component/gridlayout/GridLayoutTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/gridlayout/GridLayoutTest.java
@@ -99,6 +99,28 @@ public class GridLayoutTest {
         assertEquals(1, gl.getColumnExpandRatio(1), 0);
     }
 
+    @Test
+    public void verifyOutOfBoundsExceptionContainsHelpfulMessage() {
+        GridLayout grid = new GridLayout(1, 1);
+        try {
+            grid.addComponent(new Label(), 3, 3);
+            fail("Should have failed");
+        } catch (GridLayout.OutOfBoundsException ex) {
+            assertEquals("Area{3,3 - 3,3}, layout dimension: 1x1", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void verifyAddComponentFailsWithHelpfulMessageOnInvalidArgs() {
+        GridLayout grid = new GridLayout(6, 6);
+        try {
+            grid.addComponent(new Label(), 3, 3, 2, 2);
+            fail("Should have failed");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Illegal coordinates for the component: 3=<2, 3=<2", ex.getMessage());
+        }
+    }
+
     private void assertContentPositions(GridLayout grid) {
         assertEquals(grid.getComponentCount(), children.length);
         int c = 0;

--- a/server/src/test/java/com/vaadin/tests/server/component/gridlayout/GridLayoutTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/gridlayout/GridLayoutTest.java
@@ -106,7 +106,8 @@ public class GridLayoutTest {
             grid.addComponent(new Label(), 3, 3);
             fail("Should have failed");
         } catch (GridLayout.OutOfBoundsException ex) {
-            assertEquals("Area{3,3 - 3,3}, layout dimension: 1x1", ex.getMessage());
+            assertEquals("Area{3,3 - 3,3}, layout dimension: 1x1",
+                    ex.getMessage());
         }
     }
 
@@ -117,7 +118,8 @@ public class GridLayoutTest {
             grid.addComponent(new Label(), 3, 3, 2, 2);
             fail("Should have failed");
         } catch (IllegalArgumentException ex) {
-            assertEquals("Illegal coordinates for the component: 3=<2, 3=<2", ex.getMessage());
+            assertEquals("Illegal coordinates for the component: 3=<2, 3=<2",
+                    ex.getMessage());
         }
     }
 


### PR DESCRIPTION
The patch provides more information when GridLayout.OutOfBoundsException or IllegalArgumentException is thrown.

Fixes #11459

**Check when you have completed**
[x] Valid tests for the pull request
[x] Contributing guidelines implemented

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11461)
<!-- Reviewable:end -->
