### PR TITLE
Fix logic of lexicographical comparison of DateField range end

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VAbstractCalendarPanel.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractCalendarPanel.java
@@ -762,8 +762,18 @@ public abstract class VAbstractCalendarPanel<R extends Enum<R>>
             return true;
         }
 
+        // If dateStrResolution has more year digits than rangeEnd, we need
+        // to pad it in order to be lexicographically compatible
         String dateStrResolution = dateStrResolution(date, minResolution);
-        return rangeEnd.substring(0, dateStrResolution.length())
+        String paddedEnd = rangeEnd.substring(0);
+        int yearDigits = dateStrResolution.indexOf("-");
+        if (yearDigits == -1) {
+            yearDigits = dateStrResolution.length();
+        }
+        while (paddedEnd.indexOf("-") < yearDigits) {
+            paddedEnd = "0" + paddedEnd;
+        }
+        return paddedEnd.substring(0, dateStrResolution.length())
                 .compareTo(dateStrResolution) >= 0;
     }
 
@@ -2126,7 +2136,13 @@ public abstract class VAbstractCalendarPanel<R extends Enum<R>>
      */
     public void setRangeEnd(String newRangeEnd) {
         if (!SharedUtil.equals(rangeEnd, newRangeEnd)) {
-            rangeEnd = newRangeEnd;
+            // Dates with year 10000 or more has + prefix, which is not compatible
+            // with format returned by dateStrResolution method
+            if (newRangeEnd.startsWith("+")) {
+                rangeEnd = newRangeEnd.substring(1);
+            } else {
+                rangeEnd = newRangeEnd;
+            }
             if (initialRenderDone) {
                 // Dynamic updates to the range needs to render the calendar to
                 // update the element stylenames

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldBinderCrossValidationTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldBinderCrossValidationTest.java
@@ -50,7 +50,7 @@ public class DateFieldBinderCrossValidationTest extends SingleBrowserTest {
 
         DateFieldElement fromField = $(DateFieldElement.class).id("from-field");
         fromField.openPopup();
-        waitForElementNotPresent(By.className("v-datefield-popup"));
+        waitForElementPresent(By.className("v-datefield-popup"));
 
         WebElement monthYearLabel = findElement(By.className("v-datefield-calendarpanel-month"));
 
@@ -77,7 +77,7 @@ public class DateFieldBinderCrossValidationTest extends SingleBrowserTest {
 
         // Test that popup opens
         fromField.openPopup();
-        waitForElementNotPresent(By.className("v-datefield-popup"));
+        waitForElementPresent(By.className("v-datefield-popup"));
         assertElementPresent(By.className("v-datefield-popup"));
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldBinderCrossValidationTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldBinderCrossValidationTest.java
@@ -49,6 +49,7 @@ public class DateFieldBinderCrossValidationTest extends SingleBrowserTest {
         toFieldText.sendKeys("9999/12/31", Keys.ENTER);
 
         DateFieldElement fromField = $(DateFieldElement.class).id("from-field");
+        WebElement fromFieldText = fromField.findElement(By.tagName("input"));
         // Set year to 9999, next year and next month will be on 10000
         fromFieldText.sendKeys("9999/12/01", Keys.ENTER);
         fromField.openPopup();

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldBinderCrossValidationTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldBinderCrossValidationTest.java
@@ -49,6 +49,8 @@ public class DateFieldBinderCrossValidationTest extends SingleBrowserTest {
         toFieldText.sendKeys("9999/12/31", Keys.ENTER);
 
         DateFieldElement fromField = $(DateFieldElement.class).id("from-field");
+        // Set year to 9999, next year and next month will be on 10000
+        fromFieldText.sendKeys("9999/12/01", Keys.ENTER);
         fromField.openPopup();
         waitForElementPresent(By.className("v-datefield-popup"));
 

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldBinderCrossValidationTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldBinderCrossValidationTest.java
@@ -57,12 +57,12 @@ public class DateFieldBinderCrossValidationTest extends SingleBrowserTest {
         // The next month button should be disabled
         findElement(By.className("v-button-nextmonth")).click();
         // Test that year has not changed
-        assertTrue("",monthYearLabel.getText().contains("9999"));
+        assertTrue("Month label should contain 9999, contains: "+monthYearLabel.getText(),monthYearLabel.getText().contains("9999"));
 
         // The next year button should be disabled
         findElement(By.className("v-button-nextyear")).click();
         // Test that year has not changed
-        assertTrue("",monthYearLabel.getText().contains("9999"));
+        assertTrue("Month label should contain 9999, contains: "+monthYearLabel.getText(),monthYearLabel.getText().contains("9999"));
     }
 
     @Test

--- a/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldBinderCrossValidationTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/datefield/DateFieldBinderCrossValidationTest.java
@@ -10,6 +10,7 @@ import com.vaadin.testbench.elements.LabelElement;
 import com.vaadin.tests.tb3.SingleBrowserTest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DateFieldBinderCrossValidationTest extends SingleBrowserTest {
 
@@ -36,5 +37,47 @@ public class DateFieldBinderCrossValidationTest extends SingleBrowserTest {
         fromFieldText.sendKeys("2018/01/01", Keys.ENTER);
         assertEquals("Error message should be null", EXPECTED_NULL_ERROR,
                 label.getText());
+    }
+
+    @Test
+    public void dateFieldRangeYearDigitsIncrease() {
+        openTestURL();
+
+        DateFieldElement toField = $(DateFieldElement.class).id("to-field");
+        // This will set the rangeEnd of the fromField
+        WebElement toFieldText = toField.findElement(By.tagName("input"));
+        toFieldText.sendKeys("9999/12/31", Keys.ENTER);
+
+        DateFieldElement fromField = $(DateFieldElement.class).id("from-field");
+        fromField.openPopup();
+        waitForElementNotPresent(By.className("v-datefield-popup"));
+
+        WebElement monthYearLabel = findElement(By.className("v-datefield-calendarpanel-month"));
+
+        // The next month button should be disabled
+        findElement(By.className("v-button-nextmonth")).click();
+        // Test that year has not changed
+        assertTrue("",monthYearLabel.getText().contains("9999"));
+
+        // The next year button should be disabled
+        findElement(By.className("v-button-nextyear")).click();
+        // Test that year has not changed
+        assertTrue("",monthYearLabel.getText().contains("9999"));
+    }
+
+    @Test
+    public void dateFieldRangeYearBigNumbersPopupOpens() {
+        openTestURL();
+
+        DateFieldElement toField = $(DateFieldElement.class).id("to-field");
+        // This will set the rangeEnd of the fromField
+        WebElement toFieldText = toField.findElement(By.tagName("input"));
+        toFieldText.sendKeys("10000/12/31", Keys.ENTER);
+        DateFieldElement fromField = $(DateFieldElement.class).id("from-field");
+
+        // Test that popup opens
+        fromField.openPopup();
+        waitForElementNotPresent(By.className("v-datefield-popup"));
+        assertElementPresent(By.className("v-datefield-popup"));
     }
 }


### PR DESCRIPTION
Fix logic of lexicographical comparison of DateField range end with large year numbers ( > 9999)

Fixes #11881

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11885)
<!-- Reviewable:end -->
