### PR TITLE
Remove unnecessary null-check at ValueContext constructor

### DIFF
--- a/server/src/main/java/com/vaadin/data/ValueContext.java
+++ b/server/src/main/java/com/vaadin/data/ValueContext.java
@@ -17,7 +17,6 @@ package com.vaadin.data;
 
 import java.io.Serializable;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
 
 import com.vaadin.ui.Component;
@@ -61,8 +60,6 @@ public class ValueContext implements Serializable {
      *            The component related to current value. Can be null.
      */
     public ValueContext(Component component) {
-        Objects.requireNonNull(component,
-                "Component can't be null in ValueContext construction");
         this.component = component;
         locale = findLocale();
     }


### PR DESCRIPTION
Hi Vaadin devs.
I've found such inconsistency in your sources.
In constructor of the ValueContext there is null-check for Component argument. But the Javadoc says that it can be null. My proposal is to delete such null-check. AFAIK in later versions there are more constructors available, and also those which have more arguments. Some of them allow to give component as null, and others no. As an advice - please check it on newer versions.

Besides that there is also adjusted logic for getting component from VC using Optional#ofNullable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11913)
<!-- Reviewable:end -->
