### PR TITLE
Simplify Grid scroll handling.

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
@@ -93,9 +93,9 @@ public class GridConnector extends AbstractListingConnector
      * The scrolling methods must trigger the scrolling only after any potential
      * resizing or other similar action triggered from the server side within
      * the same round trip has had a chance to happen, so there needs to be a
-     * delay. The delay is done with <code>scheduleFinally</code> rather than
-     * <code>scheduleDeferred</code> because the latter has been known to cause
-     * flickering in Grid.
+     * delay. The delay is done with <code>scheduleDeferred</code> rather than
+     * <code>scheduleFinally</code> because otherwise the order of the
+     * operations isn't guaranteed.
      *
      */
     private class GridConnectorClientRpc implements GridClientRpc {
@@ -107,7 +107,7 @@ public class GridConnector extends AbstractListingConnector
 
         @Override
         public void scrollToRow(int row, ScrollDestination destination) {
-            Scheduler.get().scheduleFinally(() -> {
+            Scheduler.get().scheduleDeferred(() -> {
                 grid.scrollToRow(row, destination);
                 // Add details refresh listener and handle possible detail
                 // for scrolled row.
@@ -121,12 +121,12 @@ public class GridConnector extends AbstractListingConnector
 
         @Override
         public void scrollToStart() {
-            Scheduler.get().scheduleFinally(() -> grid.scrollToStart());
+            Scheduler.get().scheduleDeferred(() -> grid.scrollToStart());
         }
 
         @Override
         public void scrollToEnd() {
-            Scheduler.get().scheduleFinally(() -> {
+            Scheduler.get().scheduleDeferred(() -> {
                 grid.scrollToEnd();
                 addDetailsRefreshCallback(() -> {
                     if (rowHasDetails(grid.getDataSource().size() - 1)) {

--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -7713,14 +7713,11 @@ public class Escalator extends Widget
     public void scrollToRowAndSpacer(final int rowIndex,
             final ScrollDestination destination, final int padding)
             throws IllegalArgumentException {
-        // wait for the layout phase to finish
-        Scheduler.get().scheduleFinally(() -> {
-            if (rowIndex != -1) {
-                verifyValidRowIndex(rowIndex);
-            }
-            body.scrollToRowSpacerOrBoth(rowIndex, destination, padding,
-                    ScrollType.ROW_AND_SPACER);
-        });
+        if (rowIndex != -1) {
+            verifyValidRowIndex(rowIndex);
+        }
+        body.scrollToRowSpacerOrBoth(rowIndex, destination, padding,
+                ScrollType.ROW_AND_SPACER);
     }
 
     private static void validateScrollDestination(


### PR DESCRIPTION
If first attempt at scrolling doesn't succeed it's unlikely that
continuing to wait is going to make any difference. Cache should be
populated before triggering any actions that depend on the row being
visible, otherwise it should be enough to trust that scrollToRow
actually scrolls to row and once scrolling is done the row is as much in
view as it's going to get. This way we don't get into a situation where
Editor never opens because it's still waiting for that one last pixel
that can't be achieved thanks to browser zoom causing rounding errors.

Continues on #11672

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11835)
<!-- Reviewable:end -->
