### PR TITLE
Make VaadinService.cleanupSession public

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinService.java
@@ -1226,9 +1226,10 @@ public abstract class VaadinService implements Serializable {
     }
 
     /**
-     * Called at the end of a request, after sending the response. Closes
-     * inactive UIs in the given session, removes closed UIs from the session,
-     * and closes the session if it is itself inactive.
+     * Closes inactive UIs in the given session, removes closed UIs from the
+     * session, and closes the session if it is itself inactive. This operation
+     * should not be performed without first acquiring the session lock. By
+     * default called at the end of each request, after sending the response.
      *
      * @param session
      */

--- a/server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinService.java
@@ -1232,7 +1232,7 @@ public abstract class VaadinService implements Serializable {
      *
      * @param session
      */
-    void cleanupSession(VaadinSession session) {
+    public void cleanupSession(VaadinSession session) {
         if (isSessionActive(session)) {
             closeInactiveUIs(session);
             removeClosedUIs(session);


### PR DESCRIPTION
to allow for better integration of third party applications handling the destruction of the session. 

Usage example (see https://vaadin.com/directory/component/cleanupservlet-add-on/overview)

> "It's possible to close a browser window in such way that neither UI cleanup nor session cleanup will happen until the underlying http session timeouts. This can happen because the design idea for heartbeat is to keep the UI alive, not to ensure timely cleanup, and as such the default check is only performed at the end of each request."

We currently face exactly that problem and want to call that service to clean up Vaadin's leftover after the browser closes. (We don't want to use this 'hack' of package naming)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11738)
<!-- Reviewable:end -->
