### PR TITLE
Init logging in VaadinServlet instead of an UI

### DIFF
--- a/documentation/advanced/advanced-logging.asciidoc
+++ b/documentation/advanced/advanced-logging.asciidoc
@@ -57,10 +57,8 @@ to log the actual messages using Log4j. For more info on this, please visit the
 SLF4J site.
 
 In order to get the [package]#java.util.logging# to SLF4J bridge installed, you
-need to add the following snippet of code to your [classname]#UI# class at the
+need to add the following snippet of code to your [classname]#VaadinServlet# class at the
 very top:
-
-//TODO: Sure it's UI class and not the servlet?
 
 [source, java]
 ----
@@ -70,8 +68,9 @@ very top:
 ----
 
 This will make sure that the bridge handler is installed and working before
-Vaadin starts to process any logging calls.
-
+Vaadin starts to process any logging calls. If your app consists of multiple servlets,
+you should initialize the SLF4J logging in a [classname]#ServletContextListener# instead,
+so that the servlets' initialization methods uses the proper logger.
 
 [WARNING]
 .Please note!


### PR DESCRIPTION
If you use multiple UIs, the use of SLF4J would depend on the UI initialization order which could be pretty random. If you have multiple servlets, it's even better to init SLF4J in ServletContextListener.

Thanks for submitting a pull request!
Please confirm that your pull request follows our guidelines found in CONTRIBUTING and that you provide enough information so that we can review your pull request.

<Description of pull request, e.g. "Fix Grid Column not sortable with backend data and sort property">

Fixes #<replace with an issue number>

**Check when you have completed**
[n/a] Valid tests for the pull request
[x] Contributing guidelines implemented

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11525)
<!-- Reviewable:end -->
