### PR TITLE
Remove redundant check for for Firefox

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VAbstractCalendarPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractCalendarPanel.java
@@ -214,16 +214,7 @@ public abstract class VAbstractCalendarPanel<R extends Enum<R>>
         setStyleName(VDateField.CLASSNAME + "-calendarpanel");
         Roles.getGridRole().set(getElement());
 
-        /*
-         * Firefox auto-repeat works correctly only if we use a key press
-         * handler, other browsers handle it correctly when using a key down
-         * handler
-         */
-        if (BrowserInfo.get().isGecko()) {
-            addKeyPressHandler(this);
-        } else {
-            addKeyDownHandler(this);
-        }
+        addKeyDownHandler(this);
         addFocusHandler(this);
         addBlurHandler(this);
     }

--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldNavigationKeyBoard.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/DateFieldNavigationKeyBoard.java
@@ -1,0 +1,31 @@
+package com.vaadin.tests.components.datefield;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.AbstractLocalDateField;
+import com.vaadin.ui.DateField;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class DateFieldNavigationKeyBoard extends AbstractTestUI {
+
+    static final String DATEFIELD_ID = "datefield";
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        final AbstractLocalDateField df = new DateField();
+        df.setId(DATEFIELD_ID);
+        addComponent(df);
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Navigation in popup should be possible via arrows in Firefox 65 and later";
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 11465;
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldNavigationKeyBoardTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldNavigationKeyBoardTest.java
@@ -1,0 +1,30 @@
+package com.vaadin.tests.components.datefield;
+
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertNotEquals;
+
+public class DateFieldNavigationKeyBoardTest extends MultiBrowserTest {
+    @Test
+    public void testNavigation() {
+        openTestURL();
+        // Opening pop-up
+        findElement(By.className("v-datefield-button")).click();
+        waitForElementVisible(By.className("v-datefield-calendarpanel"));
+        // Focused element in the calendarPanel
+        WebElement focused = findElement(
+                By.className("v-datefield-calendarpanel-day-focused"));
+        // Value in it
+        String dayValue = focused.getText();
+        findElement(By.className("v-datefield-calendarpanel"))
+                .sendKeys(Keys.ARROW_LEFT);
+        assertNotEquals(dayValue,
+                findElement(
+                        By.className("v-datefield-calendarpanel-day-focused"))
+                                .getText());
+    }
+}


### PR DESCRIPTION
It seems that in older versions of Firefox (at least, older than 45) the **KeyPress** event should be used instead of **KeyDown** under certain circumstances, for example, if we want to navigate via arrows in table element. At some point (works already on 58 version, the current one is 65) the issue was resolved and starting from Firefox 65 this hook prevents from navigating in the pop-up via keyboard.
Simply removing additional logic makes navigating in both _DateField_ and _InlineDateField_ possible

Fixes #11465

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11471)
<!-- Reviewable:end -->
