### PR TITLE
Support Firefox 65+ key down event behavior (#11502)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VMenuBar.java
+++ b/client/src/main/java/com/vaadin/client/ui/VMenuBar.java
@@ -137,7 +137,7 @@ public class VMenuBar extends FocusableFlowPanel implements
          * handler, other browsers handle it correctly when using a key down
          * handler
          */
-        if (BrowserInfo.get().isGecko()) {
+        if (BrowserInfo.get().isGecko() && BrowserInfo.get().getGeckoVersion() < 65) {
             addKeyPressHandler(this);
         } else {
             addKeyDownHandler(this);

--- a/client/src/main/java/com/vaadin/client/ui/VMenuBar.java
+++ b/client/src/main/java/com/vaadin/client/ui/VMenuBar.java
@@ -133,7 +133,7 @@ public class VMenuBar extends FocusableFlowPanel implements
         addFocusHandler(this);
 
         /*
-         * Firefox auto-repeat works correctly only if we use a key press
+         * Firefox prior to v65 auto-repeat works correctly only if we use a key press
          * handler, other browsers handle it correctly when using a key down
          * handler
          */

--- a/client/src/main/java/com/vaadin/client/ui/VSlider.java
+++ b/client/src/main/java/com/vaadin/client/ui/VSlider.java
@@ -272,10 +272,7 @@ public class VSlider extends SimpleFocusablePanel
             increaseValue(true);
         } else if (DOM.eventGetType(event) == Event.MOUSEEVENTS) {
             processBaseEvent(event);
-        } else if (BrowserInfo.get().isGecko()
-                && DOM.eventGetType(event) == Event.ONKEYPRESS
-                || !BrowserInfo.get().isGecko()
-                        && DOM.eventGetType(event) == Event.ONKEYDOWN) {
+        } else if (isNavigationEvent(event)) {
 
             if (handleNavigation(event.getKeyCode(), event.getCtrlKey(),
                     event.getShiftKey())) {
@@ -299,6 +296,14 @@ public class VSlider extends SimpleFocusablePanel
         if (WidgetUtil.isTouchEvent(event)) {
             event.preventDefault(); // avoid simulated events
             event.stopPropagation();
+        }
+    }
+
+    private boolean isNavigationEvent(Event event) {
+        if (BrowserInfo.get().isGecko() && BrowserInfo.get().getGeckoVersion() < 65) {
+            return DOM.eventGetType(event) == Event.ONKEYPRESS;
+        } else {
+            return DOM.eventGetType(event) == Event.ONKEYDOWN;
         }
     }
 

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCalendarPanel.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCalendarPanel.java
@@ -216,7 +216,7 @@ public class VCalendarPanel extends FocusableFlexTable implements
          * handler, other browsers handle it correctly when using a key down
          * handler
          */
-        if (BrowserInfo.get().isGecko()) {
+        if (BrowserInfo.get().isGecko() && BrowserInfo.get().getGeckoVersion() < 65) {
             addKeyPressHandler(this);
         } else {
             addKeyDownHandler(this);

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCalendarPanel.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VCalendarPanel.java
@@ -212,7 +212,7 @@ public class VCalendarPanel extends FocusableFlexTable implements
         Roles.getGridRole().set(getElement());
 
         /*
-         * Firefox auto-repeat works correctly only if we use a key press
+         * Firefox prior to v65 auto-repeat works correctly only if we use a key press
          * handler, other browsers handle it correctly when using a key down
          * handler
          */

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
@@ -568,10 +568,10 @@ public class VScrollTable extends FlowPanel
 
         @Override
         public void onKeyPress(KeyPressEvent keyPressEvent) {
-            // This is used for Firefox only, since Firefox auto-repeat
+            // This is used for Firefox (prior to v65) only, since Firefox auto-repeat
             // works correctly only if we use a key press handler, other
             // browsers handle it correctly when using a key down handler
-            if (!isUseOldGeckoNavigation()) {
+            if (!useOldGeckoNavigation()) {
                 return;
             }
 
@@ -635,8 +635,8 @@ public class VScrollTable extends FlowPanel
         @Override
         public void onKeyDown(KeyDownEvent keyDownEvent) {
             NativeEvent event = keyDownEvent.getNativeEvent();
-            // This is not used for Firefox
-            if (isUseOldGeckoNavigation()) {
+            // This is not used for Firefox prior to v65
+            if (useOldGeckoNavigation()) {
                 return;
             }
 
@@ -840,11 +840,11 @@ public class VScrollTable extends FlowPanel
         scrollBodyPanel.addScrollHandler(this);
 
         /*
-         * Firefox auto-repeat works correctly only if we use a key press
+         * Firefox prior to v65 auto-repeat works correctly only if we use a key press
          * handler, other browsers handle it correctly when using a key down
          * handler
          */
-        if (isUseOldGeckoNavigation()) {
+        if (useOldGeckoNavigation()) {
             scrollBodyPanel.addKeyPressHandler(navKeyPressHandler);
         } else {
             scrollBodyPanel.addKeyDownHandler(navKeyDownHandler);
@@ -862,8 +862,14 @@ public class VScrollTable extends FlowPanel
         rowRequestHandler = new RowRequestHandler();
     }
 
-    private boolean isUseOldGeckoNavigation() {
-        return BrowserInfo.get().isGecko() && BrowserInfo.get().getGeckoVersion() < 65;
+    /*
+     * Firefox prior to v65 auto-repeat works correctly only if we use a key press
+     * handler, other browsers handle it correctly when using a key down
+     * handler.
+     */
+    private boolean useOldGeckoNavigation() {
+        return BrowserInfo.get().isGecko()
+                && BrowserInfo.get().getGeckoVersion() < 65;
     }
 
     @Override

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
@@ -635,7 +635,7 @@ public class VScrollTable extends FlowPanel
         @Override
         public void onKeyDown(KeyDownEvent keyDownEvent) {
             NativeEvent event = keyDownEvent.getNativeEvent();
-            // This is not used for Firefox prior to v65
+            // This is not used for Firefox after v65
             if (useOldGeckoNavigation()) {
                 return;
             }

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
@@ -571,7 +571,7 @@ public class VScrollTable extends FlowPanel
             // This is used for Firefox only, since Firefox auto-repeat
             // works correctly only if we use a key press handler, other
             // browsers handle it correctly when using a key down handler
-            if (!BrowserInfo.get().isGecko()) {
+            if (!isUseOldGeckoNavigation()) {
                 return;
             }
 
@@ -636,7 +636,7 @@ public class VScrollTable extends FlowPanel
         public void onKeyDown(KeyDownEvent keyDownEvent) {
             NativeEvent event = keyDownEvent.getNativeEvent();
             // This is not used for Firefox
-            if (BrowserInfo.get().isGecko()) {
+            if (isUseOldGeckoNavigation()) {
                 return;
             }
 
@@ -844,7 +844,7 @@ public class VScrollTable extends FlowPanel
          * handler, other browsers handle it correctly when using a key down
          * handler
          */
-        if (BrowserInfo.get().isGecko()) {
+        if (isUseOldGeckoNavigation()) {
             scrollBodyPanel.addKeyPressHandler(navKeyPressHandler);
         } else {
             scrollBodyPanel.addKeyDownHandler(navKeyDownHandler);
@@ -860,6 +860,10 @@ public class VScrollTable extends FlowPanel
         add(tFoot);
 
         rowRequestHandler = new RowRequestHandler();
+    }
+
+    private boolean isUseOldGeckoNavigation() {
+        return BrowserInfo.get().isGecko() && BrowserInfo.get().getGeckoVersion() < 65;
     }
 
     @Override

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VSlider.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VSlider.java
@@ -287,10 +287,7 @@ public class VSlider extends SimpleFocusablePanel
             increaseValue(true);
         } else if (DOM.eventGetType(event) == Event.MOUSEEVENTS) {
             processBaseEvent(event);
-        } else if (BrowserInfo.get().isGecko()
-                && DOM.eventGetType(event) == Event.ONKEYPRESS
-                || !BrowserInfo.get().isGecko()
-                        && DOM.eventGetType(event) == Event.ONKEYDOWN) {
+        } else if (isNavigationEvent(event)) {
 
             if (handleNavigation(event.getKeyCode(), event.getCtrlKey(),
                     event.getShiftKey())) {
@@ -314,6 +311,14 @@ public class VSlider extends SimpleFocusablePanel
         if (WidgetUtil.isTouchEvent(event)) {
             event.preventDefault(); // avoid simulated events
             event.stopPropagation();
+        }
+    }
+
+    private boolean isNavigationEvent(Event event) {
+        if (BrowserInfo.get().isGecko() && BrowserInfo.get().getGeckoVersion() < 65) {
+            return DOM.eventGetType(event) == Event.ONKEYPRESS;
+        } else {
+            return DOM.eventGetType(event) == Event.ONKEYDOWN;
         }
     }
 

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTree.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTree.java
@@ -220,7 +220,7 @@ public class VTree extends FocusElementPanel
          * handler, other browsers handle it correctly when using a key down
          * handler
          */
-        if (BrowserInfo.get().isGecko()) {
+        if (BrowserInfo.get().isGecko() && BrowserInfo.get().getGeckoVersion() < 65) {
             addKeyPressHandler(this);
         } else {
             addKeyDownHandler(this);

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTree.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTree.java
@@ -216,7 +216,7 @@ public class VTree extends FocusElementPanel
         }, ContextMenuEvent.getType());
 
         /*
-         * Firefox auto-repeat works correctly only if we use a key press
+         * Firefox prior to v65 auto-repeat works correctly only if we use a key press
          * handler, other browsers handle it correctly when using a key down
          * handler
          */


### PR DESCRIPTION
Support Firefox 65+ key down event behavior

Fixes #11502

**Check when you have completed**
[ ] Valid tests for the pull request
[ ] Contributing guidelines implemented

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11503)
<!-- Reviewable:end -->
