### PR TITLE
Reset selection on DataProvider change in RadioButtonGroup

### DIFF
--- a/server/src/main/java/com/vaadin/ui/RadioButtonGroup.java
+++ b/server/src/main/java/com/vaadin/ui/RadioButtonGroup.java
@@ -321,6 +321,7 @@ public class RadioButtonGroup<T> extends AbstractSingleSelect<T>
 
     @Override
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
+        setSelectedItem(null);
         internalSetDataProvider(dataProvider);
     }
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupChangeDataProvider.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupChangeDataProvider.java
@@ -1,17 +1,19 @@
 package com.vaadin.tests.components.radiobuttongroup;
 
 import com.vaadin.server.VaadinRequest;
-import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.tests.components.AbstractTestUIWithLog;
 import com.vaadin.ui.RadioButtonGroup;
 import com.vaadin.ui.Button;
 
-
-public class RadioButtonGroupChangeDataProvider extends AbstractTestUI {
+public class RadioButtonGroupChangeDataProvider extends AbstractTestUIWithLog {
     @Override
     protected void setup(VaadinRequest request) {
         RadioButtonGroup<String> radio = new RadioButtonGroup<>();
         radio.setItems("aaa", "bbb", "ccc", "ddd");
         radio.setId("radioButton");
+        radio.addValueChangeListener(event -> {
+            log("Selected value: " + event.getValue());
+        });
 
         addComponent(radio);
         Button changeProvider = new Button(

--- a/uitest/src/main/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupChangeDataProvider.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupChangeDataProvider.java
@@ -1,0 +1,23 @@
+package com.vaadin.tests.components.radiobuttongroup;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.RadioButtonGroup;
+import com.vaadin.ui.Button;
+
+
+public class RadioButtonGroupChangeDataProvider extends AbstractTestUI {
+    @Override
+    protected void setup(VaadinRequest request) {
+        RadioButtonGroup<String> radio = new RadioButtonGroup<>();
+        radio.setItems("aaa", "bbb", "ccc", "ddd");
+        radio.setId("radioButton");
+
+        addComponent(radio);
+        Button changeProvider = new Button(
+                "New Data Provider - without selected item",
+                e -> radio.setItems("111", "222", "333", "444"));
+        changeProvider.setId("changeProvider");
+        addComponent(changeProvider);
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupChangeDataProviderTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupChangeDataProviderTest.java
@@ -22,6 +22,7 @@ public class RadioButtonGroupChangeDataProviderTest extends MultiBrowserTest {
         assertTrue(findElement(By.id("radioButton"))
                 .findElements(By.className("v-select-option-selected"))
                 .isEmpty());
+        isValueChangeListenerFired("null");
         getRadioButtonGroupElement().selectByText("222");
         isSelectedOnClientSide("222");
     }
@@ -35,7 +36,16 @@ public class RadioButtonGroupChangeDataProviderTest extends MultiBrowserTest {
     private void isSelectedOnClientSide(String selectedText) {
         List<WebElement> selectOptions = findElement(By.id("radioButton"))
                 .findElements(By.className("v-select-option-selected"));
-        assertEquals("Item should be selected", selectOptions.size(), 1);
-        assertTrue(selectOptions.get(0).getText().equals(selectedText));
+        assertEquals("One item should be selected", selectOptions.size(), 1);
+        String value = selectOptions.get(0).getText();
+        assertTrue(String.format("Expected value was %s, but %s is selected",
+                selectedText, value), value.equals(selectedText));
+        isValueChangeListenerFired(selectedText);
+    }
+
+    private void isValueChangeListenerFired(String value) {
+        assertTrue(String.format(
+                "ValueChangeListener was not fired. Current value: %s ", value),
+                findElement(By.id("Log_row_0")).getText().contains(value));
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupChangeDataProviderTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupChangeDataProviderTest.java
@@ -1,0 +1,41 @@
+package com.vaadin.tests.components.radiobuttongroup;
+
+import com.vaadin.testbench.elements.RadioButtonGroupElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+public class RadioButtonGroupChangeDataProviderTest extends MultiBrowserTest {
+    @Test
+    public void verifyOptionIsSelectable() {
+        openTestURL();
+
+        getRadioButtonGroupElement().selectByText("ccc");
+        isSelectedOnClientSide("ccc");
+        findElement(By.id("changeProvider")).click();
+        assertTrue(findElement(By.id("radioButton"))
+                .findElements(By.className("v-select-option-selected"))
+                .isEmpty());
+        getRadioButtonGroupElement().selectByText("222");
+        isSelectedOnClientSide("222");
+    }
+
+    private RadioButtonGroupElement getRadioButtonGroupElement() {
+        RadioButtonGroupElement radioButtonGroup = $(
+                RadioButtonGroupElement.class).first();
+        return radioButtonGroup;
+    }
+
+    private void isSelectedOnClientSide(String selectedText) {
+        List<WebElement> selectOptions = findElement(By.id("radioButton"))
+                .findElements(By.className("v-select-option-selected"));
+        assertEquals("Item should be selected", selectOptions.size(), 1);
+        assertTrue(selectOptions.get(0).getText().equals(selectedText));
+    }
+}


### PR DESCRIPTION
Fixes #11454

Other components needing the same fix are ListSelect,NativeSelect,Combobox (The ones implementing HasDataProvider and extending AbstractSingleSelect. Grid is not affected as it extends AbstractListing and hadles selection differently)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11526)
<!-- Reviewable:end -->
