### PR TITLE
Making V8 ReadOnly TextField select row in table upon clicking

### DIFF
--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
@@ -6488,7 +6488,10 @@ public class VScrollTable extends FlowPanel
                     if (!(widget instanceof VLabel)
                             && !(widget instanceof VEmbedded)
                             && !(widget instanceof VTextField
-                                    && ((VTextField) widget).isReadOnly())) {
+                                && ((VTextField) widget).isReadOnly())
+                            && !(widget instanceof com.vaadin.client.ui.VLabel)
+                            && !(widget instanceof com.vaadin.client.ui.VTextField
+                                && ((com.vaadin.client.ui.VTextField) widget).isReadOnly())) {
                         return null;
                     }
                 }

--- a/uitest/src/main/java/com/vaadin/tests/components/table/TableReadOnlyTextField.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/table/TableReadOnlyTextField.java
@@ -1,0 +1,54 @@
+package com.vaadin.tests.components.table;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Label;
+import com.vaadin.v7.ui.Table;
+
+public class TableReadOnlyTextField extends AbstractTestUI {
+
+    @Override
+    public String getDescription() {
+        return "Selected row clicking ReadOnly Textfield should should work";
+    }
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        addComponent(makeTable());
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 11474;
+    }
+
+    private Table makeTable() {
+
+        final Table table = new Table("Table");
+        final Label clickLabel = new Label("Click?");
+        final Label valueChangeLabel = new Label("Value?");
+
+        table.addContainerProperty("Main", String.class, null);
+        table.addContainerProperty("Details", com.vaadin.ui.TextField.class,
+                null);
+        for (int i = 0; i < 3; i++) {
+            com.vaadin.ui.TextField test = new com.vaadin.ui.TextField(
+                    "Testing " + i);
+            test.setValue("Test " + i);
+            test.setReadOnly(true);
+            table.addItem(new Object[] { ("Value" + i), test }, i);
+        }
+        table.setImmediate(true);
+        table.setSelectable(true);
+        table.addItemClickListener(event -> {
+            table.markAsDirty();
+            clickLabel.setValue("Click " + event.getItemId());
+        });
+
+        table.addValueChangeListener(event -> valueChangeLabel
+                .setValue("Value " + event.getProperty().getValue()));
+        getLayout().addComponent(clickLabel);
+        getLayout().addComponent(valueChangeLabel);
+        return table;
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/table/TableReadOnlyTextFieldTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/table/TableReadOnlyTextFieldTest.java
@@ -1,0 +1,29 @@
+package com.vaadin.tests.components.table;
+
+import com.vaadin.testbench.elements.TableElement;
+import com.vaadin.testbench.elements.TableRowElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TableReadOnlyTextFieldTest extends MultiBrowserTest {
+
+    @Test
+    public void selectRowOnTextFieldClick() {
+        openTestURL();
+        TableElement table = $(TableElement.class).first();
+        assertFalse(isSelected(table.getRow(0)));
+        findElement(By.className("v-textfield-readonly")).click();
+        assertTrue(
+                "The row should be selected, if read-only TextField is clicked",
+                isSelected(table.getRow(0)));
+
+    }
+
+    private boolean isSelected(TableRowElement row) {
+        return hasCssClass(row, "v-selected");
+    }
+}


### PR DESCRIPTION
Add check for the V8 TextField used in Table in compatibility mode. This makes clicking cell with the TextField select the row, preserving behaviour from V7.
Through, as it's noted also before, this is an improved workaround, not a proper solution to address the issue.

Fixes #11474

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11480)
<!-- Reviewable:end -->
