### PR TITLE
Switch from an assert to logging and return in Grid.onBrowserEvent

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -7809,8 +7809,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
         }
 
-        assert cell != null : "received " + eventType
-                + "-event with a null cell target";
+        if (cell == null) {
+            getLogger().log(Level.WARNING,
+                    "received " + eventType + "-event with a null cell target");
+            return;
+        }
         eventCell.set(cell, getSectionFromContainer(container));
 
         GridEvent<T> gridEvent = new GridEvent<>(event, eventCell);


### PR DESCRIPTION
(#11778)

- If the Grid has frozen columns zooming can cause the regular column
cells to be ever so slightly out of sync with their corresponding rows.
This difference is not noticeable to naked eye but is big enough that
it's possible to hover over the row instead of the cell, which causes an
assertion error and a big ugly error popup. Switching to logging retains
the information delivered by the assertion error for developer purposes
but makes the end user experience smoother.
- Can be tested manually with GridColumnFrozenColumn test UI.

Fixes #11198

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11782)
<!-- Reviewable:end -->
