### PR TITLE
Close a window on a press of the ESC key, when maximized button is focused

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VWindow.java
+++ b/client/src/main/java/com/vaadin/client/ui/VWindow.java
@@ -1014,14 +1014,20 @@ public class VWindow extends VOverlay implements ShortcutActionHandlerOwner,
             // if clicked or key ENTER or SPACE is pressed
         } else if (isClosable() && target == closeBox) {
             if (type == Event.ONCLICK || (type == Event.ONKEYUP
-                    && isKeyEnterOrSpace(event.getKeyCode()))) {
-                onCloseClick();
+                    && (isKeyEnterOrSpace(event.getKeyCode()))
+                    || event.getKeyCode() == KeyCodes.KEY_ESCAPE)) {
+                closeWindow();
             }
             bubble = false;
         } else if (target == maximizeRestoreBox) {
+            // if ESC is pressed, close the window
+            if (type == Event.ONKEYUP
+                    && event.getKeyCode() == KeyCodes.KEY_ESCAPE) {
+                closeWindow();
+            }
             // handled in connector
             // if clicked or key ENTER or SPACE is pressed
-            if (type != Event.ONCLICK && !(type == Event.ONKEYUP
+            else if (type != Event.ONCLICK && !(type == Event.ONKEYUP
                     && isKeyEnterOrSpace(event.getKeyCode()))) {
                 bubble = false;
             }
@@ -1097,7 +1103,7 @@ public class VWindow extends VOverlay implements ShortcutActionHandlerOwner,
         }
     }
 
-    private void onCloseClick() {
+    private void closeWindow() {
         // Send the close event to the server
         client.updateVariable(id, "close", true, true);
     }

--- a/uitest/src/main/java/com/vaadin/tests/components/window/CloseWindowOnEscapeMaximizedButtonFocused.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/window/CloseWindowOnEscapeMaximizedButtonFocused.java
@@ -1,0 +1,41 @@
+package com.vaadin.tests.components.window;
+
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.shared.ui.window.WindowMode;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.Window;
+
+@Widgetset("com.vaadin.DefaultWidgetSet")
+public class CloseWindowOnEscapeMaximizedButtonFocused extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        Label instructions = new Label("Press Maximise button and then ESC. "
+                + " Window should be closed");
+        Button openWindow = new Button("Open Window");
+        openWindow.setId("openW");
+        openWindow.addClickListener(e -> {
+            Window win = new Window("Window test", new Label("Some content"));
+            win.setWindowMode(WindowMode.NORMAL);
+            win.setWidth("300px");
+            win.setHeight("300px");
+            win.center();
+            addWindow(win);
+        });
+        addComponent(instructions);
+        addComponent(openWindow);
+    }
+
+    @Override
+    public String getTestDescription() {
+        return "A window should be closed after the ESC button is pressed, when a maximize button is focused";
+    };
+
+    @Override
+    public Integer getTicketNumber() {
+        return 11838;
+    };
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/window/CloseWindowOnEscapeMaximizedButtonFocusedTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/window/CloseWindowOnEscapeMaximizedButtonFocusedTest.java
@@ -1,0 +1,27 @@
+package com.vaadin.tests.components.window;
+
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.WindowElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import static org.junit.Assert.assertTrue;
+
+public class CloseWindowOnEscapeMaximizedButtonFocusedTest
+        extends MultiBrowserTest {
+
+    @Test
+    public void windowIsClosed() {
+        openTestURL();
+        ButtonElement openWindow = $(ButtonElement.class).id("openW");
+        openWindow.click();
+
+        WindowElement window = $(WindowElement.class).first();
+        window.maximize();
+        findElement(By.className("v-window-restorebox")).sendKeys(Keys.ESCAPE);
+        waitForElementNotPresent(By.className("v-window"));
+        assertTrue("Window should be removed after ESC key is pressed",
+                driver.findElements(By.className("v-window ")).isEmpty());
+    }
+}


### PR DESCRIPTION
Fixes #11838

Changes:

1. Close a window when maximized button is focused and ESC is pressed
2. Add additional check for a close button to react to the ESC key press
3. Rename a private method `onCloseClick` to `closeWindow` to allow code re-use

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11840)
<!-- Reviewable:end -->
