### PR TITLE
Don't attempt to send expand/collapse events for disabled TreeGrid.

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/treegrid/TreeGridConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/treegrid/TreeGridConnector.java
@@ -288,7 +288,7 @@ public class TreeGridConnector extends GridConnector {
      */
     private void setCollapsed(int rowIndex, boolean collapsed,
             boolean userOriginated) {
-        if (isAwaitingRowChange()) {
+        if (isAwaitingRowChange() || !getState().enabled) {
             return;
         }
         if (collapsed) {

--- a/uitest/src/main/java/com/vaadin/tests/components/tree/TreeBasicFeatures.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/tree/TreeBasicFeatures.java
@@ -115,6 +115,15 @@ public class TreeBasicFeatures extends AbstractTestUIWithLog {
                                 ? t -> "level" + t.getDepth()
                                 : t -> null))
                 .setCheckable(true);
+        MenuItem enabled = componentMenu.addItem("Enabled",
+                menuItem -> tree.setEnabled(!tree.isEnabled()));
+        enabled.setCheckable(true);
+        enabled.setChecked(true);
+
+        componentMenu.addItem("Expand 0 | 0",
+                menuItem -> tree.expand(new HierarchicalTestBean(null, 0, 0)));
+        componentMenu.addItem("Collapse 0 | 0", menuItem -> tree
+                .collapse(new HierarchicalTestBean(null, 0, 0)));
 
         return menu;
     }

--- a/uitest/src/test/java/com/vaadin/tests/components/tree/TreeBasicFeaturesTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/tree/TreeBasicFeaturesTest.java
@@ -252,4 +252,26 @@ public class TreeBasicFeaturesTest extends MultiBrowserTest {
         $(TreeElement.class).first().getItem(0).showTooltip();
         assertEquals("", "0 | 0", getTooltipElement().getText());
     }
+
+    @Test
+    public void tree_disable_enable_expand_collapse() {
+        TreeElement tree = $(TreeElement.class).first();
+        selectMenuPath("Component", "Enabled");
+        assertTrue(tree.hasClassName("v-disabled"));
+        // ensure expanding doesn't work
+        tree.expand(0);
+        assertEquals("0 | 1", tree.getItem(1).getText());
+        selectMenuPath("Component", "Enabled");
+        assertFalse(tree.hasClassName("v-disabled"));
+        // ensure expanding and collapsing works again
+        tree.expand(0);
+        assertEquals("1 | 0", tree.getItem(1).getText());
+        tree.collapse(0);
+        assertEquals("0 | 1", tree.getItem(1).getText());
+        // same test for server-side expanding and collapsing
+        selectMenuPath("Component", "Expand 0 | 0");
+        assertEquals("1 | 0", tree.getItem(1).getText());
+        selectMenuPath("Component", "Collapse 0 | 0");
+        assertEquals("0 | 1", tree.getItem(1).getText());
+    }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridBasicFeaturesTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridBasicFeaturesTest.java
@@ -348,6 +348,30 @@ public class TreeGridBasicFeaturesTest extends MultiBrowserTest {
         assertEquals("Not expanded", "1 | 0", grid.getCell(1, 0).getText());
     }
 
+    @Test
+    public void disable_enable_expand_collapse() {
+        TreeGridElement treeGrid = $(TreeGridElement.class).first();
+        selectMenuPath("Component", "State", "Enabled");
+        assertTrue(treeGrid.hasClassName("v-disabled"));
+        // ensure expanding doesn't work
+        treeGrid.expandWithClick(0);
+        assertCellTexts(1, 0, new String[] { "0 | 1" });
+        selectMenuPath("Component", "State", "Enabled");
+        assertFalse(treeGrid.hasClassName("v-disabled"));
+        // ensure expanding and collapsing works again
+        treeGrid.expandWithClick(0);
+        assertCellTexts(1, 0, new String[] { "1 | 0" });
+        treeGrid.collapseWithClick(0);
+        assertCellTexts(1, 0, new String[] { "0 | 1" });
+        // same test for server-side expanding and collapsing
+        selectMenuPath("Component", "Features", "Server-side expand",
+                "Expand 0 | 0");
+        assertCellTexts(1, 0, new String[] { "1 | 0" });
+        selectMenuPath("Component", "Features", "Server-side collapse",
+                "Collapse 0 | 0");
+        assertCellTexts(1, 0, new String[] { "0 | 1" });
+    }
+
     private void assertCellTexts(int startRowIndex, int cellIndex,
             String[] cellTexts) {
         int index = startRowIndex;


### PR DESCRIPTION
(#11823)

The attempt gets blocked later down the line in any case and never
reaches the server, but sending it messes up TreeGrid's internal state.
It gets stuck waiting for the resolution of the blocked call that can
then only be resolved by server-side sending its own expand/collapse
request programmatically. Until that happens no further expand/collapse
attempts will get sent to server even after the TreeGrid has been
enabled again.

Tree is also affected as it is built upon TreeGrid.

Fixes #11822

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11828)
<!-- Reviewable:end -->
