### PR TITLE
Fix NPE in v7 compatibility Grid during datasource rebind

### DIFF
--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
@@ -7023,10 +7023,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
         selectionModel.reset();
 
-        if (this.dataSource != null) {
-            this.dataSource.addDataChangeHandler((DataChangeHandler) null);
-        }
-
         this.dataSource = dataSource;
         dataSource.addDataChangeHandler(new DataChangeHandler() {
                     @Override

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
@@ -4152,6 +4152,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      * on initialization, but not after that.
      */
     private DataSource<T> dataSource;
+    private Registration changeHandler;
 
     /**
      * Currently available row range in DataSource.
@@ -7023,8 +7024,13 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
         selectionModel.reset();
 
+        if (changeHandler != null) {
+            changeHandler.remove();
+            changeHandler = null;
+        }
+
         this.dataSource = dataSource;
-        dataSource.addDataChangeHandler(new DataChangeHandler() {
+		changeHandler = dataSource.addDataChangeHandler(new DataChangeHandler() {
                     @Override
                     public void dataUpdated(int firstIndex, int numberOfItems) {
                         escalator.getBody().refreshRows(firstIndex, numberOfItems);

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridRebindDataSourceV7.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridRebindDataSourceV7.java
@@ -1,0 +1,42 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.v7.data.util.IndexedContainer;
+import com.vaadin.v7.ui.Grid;
+
+@Widgetset("com.vaadin.v7.Vaadin7WidgetSet")
+public class GridRebindDataSourceV7 extends AbstractTestUI {
+    private Grid grid;
+    private IndexedContainer container = new IndexedContainer();
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        container.addContainerProperty("name", String.class, null);
+        container.addItem("test").getItemProperty("name").setValue("test");
+        grid = new Grid();
+        grid.setContainerDataSource(container);
+        grid.setEditorEnabled(true);
+        addComponent(grid);
+
+        Button button = new Button("Change container",
+                new Button.ClickListener() {
+
+                    @Override
+                    public void buttonClick(Button.ClickEvent event) {
+                        IndexedContainer container = new IndexedContainer();
+                        container.addContainerProperty("age", Integer.class,
+                                null);
+                        container.addItem("first").getItemProperty("age")
+                                .setValue(45);
+                        grid.removeAllColumns();
+                        grid.setContainerDataSource(container);
+                    }
+                });
+        button.setId("changeContainer");
+        addComponent(button);
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridRebindDataSourceV7Test.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridRebindDataSourceV7Test.java
@@ -1,0 +1,23 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+public class GridRebindDataSourceV7Test extends MultiBrowserTest {
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+
+        setDebug(true);
+        openTestURL();
+        waitForElementPresent(By.className("v-grid"));
+    }
+
+    @Test
+    public void testNoNPE() {
+        findElement(By.id("changeContainer")).click();
+        assertNoErrorNotifications();
+    }
+}


### PR DESCRIPTION
This fixes an **NPE** on the `com.vaadin.v7.client.widgets.Grid#setDataSource`. Calling it twice will cause a NPE because `dataSource.addDataChangeHandler(null);` is not allowed.

@see `ListDataSource`
> `com.vaadin.client.widget.grid.datasources.ListDataSource#addDataChangeHandler`
> `Objects.requireNonNull(dataChangeHandler,  "DataChangeHandler can't be null");`

@see `AbstractRemoteDataSource`
> `com.vaadin.client.data.AbstractRemoteDataSource#addDataChangeHandler`
> `Objects.requireNonNull(dataChangeHandler,  "DataChangeHandler can't be null");`
  
This broken behavior was introduced by
@OlliTietavainenVaadin in `8313623dd318c92aa49e9cf96268f5fff6ad6456` as
> v7 Grid performance improvements picked to compatibility package

This error is nasty because it happens only the second time you visit the component and it's only visible in JS Debug. So let's roll this line back to allow data rebind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11473)
<!-- Reviewable:end -->
