### PR TITLE
Fix a timing issue in ComboBox filtering via paste using mouse. (#11780)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VComboBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VComboBox.java
@@ -28,6 +28,7 @@ import java.util.logging.Logger;
 import com.google.gwt.animation.client.AnimationScheduler;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
@@ -1850,7 +1851,8 @@ public class VComboBox extends Composite implements Field, KeyDownHandler,
         if (event.getTypeInt() == Event.ONPASTE) {
             if (textInputEnabled && connector.isEnabled()
                     && !connector.isReadOnly()) {
-                filterOptions(currentPage);
+                Scheduler.get()
+                        .scheduleDeferred(() -> filterOptions(currentPage));
             }
         }
     }

--- a/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxPasteFilter.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/combobox/ComboBoxPasteFilter.java
@@ -1,0 +1,66 @@
+package com.vaadin.tests.components.combobox;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.vaadin.data.provider.ListDataProvider;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.ComboBox;
+import com.vaadin.ui.Label;
+
+public class ComboBoxPasteFilter extends AbstractTestUI {
+
+    private static final String WORDS = "loutish offer popcorn bitter buzz "
+            + "change mass boy erect aquatic donkey gentle colorful zippy "
+            + "soup pocket bathe fear supreme pan present knife quartz shy "
+            + "conscious tested thumb snow evasive reason dusty bridge giddy "
+            + "smooth bomb endurable tiger red gun fix regret quizzical income "
+            + "careless owe sleet loss silent serious play consider messy "
+            + "retire reduce shaky shiny low suggest preach bleach drunk "
+            + "talk instruct peck hungry improve meat chop title encourage "
+            + "marry island romantic fabulous kneel guarantee dock complain "
+            + "mate tour intend geese hole swing mine superb level slip "
+            + "spoon sky live nine open playground guard possible hate "
+            + "spotless apparatus bow";
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        ComboBox<String> box = new ComboBox<String>("Paste a word from below");
+        Collection<String> massiveData = massiveData();
+        box.setDataProvider(new ListDataProvider<String>(massiveData));
+        addComponent(box);
+
+        Label label = new Label(WORDS);
+        label.setSizeFull();
+        addComponent(label);
+    }
+
+    private Collection<String> massiveData() {
+        return find(WORDS, "([\\w]+)");
+    }
+
+    public List<String> find(String text, String patternStr) {
+        Pattern pattern = Pattern.compile(patternStr);
+        Matcher matcher = pattern.matcher(text);
+        List<String> result = new ArrayList<>();
+        while (matcher.find()) {
+            result.add(matcher.group());
+        }
+        return result;
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 11779;
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "ComboBox should filter regardless of whether the value is "
+                + "pasted with keyboard or with mouse";
+    }
+}


### PR DESCRIPTION
The filtering needs to be delayed, otherwise it's performed before the
new filter text is available and the old filter text is used instead.

Fixes #11779

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11784)
<!-- Reviewable:end -->
