### PR TITLE
Removal of data communicator needs to happen before call to super.rem…

### DIFF
--- a/server/src/main/java/com/vaadin/ui/components/grid/GridDragSource.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/GridDragSource.java
@@ -256,10 +256,10 @@ public class GridDragSource<T> extends DragSourceExtension<Grid<T>> {
 
     @Override
     public void remove() {
-        super.remove();
-
         getParent().getDataCommunicator()
                 .removeDataGenerator(dragDataGenerator);
+
+        super.remove();
     }
 
     @Override


### PR DESCRIPTION
…ove()

Removal of data communicator needs to happen before call to super.remove() since super.remove() sets parent to null causing the NPE.

Fixes https://github.com/vaadin/framework/issues/11617

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11710)
<!-- Reviewable:end -->
