### PR TITLE
Fix ComboBoxElement clear method

### DIFF
--- a/testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
+++ b/testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
@@ -52,8 +52,8 @@ public class ComboBoxElement extends AbstractSingleSelectElement {
             selectByTextFromPopup(text);
             return;
         }
-        getInputField().clear();
-        getInputField().sendKeys(text);
+        clear();
+        sendKeys(text);
 
         selectSuggestion(text);
     }
@@ -231,6 +231,11 @@ public class ComboBoxElement extends AbstractSingleSelectElement {
     @Override
     public void clear() {
         getInputField().clear();
+        String value = getText();
+        if (value != null && !value.isEmpty()) {
+            ((JavascriptExecutor) getDriver())
+                    .executeScript("arguments[0].value = ''", getInputField());
+        }
     }
 
     @Override

--- a/uitest/src/test/java/com/vaadin/tests/components/ErrorLevelsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ErrorLevelsTest.java
@@ -147,17 +147,7 @@ public class ErrorLevelsTest extends SingleBrowserTest {
     }
 
     private void selectErrorLevel(ErrorLevel errorLevel) {
-        errorLevelSelector.clear();
         errorLevelSelector
-                .sendKeys(errorLevel.toString().toLowerCase(Locale.ROOT));
-        errorLevelSelector.sendKeys(getReturn());
-    }
-
-    private Keys getReturn() {
-        if (BrowserUtil.isPhantomJS(getDesiredCapabilities())) {
-            return Keys.ENTER;
-        } else {
-            return Keys.RETURN;
-        }
+                .selectByText(errorLevel.toString().toUpperCase(Locale.ROOT));
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/combobox/ComboBoxSelectingNewItemValueChangeTest.java
@@ -137,7 +137,9 @@ public class ComboBoxSelectingNewItemValueChangeTest extends MultiBrowserTest {
 
     protected void typeInputAndSelect(String input,
             SelectionType selectionType) {
-        comboBoxElement.clear();
+        // clear() would cause an additional value change in chrome 70+
+        // since it always makes blur after clear()
+        comboBoxElement.sendKeys(Keys.BACK_SPACE, Keys.BACK_SPACE, Keys.BACK_SPACE);
         sendKeysToInput(input);
         switch (selectionType) {
         case ENTER:


### PR DESCRIPTION
Explicitly reset the value in case if it was cleared.
Ignore the case for selecting a suggestion.

Fixes vaadin/testbench#1122

remade PR for #11430

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11483)
<!-- Reviewable:end -->
