### PR TITLE
Make asRequired conditional on binding.setAsRequiredEnabled(..)

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -241,7 +241,7 @@ public class Binder<BEAN> implements Serializable {
         public void setAsRequiredEnabled(boolean asRequiredEnabled);
 
         /**
-         * Returns if asRequired validator is currently enabled or not
+         * Returns whether asRequired validator is currently enabled or not
          *
          * @see #asRequired(String)
          * @see #asRequired(ErrorMessageProvider)

--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -228,13 +228,15 @@ public class Binder<BEAN> implements Serializable {
         public Setter<BEAN, TARGET> getSetter();
 
         /**
-         * By default asRequired validator is enabled, with parameter
-         * value false asRequired validator can be disabled.
+         * Enable or disable asRequired validator.
+         * The validator is enabled by default.
          *
          * @see #asRequired(String)
          * @see #asRequired(ErrorMessageProvider)
-         * 
-         * @param asRequiredEnabled A boolean value
+         *
+         * @param asRequiredEnabled
+         *            {@code false} if asRequired validator should
+         *            be disabled, {@code true} otherwise (default)
          */
         public void setAsRequiredEnabled(boolean asRequiredEnabled);
 
@@ -244,7 +246,8 @@ public class Binder<BEAN> implements Serializable {
          * @see #asRequired(String)
          * @see #asRequired(ErrorMessageProvider)
          *
-         * @return A boolean value
+         * @return {@code false} if asRequired validator is disabled
+         *         {@code true} otherwise (default)
          */
         public boolean isAsRequiredEnabled();
     }
@@ -941,7 +944,7 @@ public class Binder<BEAN> implements Serializable {
                 Validator<TARGET> customRequiredValidator) {
             checkUnbound();
             this.asRequiredSet = true;
-            field.setRequiredIndicatorVisible(true);            
+            field.setRequiredIndicatorVisible(true);
             return withValidator((value, context) -> {
                 if (!field.isRequiredIndicatorVisible())
                     return ValidationResult.ok();
@@ -1317,9 +1320,11 @@ public class Binder<BEAN> implements Serializable {
 
         @Override
         public void setAsRequiredEnabled(boolean asRequiredEnabled) {
-            if (!asRequiredSet) throw new IllegalStateException(
-                 "asRequired should be set for this binding to be " 
-                         + "able to toggle this on the fly.");
+            if (!asRequiredSet) {
+                throw new IllegalStateException(
+                 "Unable to toggle asRequired validation since " 
+                         + "asRequired has not been set.");
+            }
             if (asRequiredEnabled != isAsRequiredEnabled()) {
                 field.setRequiredIndicatorVisible(asRequiredEnabled);
                         validate();

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -473,13 +473,13 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         TextField textField = new TextField();
         assertFalse(textField.isRequiredIndicatorVisible());
 
-        BindingBuilder<Person, String> binding = binder.forField(textField);
+        BindingBuilder<Person, String> bindingBuilder = binder.forField(textField);
         assertFalse(textField.isRequiredIndicatorVisible());
 
-        binding.asRequired("foobar");
+        bindingBuilder.asRequired("foobar");
         assertTrue(textField.isRequiredIndicatorVisible());
 
-        binding.bind(Person::getFirstName, Person::setFirstName);
+        Binding<Person, String> binding = bindingBuilder.bind(Person::getFirstName, Person::setFirstName);
         binder.setBean(item);
         assertNull(textField.getErrorMessage());
 

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -491,6 +491,9 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         textField.setValue("value");
         assertNull(textField.getErrorMessage());
         assertTrue(textField.isRequiredIndicatorVisible());
+
+        binding.setAsRequiredEnabled(false);
+        assertFalse(textField.isRequiredIndicatorVisible());
     }
 
     @Test


### PR DESCRIPTION
It is a very common use case in complex form that whether a field is required or not, it depends on input on other fields. Hypothetical use case sample could be that we have form for a Product and price of the product is needed except in case the Product's type is Sample. So in that kind of scenarios it would be needed to turn off asRequired() validation easily. The purpose of this enhancement and new binding.setAsRequiredEnabled(..) API is to help implementation of this kind of use cases more easily.

There is more generic ticket about conditional validation, and this PR is partially addressing it https://github.com/vaadin/framework/issues/10709

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11834)
<!-- Reviewable:end -->
