### PR TITLE
Adding css class to Editor when on selected row

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -1908,6 +1908,15 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
             updateBufferedStyleName();
 
+            // Add class name with selected modifier if the editor is being
+            // opened on selected row, see #11634
+            String selectedStylename = styleName + "-selected";
+            if (grid.isSelected(grid.getDataSource().getRow(getRow()))) {
+                cellWrapper.addClassName(selectedStylename);
+            } else {
+                cellWrapper.removeClassName(selectedStylename);
+            }
+
             int frozenColumns = grid.getVisibleFrozenColumnCount();
             double frozenColumnsWidth = 0;
             double cellHeight = 0;

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridSelectionTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridSelectionTest.java
@@ -36,20 +36,29 @@ public class GridSelectionTest extends GridBasicsTest {
         assertTrue("row should become selected", getRow(0).isSelected());
         getGridElement().getCell(0, 0).click();
         assertFalse("row shouldn't remain selected", getRow(0).isSelected());
+    }
 
-        getGridElement().getCell(0, 0).doubleClick();
+    @Test
+    public void testEditorSelectOnOff() throws Exception {
+        openTestURL();
+
+        selectMenuPath("Component", "Editor", "Enabled");
+
+        selectMenuPath("Component", "Editor", "Edit row 0");
         waitForElementVisible(By.className("v-grid-editor"));
-        assertFalse("editor should not be selected",editorIsSelected());
+        assertFalse("editor should not be selected", editorIsSelected());
         getGridElement().getEditor().cancel();
+
         toggleFirstRowSelection();
-        getGridElement().getCell(0, 0).doubleClick();
+        selectMenuPath("Component", "Editor", "Edit row 0");
         waitForElementVisible(By.className("v-grid-editor"));
-        assertTrue("editor should become selected",editorIsSelected());
+        assertTrue("editor should become selected", editorIsSelected());
         getGridElement().getEditor().cancel();
     }
 
     private boolean editorIsSelected() {
-        WebElement cellWrapperElement = findElement(By.className("v-grid-editor-cells"));
+        WebElement cellWrapperElement = findElements(
+                By.className("v-grid-editor-cells")).get(1);
         return cellWrapperElement.getAttribute("class").contains("-selected");
     }
 

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridSelectionTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridSelectionTest.java
@@ -36,6 +36,21 @@ public class GridSelectionTest extends GridBasicsTest {
         assertTrue("row should become selected", getRow(0).isSelected());
         getGridElement().getCell(0, 0).click();
         assertFalse("row shouldn't remain selected", getRow(0).isSelected());
+
+        getGridElement().getCell(0, 0).doubleClick();
+        waitForElementVisible(By.className("v-grid-editor"));
+        assertFalse("editor should not be selected",editorIsSelected());
+        getGridElement().getEditor().cancel();
+        toggleFirstRowSelection();
+        getGridElement().getCell(0, 0).doubleClick();
+        waitForElementVisible(By.className("v-grid-editor"));
+        assertTrue("editor should become selected",editorIsSelected());
+        getGridElement().getEditor().cancel();
+    }
+
+    private boolean editorIsSelected() {
+        WebElement cellWrapperElement = findElement(By.className("v-grid-editor-cells"));
+        return cellWrapperElement.getAttribute("class").contains("-selected");
     }
 
     @Test


### PR DESCRIPTION
Adding "v-grid-editor-selected" stylename in editor cell wrapper element when Grid is opened on selected row.

Addresses issue https://github.com/vaadin/framework/issues/11634

Note, by default there there is no impact, since Valo theme is not defining style with this class name. You need to set suitable styles in your application theme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11636)
<!-- Reviewable:end -->
