### PR TITLE
Fixing issue with TwinColSelect not correctly retaining visible selection

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
@@ -406,7 +406,7 @@ public class VTwinColSelect extends Composite implements MultiSelectWidget,
                 final String text = source.getItemText(optionIndex);
                 final String value = source.getValue(optionIndex);
                 target.addItem(text, value);
-                target.setItemSelected(target.getItemCount() - 1, true);                    
+                target.setItemSelected(target.getItemCount() - 1, true);
                 source.removeItem(optionIndex);
             }
         }

--- a/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
@@ -82,6 +82,7 @@ public class VTwinColSelect extends Composite implements MultiSelectWidget,
     private static final int VISIBLE_COUNT = 10;
 
     private static final int DEFAULT_COLUMN_COUNT = 10;
+    private static int scheduledScrollToItem = -1;
 
     private final DoubleClickListBox optionsListBox;
 
@@ -360,10 +361,16 @@ public class VTwinColSelect extends Composite implements MultiSelectWidget,
     }
 
     private static void scrollToView(ListBox listBox, int i) {
-        Scheduler.get().scheduleDeferred(() -> {
-             Element el = (Element) listBox.getElement().getChild(i);
-             el.scrollIntoView();
-        });
+        if (scheduledScrollToItem == -1) {
+            scheduledScrollToItem = i;
+            Scheduler.get().scheduleDeferred(() -> {
+                 Element el = (Element) listBox.getElement().getChild(scheduledScrollToItem);
+                 el.scrollIntoView();
+                 scheduledScrollToItem = -1;
+            });
+        } else {
+            scheduledScrollToItem = i;
+        }
     }
 
     private static boolean[] getSelectionBitmap(ListBox listBox) {

--- a/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
@@ -352,7 +352,7 @@ public class VTwinColSelect extends Composite implements MultiSelectWidget,
             if (isSelected) {
                 // Ensure that last selected item is visible
                 scrollToView(listBox,i);
-            }            
+            }
         }
         // remove extra
         for (int i = listBox.getItemCount() - 1; i >= options.size(); i--) {

--- a/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTwinColSelect.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -384,7 +385,6 @@ public class VTwinColSelect extends Composite implements MultiSelectWidget,
                 final String text = source.getItemText(optionIndex);
                 final String value = source.getValue(optionIndex);
                 target.addItem(text, value);
-                target.setItemSelected(target.getItemCount() - 1, true);
                 source.removeItem(optionIndex);
             }
         }
@@ -396,7 +396,27 @@ public class VTwinColSelect extends Composite implements MultiSelectWidget,
             source.setFocus(true);
         }
 
+        for (String item: movedItems) {
+            setSelectedItem(target,item);
+        }
+
         return movedItems;
+    }
+
+    private static void setSelectedItem(ListBox select, String value) {
+    	if (value == null) return;
+    	// There is a bug in GWT ListBox, it retains selection by indexes after
+    	// being sorted when new item has been added. This is a workaround.
+    	// See issue #11287
+        Scheduler.get().scheduleFixedDelay(() -> {
+            for (int i=0;i<select.getItemCount();i++) {
+                if (select.getValue(i).equals(value)) {
+                    select.setItemSelected(i, true);
+                    break;
+                }
+            }
+            return false;
+        },100);        	
     }
 
     @Override


### PR DESCRIPTION
There is a bug in TwinColSelect loging, it retains selection by indexes not by values after being sorted when new item has been added. This is a fixed by changing updateListBox method to retain the selection as it is being called after selection is being done.

Fixes: https://github.com/vaadin/framework/issues/11287

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11799)
<!-- Reviewable:end -->
