### PR TITLE
Change VCalendarPanel to use KeyDownHandler with Firefox 65+

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VCalendarPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VCalendarPanel.java
@@ -211,11 +211,11 @@ public class VCalendarPanel extends FocusableFlexTable implements
         Roles.getGridRole().set(getElement());
 
         /*
-         * Firefox auto-repeat works correctly only if we use a key press
+         * Firefox prior to v65 auto-repeat works correctly only if we use a key press
          * handler, other browsers handle it correctly when using a key down
          * handler
          */
-        if (BrowserInfo.get().isGecko()) {
+        if (BrowserInfo.get().isGecko() && BrowserInfo.get().getGeckoVersion() < 65) {
             addKeyPressHandler(this);
         } else {
             addKeyDownHandler(this);


### PR DESCRIPTION
Fixes #11502

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11507)
<!-- Reviewable:end -->
