### PR TITLE
Fix the end limit of the allowed scrollTo rows.

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -4390,7 +4390,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
         Objects.requireNonNull(destination,
                 "ScrollDestination can not be null");
 
-        if (row > getDataCommunicator().getDataProviderSize()) {
+        if (row >= getDataCommunicator().getDataProviderSize()) {
             throw new IllegalArgumentException("Row outside dataProvider size");
         }
 


### PR DESCRIPTION
- Row index counts up from zero, data provider size counts up from one,
as one would expect. If the two match we are already past the available
range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11771)
<!-- Reviewable:end -->
