### PR TITLE
Fixing issue with Push stopping working in some circumstances

### DIFF
--- a/client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -259,7 +259,9 @@ public class MessageHandler {
     protected void handleJSON(final ValueMap json) {
         final int serverId = getServerId(json);
 
-        if (!isResynchronize(json) && resyncInProgress) {
+        boolean hasResynchronize = isResynchronize(json);
+
+        if (!hasResynchronize && resyncInProgress) {
             Logger.getLogger(MessageHandler.class.getName())
                 .warning("Dropping the response of a request before a resync request.");
             return;
@@ -267,7 +269,7 @@ public class MessageHandler {
 
         resyncInProgress = false;
 
-        if (isResynchronize(json) && !isNextExpectedMessage(serverId)) {
+        if (hasResynchronize && !isNextExpectedMessage(serverId)) {
             // Resynchronize request. We must remove any old pending
             // messages and ensure this is handled next. Otherwise we
             // would keep waiting for an older message forever (if this
@@ -330,7 +332,7 @@ public class MessageHandler {
             int serverNextExpected = json
                     .getInt(ApplicationConstants.CLIENT_TO_SERVER_ID);
             getMessageSender().setClientToServerMessageId(serverNextExpected,
-                    isResynchronize(json));
+                    hasResynchronize);
         }
 
         if (serverId != -1) {

--- a/client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -193,6 +193,7 @@ public class MessageHandler {
     private int lastSeenServerSyncId = UNDEFINED_SYNC_ID;
 
     private ApplicationConnection connection;
+    private boolean resyncInProgress;
 
     /**
      * Data structure holding information about pending UIDL messages.
@@ -257,6 +258,14 @@ public class MessageHandler {
 
     protected void handleJSON(final ValueMap json) {
         final int serverId = getServerId(json);
+
+        if (!isResynchronize(json) && resyncInProgress) {
+            Logger.getLogger(MessageHandler.class.getName())
+                .warning("Dropping the response of a request before a resync request.");
+            return;
+        }
+
+        resyncInProgress = false;
 
         if (isResynchronize(json) && !isNextExpectedMessage(serverId)) {
             // Resynchronize request. We must remove any old pending
@@ -1822,4 +1831,7 @@ public class MessageHandler {
         }
     }-*/;
 
+    public void onResynchronize() {
+        resyncInProgress = true;
+    }
 }

--- a/client/src/main/java/com/vaadin/client/communication/MessageSender.java
+++ b/client/src/main/java/com/vaadin/client/communication/MessageSender.java
@@ -349,6 +349,7 @@ public class MessageSender {
      * state from the server
      */
     public void resynchronize() {
+        getMessageHandler().onResynchronize();
         getLogger().info("Resynchronizing from server");
         JsonObject resyncParam = Json.createObject();
         resyncParam.put(ApplicationConstants.RESYNCHRONIZE_ID, true);


### PR DESCRIPTION
If new request is attempted when resynchronization is ongoing, the Push will stop working. This patch fixes the issue by aborting handleJson if resynch is already ongoing. 

This PR supercedes https://github.com/vaadin/framework/pull/11786

Fixes #11702, #7719

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11791)
<!-- Reviewable:end -->
