### PR TITLE
Fix TextField placeholder

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VTextField.java
+++ b/client/src/main/java/com/vaadin/client/ui/VTextField.java
@@ -36,6 +36,12 @@ public class VTextField extends TextBoxBase
     public static final String CLASSNAME = "v-textfield";
     public static final String CLASSNAME_FOCUS = "focus";
 
+    /** For internal use only. May be removed or replaced in the future. */
+    public boolean enabled;
+
+    /** For internal use only. May be removed or replaced in the future. */
+    public boolean readOnly;
+
     public VTextField() {
         this(DOM.createInputText());
     }
@@ -56,7 +62,7 @@ public class VTextField extends TextBoxBase
     }
 
     public void setPlaceholder(String placeholder) {
-        if (placeholder != null) {
+        if (placeholder != null && !readOnly && enabled) {
             getElement().setAttribute("placeholder", placeholder);
         } else {
             getElement().removeAttribute("placeholder");

--- a/client/src/main/java/com/vaadin/client/ui/textfield/TextFieldConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/textfield/TextFieldConnector.java
@@ -47,4 +47,13 @@ public class TextFieldConnector extends AbstractTextFieldConnector {
         return (VTextField) super.getWidget();
     }
 
+    @OnStateChange({"readOnly", "enabled"})
+    private void onReadOnlyChanged() {
+        VTextField widget = getWidget();
+        widget.readOnly = isReadOnly();
+        widget.enabled = isEnabled();
+        widget.setReadOnly(isReadOnly());
+        widget.setEnabled(isEnabled());
+        widget.setPlaceholder(getState().placeholder);
+    } 
 }

--- a/client/src/main/java/com/vaadin/client/ui/textfield/TextFieldConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/textfield/TextFieldConnector.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.client.ui.textfield;
 
+import com.vaadin.client.annotations.OnStateChange;
 import com.vaadin.client.event.InputEvent;
 import com.vaadin.client.ui.VTextField;
 import com.vaadin.shared.ui.Connect;


### PR DESCRIPTION
Make TextField placeholder behave similarly to ComboBox (and TextField in Vaadin10+), i.e. placeholder / input prompt should not be visible when not enabled or readonly.

Fixes https://github.com/vaadin/framework/issues/11837

TODO: Fix DateField in similar fashion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11857)
<!-- Reviewable:end -->
