### PR TITLE
Ensure value change happens before shortcuts in compatibility components

### DIFF
--- a/uitest/src/main/java/com/vaadin/tests/components/datefield/CompatibilityDateFieldShortcut.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/datefield/CompatibilityDateFieldShortcut.java
@@ -1,0 +1,47 @@
+package com.vaadin.tests.components.datefield;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import com.vaadin.event.ShortcutAction.KeyCode;
+import com.vaadin.event.ShortcutListener;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Notification;
+import com.vaadin.v7.ui.DateField;
+
+@SuppressWarnings("deprecation")
+public class CompatibilityDateFieldShortcut extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        String dateFormat = "dd/MM/yyyy";
+
+        DateField dateField = new DateField();
+        dateField.setValue(new Date(2018 - 1900, 0, 11));
+        dateField.setDateFormat(dateFormat);
+
+        dateField.addShortcutListener(
+                new ShortcutListener("Enter", KeyCode.ENTER, null) {
+                    @Override
+                    public void handleAction(Object sender, Object target) {
+                        SimpleDateFormat df = new SimpleDateFormat(dateFormat);
+                        Notification.show(df.format(dateField.getValue()));
+                    }
+                });
+
+        addComponent(dateField);
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Modify the date manually (without using the popup element) and"
+                + " then press Enter. The notification should show the modified"
+                + " value instead of the old value.";
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 10854;
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/CompatibilityDateFieldShortcutTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/CompatibilityDateFieldShortcutTest.java
@@ -1,0 +1,39 @@
+package com.vaadin.tests.components.datefield;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.testbench.elements.DateFieldElement;
+import com.vaadin.testbench.elements.NotificationElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class CompatibilityDateFieldShortcutTest extends SingleBrowserTest {
+
+    private static final String DATEFIELD_VALUE_ORIGINAL = "11/01/2018";
+    private static final String DATEFIELD_VALUE_MODIFIED = "21/01/2018";
+
+    @Test
+    public void modifyValueAndPressEnter() {
+        openTestURL();
+
+        DateFieldElement dateField = $(DateFieldElement.class).first();
+        WebElement dateFieldText = dateField.findElement(By.tagName("input"));
+
+        assertEquals("DateField value should be \"" + DATEFIELD_VALUE_ORIGINAL
+                + "\"", DATEFIELD_VALUE_ORIGINAL, dateField.getValue());
+
+        dateFieldText.click();
+        dateFieldText.sendKeys(Keys.HOME, Keys.DELETE, "2");
+        dateFieldText.sendKeys(Keys.ENTER);
+
+        assertEquals("DateField value should be \"" + DATEFIELD_VALUE_MODIFIED
+                + "\"", DATEFIELD_VALUE_MODIFIED, dateField.getValue());
+
+        assertEquals(DATEFIELD_VALUE_MODIFIED,
+                $(NotificationElement.class).first().getCaption());
+    }
+}


### PR DESCRIPTION
Fixes #10854

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11871)
<!-- Reviewable:end -->
