### PR TITLE
Change VScrollTable to use KeyDownHandler with Firefox 65+

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VScrollTable.java
+++ b/client/src/main/java/com/vaadin/client/ui/VScrollTable.java
@@ -557,10 +557,10 @@ public class VScrollTable extends FlowPanel
 
         @Override
         public void onKeyPress(KeyPressEvent keyPressEvent) {
-            // This is used for Firefox only, since Firefox auto-repeat
+            // This is used for Firefox prior to v65 only, since Firefox auto-repeat
             // works correctly only if we use a key press handler, other
             // browsers handle it correctly when using a key down handler
-            if (!BrowserInfo.get().isGecko()) {
+            if (!useOldGeckoNavigation()) {
                 return;
             }
 
@@ -624,8 +624,8 @@ public class VScrollTable extends FlowPanel
         @Override
         public void onKeyDown(KeyDownEvent keyDownEvent) {
             NativeEvent event = keyDownEvent.getNativeEvent();
-            // This is not used for Firefox
-            if (BrowserInfo.get().isGecko()) {
+            // This is not used for Firefox prior to v65
+            if (useOldGeckoNavigation()) {
                 return;
             }
 
@@ -829,11 +829,11 @@ public class VScrollTable extends FlowPanel
         scrollBodyPanel.addScrollHandler(this);
 
         /*
-         * Firefox auto-repeat works correctly only if we use a key press
+         * Firefox prior to v65 auto-repeat works correctly only if we use a key press
          * handler, other browsers handle it correctly when using a key down
          * handler
          */
-        if (BrowserInfo.get().isGecko()) {
+        if (useOldGeckoNavigation()) {
             scrollBodyPanel.addKeyPressHandler(navKeyPressHandler);
         } else {
             scrollBodyPanel.addKeyDownHandler(navKeyDownHandler);
@@ -854,6 +854,10 @@ public class VScrollTable extends FlowPanel
     @Override
     public void setStyleName(String style) {
         updateStyleNames(style, false);
+    }
+
+    private boolean useOldGeckoNavigation() {
+        return BrowserInfo.get().isGecko() && BrowserInfo.get().getGeckoVersion() < 65;
     }
 
     @Override


### PR DESCRIPTION
Fixes #11502

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11508)
<!-- Reviewable:end -->
