### PR TITLE
fixes #11437 for V7

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VFilterSelect.java
+++ b/client/src/main/java/com/vaadin/client/ui/VFilterSelect.java
@@ -1416,7 +1416,12 @@ public class VFilterSelect extends Composite
              * way, and they might be useful in a combo box where new items are
              * allowed.
              */
-            getElement().setAttribute("autocomplete", "nope");
+            if (BrowserInfo.get().isChrome()) {
+                // Chrome supports "off" and random number does not work with Chrome
+                getElement().setAttribute("autocomplete", "off");
+            } else {
+                getElement().setAttribute("autocomplete", Math.random() + "");
+            }
         }
 
         /**


### PR DESCRIPTION
New Chrome supports autocomplete="off" for ComboBox. Same fix for the Vaadin 8 branch here: https://github.com/vaadin/framework/pull/11523

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11588)
<!-- Reviewable:end -->
