### PR TITLE
Delegate enabled handling to Composite root.

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Composite.java
+++ b/server/src/main/java/com/vaadin/ui/Composite.java
@@ -216,6 +216,16 @@ public class Composite extends AbstractComponent implements HasComponents {
     }
 
     @Override
+    public void setEnabled(boolean enabled) {
+        getRootOrThrow().setEnabled(enabled);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return getRootOrThrow().isEnabled();
+    }
+
+    @Override
     public float getWidth() {
         return getRootOrThrow().getWidth();
     }

--- a/uitest/src/main/java/com/vaadin/tests/components/tree/TreeInitiallyDisabled.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/tree/TreeInitiallyDisabled.java
@@ -1,0 +1,51 @@
+package com.vaadin.tests.components.tree;
+
+import com.vaadin.data.TreeData;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Tree;
+
+public class TreeInitiallyDisabled extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        Tree<String> tree = new Tree<>();
+        TreeData<String> treeData = new TreeData<>();
+        String parent1 = "Parent 1";
+        treeData.addItem(null, parent1);
+        treeData.addItem(parent1, "Child 1.1");
+        treeData.addItem(parent1, "Child 1.2");
+        treeData.addItem(parent1, "Child 1.3");
+        String parent2 = "Parent 2";
+        treeData.addItem(null, parent2);
+        treeData.addItem(parent2, "Child 2.1");
+        treeData.addItem(parent2, "Child 2.2");
+        treeData.addItem(parent2, "Child 2.3");
+        String parent3 = "Parent 3";
+        treeData.addItem(null, parent3);
+        treeData.addItem(parent3, "Child 3.1");
+        treeData.addItem(parent3, "Child 3.2");
+        treeData.addItem(parent3, "Child 3.3");
+        tree.setTreeData(treeData);
+
+        Button button = new Button("Toggle enabled/disabled");
+        button.addClickListener(event -> {
+            tree.setEnabled(!tree.isEnabled());
+        });
+
+        addComponents(tree, button);
+
+        tree.setEnabled(false);
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 11831;
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Initially disabled Tree should have disabled styles.";
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/tree/TreeInitiallyDisabledTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/tree/TreeInitiallyDisabledTest.java
@@ -1,0 +1,18 @@
+package com.vaadin.tests.components.tree;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.TreeElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class TreeInitiallyDisabledTest extends SingleBrowserTest {
+
+    @Test
+    public void checkDisabledStyleAdded() {
+        openTestURL();
+        TreeElement tree = $(TreeElement.class).first();
+        assertTrue(tree.hasClassName("v-disabled"));
+    }
+}


### PR DESCRIPTION
Otherwise the changed state isn't communicated properly to the
client-side in the initial round trip, as the client-side uses the child
connector's state directly.

Fixes #11831

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11832)
<!-- Reviewable:end -->
