### PR TITLE
Making setSessionLock / getSessionLock overrideable

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinPortletService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinPortletService.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -365,5 +367,41 @@ public class VaadinPortletService extends VaadinService {
     protected void removeFromHttpSession(WrappedSession wrappedSession) {
         getWrappedPortletSession(wrappedSession).removeAttribute(
                 getSessionAttributeName(), PortletSession.APPLICATION_SCOPE);
+    }
+
+    @Override
+    protected void setSessionLock(WrappedSession wrappedSession, Lock lock) {
+        if (wrappedSession == null) {
+            throw new IllegalArgumentException(
+                    "Can't set a lock for a null session");
+        }
+        Object currentSessionLock = getWrappedPortletSession(wrappedSession)
+                .getAttribute(getLockAttributeName(),
+                        PortletSession.APPLICATION_SCOPE);
+        assert (currentSessionLock == null
+                || currentSessionLock == lock) : "Changing the lock for a session is not allowed";
+
+        getWrappedPortletSession(wrappedSession).setAttribute(
+                getLockAttributeName(), lock,
+                PortletSession.APPLICATION_SCOPE);
+    }
+
+    @Override
+    protected Lock getSessionLock(WrappedSession wrappedSession) {
+        Object lock = getWrappedPortletSession(wrappedSession)
+                .getAttribute(getLockAttributeName(),
+                        PortletSession.APPLICATION_SCOPE);
+
+        if (lock instanceof ReentrantLock) {
+            return (ReentrantLock) lock;
+        }
+
+        if (lock == null) {
+            return null;
+        }
+
+        throw new RuntimeException(
+                "Something else than a ReentrantLock was stored in the "
+                        + getLockAttributeName() + " in the session");
     }
 }

--- a/server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinService.java
@@ -622,7 +622,7 @@ public abstract class VaadinService implements Serializable {
      * @param lock
      *            The lock object
      */
-    private void setSessionLock(WrappedSession wrappedSession, Lock lock) {
+    protected void setSessionLock(WrappedSession wrappedSession, Lock lock) {
         if (wrappedSession == null) {
             throw new IllegalArgumentException(
                     "Can't set a lock for a null session");
@@ -640,7 +640,7 @@ public abstract class VaadinService implements Serializable {
      *
      * @return The attribute name for the lock
      */
-    private String getLockAttributeName() {
+    protected String getLockAttributeName() {
         return getServiceName() + ".lock";
     }
 

--- a/server/src/test/java/com/vaadin/server/VaadinPortletServiceTest.java
+++ b/server/src/test/java/com/vaadin/server/VaadinPortletServiceTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.locks.ReentrantLock;
 
+import javax.portlet.PortletSession;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -185,9 +187,9 @@ public class VaadinPortletServiceTest {
             ReentrantLock mockLock = Mockito.mock(ReentrantLock.class);
             when(mockLock.isHeldByCurrentThread()).thenReturn(true);
 
-            WrappedSession emptyWrappedSession = Mockito
+            WrappedPortletSession emptyWrappedSession = Mockito
                     .mock(WrappedPortletSession.class);
-            when(emptyWrappedSession.getAttribute("null.lock"))
+            when(emptyWrappedSession.getAttribute("null.lock",PortletSession.APPLICATION_SCOPE))
                     .thenReturn(mockLock);
             VaadinRequest requestWithUIIDSet = Mockito
                     .mock(VaadinRequest.class);


### PR DESCRIPTION
Making setSessionLock / getSessionLock overrideable in VaadinService and overriding setSessionLock / getSessionLock in VaadinPortletService to use portlet APPLICATION_SCOPE Portlet session itself is also stored in APPLICATION_SCOPE. The default scope is PORTLET_SCOPE, so lock would be otherwise unsync.

Fixes: https://github.com/vaadin/framework/issues/11611

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11792)
<!-- Reviewable:end -->
