### PR TITLE
Decode path in getStaticFilePath

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1365,9 +1365,9 @@ public class VaadinServlet extends HttpServlet implements Constants {
         }
         String filePath = decodedPath.substring(contextPath.length());
         String servletPath = request.getServletPath();
-        if (!servletPath.isEmpty() && !servletPath.equals("/VAADIN")) {
-            filePath = filePath.substring(servletPath.length());
-        }        
+            if (!servletPath.isEmpty() && !servletPath.equals("/VAADIN") && filePath.startsWith(servletPath)) {
+          	filePath = filePath.substring(servletPath.length());
+        }
         // Servlet mapped as /* serves at /VAADIN
         // Servlet mapped as /foo/bar/* serves at /foo/bar/VAADIN
         if (filePath.startsWith("/VAADIN/")) {

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1350,21 +1350,23 @@ public class VaadinServlet extends HttpServlet implements Constants {
      * @since 8.0
      */
     protected String getStaticFilePath(HttpServletRequest request) {
-        String pathInfo = request.getPathInfo();
-        if (pathInfo == null) {
+        if (request.getPathInfo() == null) {
             return null;
         }
         String decodedPath = null;
         String contextPath = null;
         try {
-            // pathInfo should be already decoded, but some containers do not decode
+            // pathInfo should be already decoded, but some containers do not decode it,
+            // hence we use getRequestURI instead.
             decodedPath = URLDecoder.decode(request.getRequestURI(), StandardCharsets.UTF_8.name());
             contextPath = URLDecoder.decode(request.getContextPath(), StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("An error occurred during decoding URL.",e);
         }
+        // Possible context path needs to be removed
         String filePath = decodedPath.substring(contextPath.length());
         String servletPath = request.getServletPath();
+        // Possible servlet path needs to be removed
         if (!servletPath.isEmpty() && !servletPath.equals("/VAADIN") 
                 && filePath.startsWith(servletPath)) {
             filePath = filePath.substring(servletPath.length());

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1365,7 +1365,7 @@ public class VaadinServlet extends HttpServlet implements Constants {
         }
         String filePath = decodedPath.substring(contextPath.length());
         String servletPath = request.getServletPath();
-        if (!servletPath.isEmpty()) {
+        if (!servletPath.isEmpty() && !serlvetPath.equals("/VAADIN")) {
             filePath = filePath.substring(servletPath.length());
         }        
         // Servlet mapped as /* serves at /VAADIN

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1361,12 +1361,13 @@ public class VaadinServlet extends HttpServlet implements Constants {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("An error occurred during decoding URL.",e);
         }
+        String filePath = decodedPath.replace(request.getContextPath(), "");
         // Servlet mapped as /* serves at /VAADIN
         // Servlet mapped as /foo/bar/* serves at /foo/bar/VAADIN
-        if (decodedPath.startsWith("/VAADIN/")) {
-            return decodedPath;
+        if (filePath.startsWith("/VAADIN/")) {
+            return filePath;
         }
-        String servletPrefixedPath = request.getServletPath() + decodedPath;
+        String servletPrefixedPath = request.getServletPath() + filePath;
         // Servlet mapped as /VAADIN/*
         if (servletPrefixedPath.startsWith("/VAADIN/")) {
             return servletPrefixedPath;

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1364,7 +1364,6 @@ public class VaadinServlet extends HttpServlet implements Constants {
             throw new RuntimeException("An error occurred during decoding URL.",e);
         }
         String filePath = decodedPath.substring(contextPath.length());
-        if (filePath.equals("/VAADIN")) filePath = "/VAADIN/";
         // Servlet mapped as /* serves at /VAADIN
         // Servlet mapped as /foo/bar/* serves at /foo/bar/VAADIN
         if (filePath.startsWith("/VAADIN/")) {

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1364,6 +1364,7 @@ public class VaadinServlet extends HttpServlet implements Constants {
             throw new RuntimeException("An error occurred during decoding URL.",e);
         }
         String filePath = decodedPath.substring(contextPath.length());
+        if (filePath.equals("/VAADIN")) filePath = "/VAADIN/";
         // Servlet mapped as /* serves at /VAADIN
         // Servlet mapped as /foo/bar/* serves at /foo/bar/VAADIN
         if (filePath.startsWith("/VAADIN/")) {

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1361,7 +1361,13 @@ public class VaadinServlet extends HttpServlet implements Constants {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("An error occurred during decoding URL.",e);
         }
-        String filePath = decodedPath.replace(request.getContextPath(), "");
+        String contextPath = request.getContextPath();
+        String filePath = null;
+        if (contextPath != null && !contextPath.isEmpty()) {
+            filePath = decodedPath.replace(request.getContextPath(), "");
+        } else {
+            filePath = decodedPath;
+        }
         // Servlet mapped as /* serves at /VAADIN
         // Servlet mapped as /foo/bar/* serves at /foo/bar/VAADIN
         if (filePath.startsWith("/VAADIN/")) {

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1365,8 +1365,9 @@ public class VaadinServlet extends HttpServlet implements Constants {
         }
         String filePath = decodedPath.substring(contextPath.length());
         String servletPath = request.getServletPath();
-            if (!servletPath.isEmpty() && !servletPath.equals("/VAADIN") && filePath.startsWith(servletPath)) {
-          	filePath = filePath.substring(servletPath.length());
+        if (!servletPath.isEmpty() && !servletPath.equals("/VAADIN") 
+                && filePath.startsWith(servletPath)) {
+            filePath = filePath.substring(servletPath.length());
         }
         // Servlet mapped as /* serves at /VAADIN
         // Servlet mapped as /foo/bar/* serves at /foo/bar/VAADIN

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1355,19 +1355,15 @@ public class VaadinServlet extends HttpServlet implements Constants {
             return null;
         }
         String decodedPath = null;
+        String contextPath = null;
         try {
             // pathInfo should be already decoded, but some containers do not decode
-            decodedPath = URLDecoder.decode(pathInfo, StandardCharsets.UTF_8.name());
+            decodedPath = URLDecoder.decode(request.getRequestURI(), StandardCharsets.UTF_8.name());
+            contextPath = URLDecoder.decode(request.getContextPath(), StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("An error occurred during decoding URL.",e);
         }
-        String contextPath = request.getContextPath();
-        String filePath = null;
-        if (contextPath != null && !contextPath.isEmpty()) {
-            filePath = decodedPath.replace(request.getContextPath(), "");
-        } else {
-            filePath = decodedPath;
-        }
+        String filePath = decodedPath.substring(contextPath.length());
         // Servlet mapped as /* serves at /VAADIN
         // Servlet mapped as /foo/bar/* serves at /foo/bar/VAADIN
         if (filePath.startsWith("/VAADIN/")) {

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1351,6 +1351,9 @@ public class VaadinServlet extends HttpServlet implements Constants {
      */
     protected String getStaticFilePath(HttpServletRequest request) {
         String pathInfo = request.getPathInfo();
+        if (pathInfo == null) {
+            return null;
+        }
         String decodedPath = null;
         try {
             // pathInfo should be already decoded, but some containers do not decode
@@ -1358,13 +1361,10 @@ public class VaadinServlet extends HttpServlet implements Constants {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("An error occurred during decoding URL.",e);
         }
-        if (decodedPath == null) {
-            return null;
-        }
         // Servlet mapped as /* serves at /VAADIN
         // Servlet mapped as /foo/bar/* serves at /foo/bar/VAADIN
         if (decodedPath.startsWith("/VAADIN/")) {
-            return pathInfo;
+            return decodedPath;
         }
         String servletPrefixedPath = request.getServletPath() + decodedPath;
         // Servlet mapped as /VAADIN/*

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1365,7 +1365,7 @@ public class VaadinServlet extends HttpServlet implements Constants {
         }
         String filePath = decodedPath.substring(contextPath.length());
         String servletPath = request.getServletPath();
-        if (!servletPath.isEmpty() && !serlvetPath.equals("/VAADIN")) {
+        if (!servletPath.isEmpty() && !servletPath.equals("/VAADIN")) {
             filePath = filePath.substring(servletPath.length());
         }        
         // Servlet mapped as /* serves at /VAADIN

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -1364,12 +1364,16 @@ public class VaadinServlet extends HttpServlet implements Constants {
             throw new RuntimeException("An error occurred during decoding URL.",e);
         }
         String filePath = decodedPath.substring(contextPath.length());
+        String servletPath = request.getServletPath();
+        if (!servletPath.isEmpty()) {
+            filePath = filePath.substring(servletPath.length());
+        }        
         // Servlet mapped as /* serves at /VAADIN
         // Servlet mapped as /foo/bar/* serves at /foo/bar/VAADIN
         if (filePath.startsWith("/VAADIN/")) {
             return filePath;
         }
-        String servletPrefixedPath = request.getServletPath() + filePath;
+        String servletPrefixedPath = servletPath + filePath;
         // Servlet mapped as /VAADIN/*
         if (servletPrefixedPath.startsWith("/VAADIN/")) {
             return servletPrefixedPath;

--- a/server/src/main/java/com/vaadin/server/VaadinServlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinServlet.java
@@ -33,6 +33,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -1349,15 +1350,22 @@ public class VaadinServlet extends HttpServlet implements Constants {
      */
     protected String getStaticFilePath(HttpServletRequest request) {
         String pathInfo = request.getPathInfo();
-        if (pathInfo == null) {
+        String decodedPath = null;
+        try {
+            // pathInfo should be already decoded, but some containers do not decode
+            decodedPath = URLDecoder.decode(pathInfo, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("An error occurred during decoding URL.",e);
+        }
+        if (decodedPath == null) {
             return null;
         }
         // Servlet mapped as /* serves at /VAADIN
         // Servlet mapped as /foo/bar/* serves at /foo/bar/VAADIN
-        if (pathInfo.startsWith("/VAADIN/")) {
+        if (decodedPath.startsWith("/VAADIN/")) {
             return pathInfo;
         }
-        String servletPrefixedPath = request.getServletPath() + pathInfo;
+        String servletPrefixedPath = request.getServletPath() + decodedPath;
         // Servlet mapped as /VAADIN/*
         if (servletPrefixedPath.startsWith("/VAADIN/")) {
             return servletPrefixedPath;

--- a/server/src/test/java/com/vaadin/server/VaadinServletTest.java
+++ b/server/src/test/java/com/vaadin/server/VaadinServletTest.java
@@ -117,7 +117,7 @@ public class VaadinServletTest {
         Mockito.when(request.getServletPath()).thenReturn(servletPath);
         Mockito.when(request.getPathInfo()).thenReturn(pathInfo);
         Mockito.when(request.getRequestURI()).thenReturn("context/"+pathInfo);
-        Mockito.when(request.getContextPath()).thenReturn("context");
+        Mockito.when(request.getContextPath()).thenReturn("context/");
         return request;
     }
 }

--- a/server/src/test/java/com/vaadin/server/VaadinServletTest.java
+++ b/server/src/test/java/com/vaadin/server/VaadinServletTest.java
@@ -116,6 +116,8 @@ public class VaadinServletTest {
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         Mockito.when(request.getServletPath()).thenReturn(servletPath);
         Mockito.when(request.getPathInfo()).thenReturn(pathInfo);
+        Mockito.when(request.getRequestURI()).thenReturn("context/"+pathInfo);
+        Mockito.when(request.getContextPath()).thenReturn("context");
         return request;
     }
 }

--- a/server/src/test/java/com/vaadin/server/VaadinServletTest.java
+++ b/server/src/test/java/com/vaadin/server/VaadinServletTest.java
@@ -116,8 +116,8 @@ public class VaadinServletTest {
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         Mockito.when(request.getServletPath()).thenReturn(servletPath);
         Mockito.when(request.getPathInfo()).thenReturn(pathInfo);
-        Mockito.when(request.getRequestURI()).thenReturn("context/"+pathInfo);
-        Mockito.when(request.getContextPath()).thenReturn("context/");
+        Mockito.when(request.getRequestURI()).thenReturn("/context"+pathInfo);
+        Mockito.when(request.getContextPath()).thenReturn("/context");
         return request;
     }
 }


### PR DESCRIPTION
Some containers do not decode path when using getPathInfo, in case path has not been decoded there is a risk for path traversal vulnerability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11812)
<!-- Reviewable:end -->
