### PR TITLE
Fixing autocompletion issue with ComboBox on newer Chrome versions

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VFilterSelect.java
+++ b/client/src/main/java/com/vaadin/client/ui/VFilterSelect.java
@@ -1416,7 +1416,12 @@ public class VFilterSelect extends Composite
              * way, and they might be useful in a combo box where new items are
              * allowed.
              */
-            getElement().setAttribute("autocomplete", "nope");
+            if (BrowserInfo.get().isChrome()) {
+                // Chrome supports "off" and random number does not work with Chrome
+                getElement().setAttribute("autocomplete", "off");        		
+            } else {
+                getElement().setAttribute("autocomplete", Math.random() + "");
+            }
         }
 
         /**


### PR DESCRIPTION
Newer Chrome versions do not work with random number hack to prevent auto completion, but it finally supports autocomplete=off.

Adapted from #11472

Fixes #11437

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11539)
<!-- Reviewable:end -->
