### PR TITLE
Fix regression that broke PreserveOnRefresh functionality with Navigator

### DIFF
--- a/server/src/main/java/com/vaadin/ui/UI.java
+++ b/server/src/main/java/com/vaadin/ui/UI.java
@@ -162,6 +162,12 @@ public abstract class UI extends AbstractSingleComponentContainer
             this);
 
     /**
+     * Holder for old navigation state, needed in doRefresh in order not to call
+     * navigateTo too often
+     */
+    private String oldNavigationState;
+
+    /**
      * Scroll Y position.
      */
     private int scrollTop = 0;
@@ -871,10 +877,15 @@ public abstract class UI extends AbstractSingleComponentContainer
         page.updateBrowserWindowSize(newWidth, newHeight, true);
 
         // Navigate if there is navigator, this is needed in case of
-        // PushStateNavigation
+        // PushStateNavigation. Call navigateTo only if state have
+        // truly changed
         Navigator navigator = getNavigator();
         if (navigator != null) {
-            navigator.navigateTo(navigator.getState());
+            if (oldNavigationState == null) oldNavigationState = getNavigator().getState();
+            if (!navigator.getState().equals(oldNavigationState)) {
+                navigator.navigateTo(navigator.getState());
+                oldNavigationState = navigator.getState();
+            }
         }
     }
 

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/RefreshUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/RefreshUI.java
@@ -1,0 +1,29 @@
+package com.vaadin.tests.components.ui;
+
+import com.vaadin.annotations.PreserveOnRefresh;
+import com.vaadin.navigator.Navigator;
+import com.vaadin.navigator.View;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.VerticalLayout;
+
+@PreserveOnRefresh
+public class RefreshUI extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        final Navigator navigator = new Navigator(this, this);
+        navigator.addView("", MyView.class);
+        setNavigator(navigator);
+    }
+
+    public static class MyView extends VerticalLayout implements View {
+        private static int instanceNumber = 0;
+
+        public MyView() {
+            instanceNumber++;
+            addComponent(new Label("This is instance no " + instanceNumber));
+        }
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/ui/RefreshUITest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ui/RefreshUITest.java
@@ -1,0 +1,25 @@
+package com.vaadin.tests.components.ui;
+
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.LabelElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+import static org.junit.Assert.assertEquals;
+
+public class RefreshUITest extends MultiBrowserTest {
+
+    @Test
+    public void testUIRefresh_viewNotRecreated() {
+        openTestURL();
+        assertEquals("The Label content is not matching",
+                "This is instance no 1",
+                $(LabelElement.class).first().getText());
+
+        // Reload the page; UI.refresh should be invoked
+        openTestURL();
+        assertEquals("The Label content is not matching",
+                "This is instance no 1",
+                $(LabelElement.class).first().getText());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/vaadin/framework/issues/11614

Old patch https://github.com/vaadin/framework/issues/11416 called navigateTo allways when Navigator was present, which is wrong, since it needs to be called only when navigation state has changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11615)
<!-- Reviewable:end -->
