### PR TITLE
Added 1px tolerance to ScrollbarBundle's internal sanity check.

### DIFF
--- a/client/src/main/java/com/vaadin/client/widget/escalator/ScrollbarBundle.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/ScrollbarBundle.java
@@ -587,10 +587,12 @@ public abstract class ScrollbarBundle implements DeferredWorker {
      * @return the new scroll position in pixels
      */
     public final double getScrollPos() {
-        assert internalGetScrollPos() == toInt32(
-                scrollPos) : "calculated scroll position (" + scrollPos
+        int internalScrollPos = internalGetScrollPos();
+        assert Math.abs(internalScrollPos
+                - toInt32(scrollPos)) <= 1 : "calculated scroll position ("
+                        + scrollPos
                         + ") did not match the DOM element scroll position ("
-                        + internalGetScrollPos() + ")";
+                        + internalScrollPos + ")";
         return scrollPos;
     }
 


### PR DESCRIPTION
Requiring exact match can cause this check to fail when the browser is
zoomed since rounding is involved. This can in turn block some features
like opening of Grid Editor from working until some more scrolling
happens and the minute inconsistency is fixed.

Can be tested manually using GridEditorUI, depending on the environment
different amounts of zooming may be required for the problem to
manifest.

Fixes #11672

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11777)
<!-- Reviewable:end -->
