### PR TITLE
Update bnd.bnd for Liferay 7.2 compatibility

### DIFF
--- a/server/bnd.bnd
+++ b/server/bnd.bnd
@@ -4,7 +4,7 @@ Bundle-Version: ${osgi.bundle.version}
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
 Import-Package: com.vaadin.sass.*;resolution:=optional,\
-  com.liferay.portal.kernel.util;resolution:=optional;version='[7.0.0,9.0.0)',\
+  com.liferay.portal.kernel.util;resolution:=optional;version='[7.0.0,10.0.0)',\
   javax.portlet*;resolution:=optional,\
   javax.validation*;resolution:=optional;version='${javax.validation.version}',\
   org.atmosphere*;resolution:=optional;version='${atmosphere.runtime.version}',\


### PR DESCRIPTION
Change so that liferay 7.2 can run Vaadin portlets

LIferay 7.2 CE RC1 has a newer version of com.liferay.portal.kernel.util

Thanks to @sammso I've updated the bnb.bnd for vaadin-server and can now load and run Vaadin 8.8 portlets on LIferay 7.2 CE RC1 

Fixes #11563

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11564)
<!-- Reviewable:end -->
