### PR TITLE
Reduce excess positioning calls for ComboBox popup. (#11808)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VComboBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VComboBox.java
@@ -428,10 +428,15 @@ public class VComboBox extends Composite implements Field, KeyDownHandler,
             // Add TT anchor point
             getElement().setId("VAADIN_COMBOBOX_OPTIONLIST");
 
-            leftPosition = getDesiredLeftPosition();
-            topPosition = getDesiredTopPosition();
+            // Set the default position if the popup isn't already visible,
+            // the setPopupPositionAndShow call later on can deal with any
+            // adjustments that might be needed
+            if (!popup.isShowing()) {
+                leftPosition = getDesiredLeftPosition();
+                topPosition = getDesiredTopPosition();
 
-            setPopupPosition(leftPosition, topPosition);
+                setPopupPosition(leftPosition, topPosition);
+            }
 
             int nullOffset = getNullSelectionItemShouldBeVisible() ? 1 : 0;
             boolean firstPage = currentPage == 0;
@@ -894,16 +899,24 @@ public class VComboBox extends Composite implements Field, KeyDownHandler,
                 }
             }
 
+            if (offsetWidth + menuMarginBorderPaddingWidth
+                    + left < VComboBox.this.getAbsoluteLeft()
+                            + VComboBox.this.getOffsetWidth()) {
+                // Popup doesn't reach all the way to the end of the input
+                // field, filtering may have changed the popup width.
+                left = VComboBox.this.getAbsoluteLeft();
+            }
             if (offsetWidth + menuMarginBorderPaddingWidth + left > Window
                     .getClientWidth()) {
+                // Popup doesn't fit the view, needs to be opened to the left
+                // instead.
                 left = VComboBox.this.getAbsoluteLeft()
                         + VComboBox.this.getOffsetWidth() - offsetWidth
                         - (int) menuMarginBorderPaddingWidth;
-                if (left < 0) {
-                    left = 0;
-                    menu.setWidth(Window.getClientWidth() + "px");
-
-                }
+            }
+            if (left < 0) {
+                left = 0;
+                menu.setWidth(Window.getClientWidth() + "px");
             }
 
             setPopupPosition(left, top);


### PR DESCRIPTION
- If an open popup is reset to its default position on every update from
the server before getting adjusted again to the actual expected
position, on heavier applications some of those intermediate positions
might get rendered. If the ComboBox is positioned at the right edge and
the popup contents are longer than the input field (i.e. popup should
open to the left, not right) this might cause flickering.
- Setting the default position is only actually needed when the popup is
opened in order to give it a baseline, otherwise it's better to simply
adjust the position if needed.

Continues on #11718

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11809)
<!-- Reviewable:end -->
