### PR TITLE
Add method writeBeanAsDraft(bean) in Binder

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1788,7 +1788,7 @@ public class Binder<BEAN> implements Serializable {
 
     /**
      * Writes successfully converted and validated changes from the bound fields
-     * to the bean regardless if there are some fields with non-validated changes.
+     * to the bean even if there are other fields with non-validated changes.
      *
      * @see #writeBean(Object)
      * @see #writeBeanIfValid(Object)

--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1787,6 +1787,24 @@ public class Binder<BEAN> implements Serializable {
     }
 
     /**
+     * Writes successfully converted changes from the bound fields bypassing
+     * all the Validation. If the conversion fails, the value written to the
+     * bean will be null.
+     *
+     * @see #writeBean(Object)
+     * @see #writeBeanIfValid(Object)
+     * @see #readBean(Object)
+     * @see #setBean(Object)
+     *
+     * @param bean
+     *            the object to which to write the field values, not
+     *            {@code null}
+     */
+    public void writeBeanAsDraft(BEAN bean) {
+   		doWriteDraft(bean, new ArrayList<>(bindings));
+    }
+
+    /**
      * Writes changes from the bound fields to the given bean if all validators
      * (binding and bean level) pass.
      * <p>
@@ -1871,6 +1889,22 @@ public class Binder<BEAN> implements Serializable {
         getValidationStatusHandler().statusChange(status);
         fireStatusChangeEvent(!status.isOk());
         return status;
+    }
+
+    /**
+     * Writes the successfully converted field values into the given bean
+     *
+     * @param bean
+     *            the bean to write field values into
+     * @param bindings
+     *            the set of bindings to write to the bean
+     */
+    @SuppressWarnings({ "unchecked" })
+    private void doWriteDraft(BEAN bean, Collection<Binding<BEAN, ?>> bindings) {
+        Objects.requireNonNull(bean, "bean cannot be null");
+
+        bindings.forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)
+                    .writeFieldValue(bean));
     }
 
     /**

--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1800,7 +1800,7 @@ public class Binder<BEAN> implements Serializable {
      *            {@code null}
      */
     public void writeBeanAsDraft(BEAN bean) {
-   		doWriteDraft(bean, new ArrayList<>(bindings));
+   	    doWriteDraft(bean, new ArrayList<>(bindings));
     }
 
     /**

--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1787,9 +1787,8 @@ public class Binder<BEAN> implements Serializable {
     }
 
     /**
-     * Writes successfully converted changes from the bound fields bypassing
-     * all the Validation. If the conversion fails, the value written to the
-     * bean will be null.
+     * Writes successfully converted and validated changes from the bound fields
+     * to the bean regardless if there are some fields with non-validated changes.
      *
      * @see #writeBean(Object)
      * @see #writeBeanIfValid(Object)

--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1891,7 +1891,8 @@ public class Binder<BEAN> implements Serializable {
     }
 
     /**
-     * Writes the successfully converted field values into the given bean
+     * Writes the successfully converted and validated field values into the
+     * given bean.
      *
      * @param bean
      *            the bean to write field values into

--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1800,7 +1800,7 @@ public class Binder<BEAN> implements Serializable {
      *            {@code null}
      */
     public void writeBeanAsDraft(BEAN bean) {
-   	    doWriteDraft(bean, new ArrayList<>(bindings));
+        doWriteDraft(bean, new ArrayList<>(bindings));
     }
 
     /**

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -278,17 +278,28 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 else return ValidationResult.error("value must be Mike");
             })
             .bind(Person::getFirstName, Person::setFirstName);
+        binder.forField(ageField)
+                .withConverter(new StringToIntegerConverter(""))
+                .bind(Person::getAge, Person::setAge);
 
         Person person = new Person();
 
         String fieldValue = "John";
         nameField.setValue(fieldValue);
 
+        int age = 10;
+        ageField.setValue("10");
+
         person.setFirstName("Mark");
 
         binder.writeBeanAsDraft(person);
 
-        assertEquals(fieldValue, person.getFirstName());
+        // name is not written to draft as validation / conversion
+        // does not pass
+        assertNoteEquals(fieldValue, person.getFirstName());
+        // age is written to draft even if firstname validation
+        // fails
+        assertEquals(age, person.getAge());
     }
     
     @Test

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -296,7 +296,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
         // name is not written to draft as validation / conversion
         // does not pass
-        assertNoteEquals(fieldValue, person.getFirstName());
+        assertNotEquals(fieldValue, person.getFirstName());
         // age is written to draft even if firstname validation
         // fails
         assertEquals(age, person.getAge());

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -270,6 +270,26 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
+    public void save_bound_beanAsDraft() {
+        Binder<Person> binder = new Binder<>();
+        binder.forField(nameField)
+            .withValidator((value,context) -> {
+                if (value.equals("Mike")) return ValidationResult.ok();
+                else return ValidationResult.error("value must be Mike");
+            })
+            .bind(Person::getFirstName, Person::setFirstName);
+
+        Person person = new Person();
+
+        String fieldValue = "John";
+        nameField.setValue(fieldValue);
+
+        binder.writeBeanAsDraft(person);
+
+        assertEquals(fieldValue, person.getFirstName());
+    }
+    
+    @Test
     public void load_bound_fieldValueIsUpdated() {
         binder.bind(nameField, Person::getFirstName, Person::setFirstName);
 

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -284,6 +284,8 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         String fieldValue = "John";
         nameField.setValue(fieldValue);
 
+        person.setFirstName("John");
+
         binder.writeBeanAsDraft(person);
 
         assertEquals(fieldValue, person.getFirstName());

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -301,7 +301,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         // fails
         assertEquals(age, person.getAge());
     }
-    
+
     @Test
     public void load_bound_fieldValueIsUpdated() {
         binder.bind(nameField, Person::getFirstName, Person::setFirstName);

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -284,7 +284,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         String fieldValue = "John";
         nameField.setValue(fieldValue);
 
-        person.setFirstName("John");
+        person.setFirstName("Mark");
 
         binder.writeBeanAsDraft(person);
 


### PR DESCRIPTION
With current Binder implementation it is not easy to support Forms, which you want to save as draft, i.e. incomplete. For example there can be big text areas, that require time to fill, or lot of fields. Therefore it is needed to that form can be saved, e.g. to other bean in incomplete state when it is not yet passing validation and this other bean can be persisted to draft storage for further editing in the future. This method helps to achieve that easily.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11833)
<!-- Reviewable:end -->
