### PR TITLE
Fix to RadioButtonGroup readOnly handling.

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/optiongroup/RadioButtonGroupConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/optiongroup/RadioButtonGroupConnector.java
@@ -86,7 +86,12 @@ public class RadioButtonGroupConnector
 
     @OnStateChange("readOnly")
     void updateWidgetReadOnly() {
-        getWidget().setEnabled(isEnabled() && !isReadOnly());
+        getWidget().setReadonly(isReadOnly());
+    }
+
+    @OnStateChange("enabled")
+    void updateWidgetEnabled() {
+        getWidget().setEnabled(isEnabled());
     }
 
     @OnStateChange("selectedItemKey")

--- a/uitest/src/main/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupDisablingAndReadOnly.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupDisablingAndReadOnly.java
@@ -1,0 +1,36 @@
+package com.vaadin.tests.components.radiobuttongroup;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.RadioButtonGroup;
+
+public class RadioButtonGroupDisablingAndReadOnly extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setEnabled(false);
+        group.setReadOnly(true);
+        group.setItems("a", "b", "c");
+        addComponent(group);
+
+        addComponent(new Button("Toggle enabled", e -> {
+            group.setEnabled(!group.isEnabled());
+        }));
+
+        addComponent(new Button("Toggle readOnly", e -> {
+            group.setReadOnly(!group.isReadOnly());
+        }));
+
+        addComponent(new Button("Clear selection", e -> {
+            group.setValue(null);
+        }));
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Options should only be selectable when the group is "
+                + "neither disabled nor readOnly";
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupDisablingAndReadOnlyTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/radiobuttongroup/RadioButtonGroupDisablingAndReadOnlyTest.java
@@ -1,0 +1,206 @@
+package com.vaadin.tests.components.radiobuttongroup;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.testbench.elements.AbstractComponentElement.ReadOnlyException;
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.RadioButtonGroupElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+/**
+ * Test styles, selectByText, and selection by clicking for all enabled/readOnly
+ * combinations and how toggling the states affects the selectability. The
+ * styles and behaviour should match for all combinations and selection
+ * attempts.
+ *
+ */
+public class RadioButtonGroupDisablingAndReadOnlyTest extends MultiBrowserTest {
+
+    private RadioButtonGroupElement group;
+    private List<WebElement> options;
+    private ButtonElement toggleEnabled;
+    private ButtonElement toggleReadOnly;
+    private ButtonElement clearSelection;
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        openTestURL();
+        group = $(RadioButtonGroupElement.class).first();
+        options = group.getOptionElements();
+        toggleEnabled = $(ButtonElement.class).caption("Toggle enabled")
+                .first();
+        toggleReadOnly = $(ButtonElement.class).caption("Toggle readOnly")
+                .first();
+        clearSelection = $(ButtonElement.class).caption("Clear selection")
+                .first();
+    }
+
+    private void testSelect() {
+        try {
+            group.selectByText("b");
+        } catch (ReadOnlyException e) {
+            // NOP
+        }
+    }
+
+    @Test
+    public void testEnabledToggleWhileReadOnly() {
+        assertTrue(group.hasClassName("v-readonly"));
+        assertTrue(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertNull(group.getValue());
+
+        toggleEnabled.click();
+
+        assertTrue(group.hasClassName("v-readonly"));
+        assertFalse(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertNull(group.getValue());
+
+        toggleEnabled.click();
+
+        assertTrue(group.hasClassName("v-readonly"));
+        assertTrue(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertNull(group.getValue());
+    }
+
+    @Test
+    public void testEnabledToggleWhileNotReadOnly() {
+        toggleReadOnly.click();
+
+        assertFalse(group.hasClassName("v-readonly"));
+        assertTrue(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertNull(group.getValue());
+
+        toggleEnabled.click();
+
+        assertFalse(group.hasClassName("v-readonly"));
+        assertFalse(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertEquals("b", group.getValue());
+
+        clearSelection.click();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertEquals("b", group.getValue());
+
+        clearSelection.click();
+        assertNull(group.getValue());
+
+        toggleEnabled.click();
+
+        assertFalse(group.hasClassName("v-readonly"));
+        assertTrue(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertNull(group.getValue());
+    }
+
+    @Test
+    public void testReadOnlyToggleWhileDisabled() {
+        assertTrue(group.hasClassName("v-readonly"));
+        assertTrue(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertNull(group.getValue());
+
+        toggleReadOnly.click();
+
+        assertFalse(group.hasClassName("v-readonly"));
+        assertTrue(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertNull(group.getValue());
+
+        toggleReadOnly.click();
+
+        assertTrue(group.hasClassName("v-readonly"));
+        assertTrue(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertNull(group.getValue());
+    }
+
+    @Test
+    public void testReadOnlyToggleWhileEnabled() {
+        toggleEnabled.click();
+
+        assertTrue(group.hasClassName("v-readonly"));
+        assertFalse(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertNull(group.getValue());
+
+        toggleReadOnly.click();
+
+        assertFalse(group.hasClassName("v-readonly"));
+        assertFalse(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertEquals("b", group.getValue());
+
+        clearSelection.click();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertEquals("b", group.getValue());
+
+        clearSelection.click();
+        assertNull(group.getValue());
+
+        toggleReadOnly.click();
+
+        assertTrue(group.hasClassName("v-readonly"));
+        assertFalse(group.hasClassName("v-disabled"));
+
+        testSelect();
+        assertNull(group.getValue());
+
+        options.get(1).click();
+        assertNull(group.getValue());
+    }
+}


### PR DESCRIPTION
Updated the connector to use the widget's enabled and readOnly handling
as intended.

Fixes #11843

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11855)
<!-- Reviewable:end -->
