### PR TITLE
Wrap selects in TwinColSelect to workaround Chrome 76 layout bug

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
+import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.event.dom.client.ClickEvent;

--- a/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
@@ -167,14 +167,22 @@ public class VTwinColSelect extends Composite implements MultiSelectWidget,
         // extra empty space
         captionWrapper.setVisible(false);
 
-        panel.add(optionsListBox);
+        // Wrap select in Div to workaround bug in Chrome 76, see #11712
+        HTML optionsWrapper = new HTML("<div></div>");
+        optionsWrapper.getElement().appendChild(optionsListBox.getElement());
+        optionsWrapper.getElement().getStyle().setDisplay(Display.INLINE_BLOCK);
+        panel.add(optionsWrapper);
         buttons.add(addItemsLeftToRightButton);
         final HTML br = new HTML("<span/>");
         br.setStyleName(CLASSNAME + "-deco");
         buttons.add(br);
         buttons.add(removeItemsRightToLeftButton);
         panel.add(buttons);
-        panel.add(selectionsListBox);
+        // Wrap select in Div to workaround bug in Chrome 76, see #11712
+        HTML selectionsWrapper = new HTML("<div></div>");
+        selectionsWrapper.getElement().appendChild(selectionsListBox.getElement());
+        selectionsWrapper.getElement().getStyle().setDisplay(Display.INLINE_BLOCK);
+        panel.add(selectionsWrapper);
 
         optionsListBox.addKeyDownHandler(this);
         optionsListBox.addMouseDownHandler(this);


### PR DESCRIPTION
Addresses https://github.com/vaadin/framework/issues/11712

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11714)
<!-- Reviewable:end -->
