### PR TITLE
Fixing upload handler error handling

### DIFF
--- a/server/src/main/java/com/vaadin/server/communication/FileUploadHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/FileUploadHandler.java
@@ -270,7 +270,7 @@ public class FileUploadHandler implements RequestHandler {
         try {
             UI uI = session.getUIById(Integer.parseInt(uiId));
             if (uI == null) {
-                throw new UploadException(
+                throw new IOException(
                         "File upload ignored because the UI was not found and stream variable cannot be determined");
             }
             // Set UI so that it can be used in stream variable clean up

--- a/server/src/main/java/com/vaadin/server/communication/FileUploadHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/FileUploadHandler.java
@@ -269,13 +269,17 @@ public class FileUploadHandler implements RequestHandler {
         session.lock();
         try {
             UI uI = session.getUIById(Integer.parseInt(uiId));
+            if (uI == null) {
+                throw new UploadException(
+                        "File upload ignored because the UI was not found and stream variable cannot be determined");
+            }
+            // Set UI so that it can be used in stream variable clean up
             UI.setCurrent(uI);
 
             streamVariable = uI.getConnectorTracker()
                     .getStreamVariable(connectorId, variableName);
             String secKey = uI.getConnectorTracker().getSeckey(streamVariable);
             if (secKey == null || !secKey.equals(parts[3])) {
-                // TODO Should rethink error handling
                 return true;
             }
 
@@ -456,7 +460,7 @@ public class FileUploadHandler implements RequestHandler {
         try {
             // Store ui reference so we can do cleanup even if connector is
             // detached in some event handler
-            UI ui = connector.getUI();
+            UI ui = UI.getCurrent();
             boolean forgetVariable = streamToReceiver(session, inputStream,
                     streamVariable, filename, mimeType, contentLength);
             if (forgetVariable) {


### PR DESCRIPTION
For some reason stream variable cleanup did not use UI.getCurrent(), despite current UI was set earlier in handleRequest, what I see specifically for this purpose. So I chanted this. This will address also issue #7289

Furthermore there was TODO in handle request about error handling. I interpreted this to refer to possible corner case, that UI is not found via session. In this case it is more appropriate throw IOException with clearer note and abort, than let NPE happen (ref. https://stackoverflow.com/questions/56653755/npe-while-using-multiplefileupload ) .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11630)
<!-- Reviewable:end -->
