### PR TITLE
Added note about dependency injection in BrowserWindowOpener JavaDocs

### DIFF
--- a/server/src/main/java/com/vaadin/server/BrowserWindowOpener.java
+++ b/server/src/main/java/com/vaadin/server/BrowserWindowOpener.java
@@ -71,6 +71,11 @@ public class BrowserWindowOpener extends AbstractExtension {
      * Creates a window opener that will open windows containing the provided UI
      * class.
      *
+     * Note: The new UI instance will not work with dependency injection (CDI). 
+     * Use {@link BrowserWindowOpener(String)} instead.
+     * {@code VaadinServlet.getCurrent().getServletContext().getContextPath()} gives 
+     * the current context path.
+     *
      * @param uiClass
      *            the UI class that should be opened when the extended component
      *            is clicked
@@ -82,6 +87,11 @@ public class BrowserWindowOpener extends AbstractExtension {
     /**
      * Creates a window opener that will open windows containing the provided UI
      * using the provided path.
+     *
+     * Note: The new UI instance will not work with dependency injection (CDI). 
+     * Use {@link BrowserWindowOpener(String)} instead.
+     * {@code VaadinServlet.getCurrent().getServletContext().getContextPath()} gives 
+     * the current context path.
      *
      * @param uiClass
      *            the UI class that should be opened when the extended component

--- a/server/src/main/java/com/vaadin/server/BrowserWindowOpener.java
+++ b/server/src/main/java/com/vaadin/server/BrowserWindowOpener.java
@@ -71,8 +71,8 @@ public class BrowserWindowOpener extends AbstractExtension {
      * Creates a window opener that will open windows containing the provided UI
      * class.
      *
-     * Note: The new UI instance will not work with dependency injection (CDI). 
-     * Use {@link BrowserWindowOpener(String)} instead.
+     * Note: The new UI instance will not work with dependency injection (CDI and
+     * Spring). Use {@link BrowserWindowOpener(String)} instead.
      * {@code VaadinServlet.getCurrent().getServletContext().getContextPath()} gives 
      * the current context path.
      *
@@ -88,8 +88,8 @@ public class BrowserWindowOpener extends AbstractExtension {
      * Creates a window opener that will open windows containing the provided UI
      * using the provided path.
      *
-     * Note: The new UI instance will not work with dependency injection (CDI). 
-     * Use {@link BrowserWindowOpener(String)} instead.
+     * Note: The new UI instance will not work with dependency injection (CDI
+     * and Spring). Use {@link BrowserWindowOpener(String)} instead.
      * {@code VaadinServlet.getCurrent().getServletContext().getContextPath()} gives 
      * the current context path.
      *

--- a/server/src/main/java/com/vaadin/server/BrowserWindowOpener.java
+++ b/server/src/main/java/com/vaadin/server/BrowserWindowOpener.java
@@ -75,7 +75,7 @@ public class BrowserWindowOpener extends AbstractExtension {
      * Spring). Use {@link BrowserWindowOpener(String)} instead.
      * {@code VaadinServlet.getCurrent().getServletContext().getContextPath()} gives 
      * the current context path.
-     *
+     * <p>
      * @param uiClass
      *            the UI class that should be opened when the extended component
      *            is clicked
@@ -87,7 +87,7 @@ public class BrowserWindowOpener extends AbstractExtension {
     /**
      * Creates a window opener that will open windows containing the provided UI
      * using the provided path.
-     *
+     * <p>
      * Note: The new UI instance will not work with dependency injection (CDI
      * and Spring). Use {@link BrowserWindowOpener(String)} instead.
      * {@code VaadinServlet.getCurrent().getServletContext().getContextPath()} gives 

--- a/server/src/main/java/com/vaadin/server/BrowserWindowOpener.java
+++ b/server/src/main/java/com/vaadin/server/BrowserWindowOpener.java
@@ -70,12 +70,12 @@ public class BrowserWindowOpener extends AbstractExtension {
     /**
      * Creates a window opener that will open windows containing the provided UI
      * class.
-     *
+     * <p>
      * Note: The new UI instance will not work with dependency injection (CDI and
      * Spring). Use {@link BrowserWindowOpener(String)} instead.
      * {@code VaadinServlet.getCurrent().getServletContext().getContextPath()} gives 
      * the current context path.
-     * <p>
+     * 
      * @param uiClass
      *            the UI class that should be opened when the extended component
      *            is clicked


### PR DESCRIPTION
If BrowserWindowOpener is used with constructor using Class<? extends UI> as parameter, it will have UI provider with generated url. This will not match UI beans in contextual storage and hence newly created UI will not be managed bean. Due this, injection to new UI instance will not happen. If you are using CDI , BrowserWindowOpener(String) constructor needs to be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11495)
<!-- Reviewable:end -->
