### PR TITLE
Update hibernate version

### DIFF
--- a/compatibility-server/src/main/java/com/vaadin/v7/data/validator/BeanValidator.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/validator/BeanValidator.java
@@ -92,9 +92,16 @@ public class BeanValidator implements Validator {
         public Object getValidatedValue() {
             return value;
         }
+
+        /**
+         * Do not use, the method is just for purpose of compatibility with newer
+         * validation API.
+         *
+         * @param type Do not use.
+         */
         @Override
         public <T> T unwrap(Class<T> type) {
-            return violation.unwrap(type);
+            return null;
         }
     }
 

--- a/compatibility-server/src/main/java/com/vaadin/v7/data/validator/BeanValidator.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/validator/BeanValidator.java
@@ -92,7 +92,10 @@ public class BeanValidator implements Validator {
         public Object getValidatedValue() {
             return value;
         }
-
+        @Override
+        public <T> T unwrap(Class<T> type) {
+            return violation.unwrap(type);
+        }
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,11 @@
                 <version>6.0.1.Final</version>
             </dependency>
             <dependency>
+                <groupId>org.glassfish.web</groupId>
+                <artifactId>javax.el</artifactId>
+                <version>2.2.4</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
                 <version>${jsoup.version}</version>
@@ -341,6 +346,11 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.el</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <vaadin.plugin.version>8.7-SNAPSHOT</vaadin.plugin.version>
 
         <!-- Used in OSGi manifests -->
-        <javax.validation.version>1.0.0.GA</javax.validation.version>
+        <javax.validation.version>2.0.1.Final</javax.validation.version>
         <jsoup.version>1.11.2</jsoup.version>
         <javax.portlet.version>2.0</javax.portlet.version>
         <vaadin.sass.version>0.9.13</vaadin.sass.version>
@@ -208,7 +208,7 @@
                 <version>1.7.7</version>
             </dependency>
             <dependency>
-                <groupId>javax.validation</groupId>
+                <groupId</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>${javax.validation.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
                 <version>1.7.7</version>
             </dependency>
             <dependency>
-                <groupId</groupId>
+                <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>${javax.validation.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>4.2.0.Final</version>
+                <version>6.0.1.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>

--- a/server/src/main/java/com/vaadin/data/validator/BeanValidator.java
+++ b/server/src/main/java/com/vaadin/data/validator/BeanValidator.java
@@ -69,6 +69,10 @@ public class BeanValidator implements Validator<Object> {
             return violation.getInvalidValue();
         }
 
+        @Override
+        public <T> T unwrap(Class<T> type) {
+            return violation.unwrap(type);
+        }
     }
 
     private String propertyName;


### PR DESCRIPTION
Vaadin is not affected by CVE-2014-3558, the purpose of the update is avoid false positive alarm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11904)
<!-- Reviewable:end -->
