### PR TITLE
Catch exception that is thrown when Grid is scrolled during operation

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -2140,15 +2140,21 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             double newLeft = frozenWidth - scrollLeft;
             cellWrapper.getStyle().setLeft(newLeft, Unit.PX);
 
-            // sometimes focus handling twists the editor row out of alignment
-            // with the grid itself and the position needs to be compensated for
-            TableRowElement rowElement = grid.getEscalator().getBody()
+            try {
+                // sometimes focus handling twists the editor row out of alignment
+                // with the grid itself and the position needs to be compensated for
+                TableRowElement rowElement = grid.getEscalator().getBody()
                     .getRowElement(grid.getEditor().getRow());
-            int rowLeft = rowElement.getAbsoluteLeft();
-            int editorLeft = cellWrapper.getAbsoluteLeft();
-            if (editorLeft != rowLeft + frozenWidth) {
-                cellWrapper.getStyle().setLeft(newLeft + rowLeft - editorLeft,
+                int rowLeft = rowElement.getAbsoluteLeft();
+                int editorLeft = cellWrapper.getAbsoluteLeft();
+                if (editorLeft != rowLeft + frozenWidth) {
+                    cellWrapper.getStyle().setLeft(newLeft + rowLeft - editorLeft,
                         Unit.PX);
+                }
+            } catch (IllegalStateException e) {
+                // IllegalStateException may occur if user has scrolled Grid so
+                // that Escalator has updated, and row under Editor is no longer
+                // there
             }
         }
 


### PR DESCRIPTION
IllegalStateException may occur if user has scrolled Grid so that Escalator has updated, and row under Editor is no longer there

Fixes https://github.com/vaadin/framework/issues/11463

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11467)
<!-- Reviewable:end -->
