### PR TITLE
Refresh :checked pseudo class for RadioButtonGroup in ComponentRenderer.

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/grid/ComponentRendererConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/ComponentRendererConnector.java
@@ -17,7 +17,6 @@ package com.vaadin.client.connectors.grid;
 
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.logging.Logger;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -28,7 +27,7 @@ import com.vaadin.client.ConnectorMap;
 import com.vaadin.client.renderers.Renderer;
 import com.vaadin.client.renderers.WidgetRenderer;
 import com.vaadin.client.ui.AbstractComponentConnector;
-import com.vaadin.client.ui.AbstractConnector;
+import com.vaadin.client.ui.HasRendererWorkaround;
 import com.vaadin.client.widget.grid.RendererCellReference;
 import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.ui.grid.renderers.ComponentRendererState;
@@ -73,6 +72,10 @@ public class ComponentRendererConnector
                     }
                 }
                 if (connectorWidget != null) {
+                    if (connectorWidget instanceof HasRendererWorkaround) {
+                        ((HasRendererWorkaround) connectorWidget)
+                                .rendererWorkaround();
+                    }
                     widget.setWidget(connectorWidget);
                 } else if (widget.getWidget() != null) {
                     widget.remove(widget.getWidget());
@@ -119,9 +122,9 @@ public class ComponentRendererConnector
     }
 
     private void unregisterHierarchyHandler() {
-        if (this.handlerRegistration != null) {
-            this.handlerRegistration.removeHandler();
-            this.handlerRegistration = null;
+        if (handlerRegistration != null) {
+            handlerRegistration.removeHandler();
+            handlerRegistration = null;
         }
     }
 

--- a/client/src/main/java/com/vaadin/client/ui/HasRendererWorkaround.java
+++ b/client/src/main/java/com/vaadin/client/ui/HasRendererWorkaround.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.client.ui;
+
+/**
+ * For internal use only. May be removed or replaced in the future.
+ * <p>
+ * Renderers are sometimes too slow to work well with widgets by default. This
+ * interface signifies that the Widget in question may need further refreshing
+ * after Grid has finished its own handling.
+ *
+ * @author Vaadin Ltd.
+ * @since
+ */
+public interface HasRendererWorkaround {
+
+    /**
+     * For internal use only. May be removed or replaced in the future.
+     */
+    public void rendererWorkaround();
+}

--- a/client/src/main/java/com/vaadin/client/ui/VSlider.java
+++ b/client/src/main/java/com/vaadin/client/ui/VSlider.java
@@ -35,8 +35,14 @@ import com.vaadin.client.BrowserInfo;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.shared.ui.slider.SliderOrientation;
 
-public class VSlider extends SimpleFocusablePanel
-        implements Field, HasValue<Double>, SubPartAware {
+/**
+ * The client-side widget for the {@code Slider} component.
+ *
+ * @author Vaadin Ltd.
+ */
+@SuppressWarnings("deprecation")
+public class VSlider extends SimpleFocusablePanel implements Field,
+        HasValue<Double>, SubPartAware, HasRendererWorkaround {
 
     public static final String CLASSNAME = "v-slider";
 
@@ -95,6 +101,8 @@ public class VSlider extends SimpleFocusablePanel
         fireValueChanged();
         acceleration = 1;
     });
+
+    private boolean rendererWorkaroundTriggered = false;
 
     public VSlider() {
         super();
@@ -683,5 +691,23 @@ public class VSlider extends SimpleFocusablePanel
      */
     public void setUpdateValueOnClick(boolean updateValueOnClick) {
         this.updateValueOnClick = updateValueOnClick;
+    }
+
+    /**
+     * For internal use only. May be removed or replaced in the future.
+     * <p>
+     * Causes delayed refresh of handle position with the old value. This is
+     * needed for ComponentRenderer to render the widget correctly during
+     * scrolling.
+     */
+    @Override
+    public void rendererWorkaround() {
+        if (!rendererWorkaroundTriggered) {
+            rendererWorkaroundTriggered = true;
+            Scheduler.get().scheduleFinally(() -> {
+                setValue(getValue(), false);
+                rendererWorkaroundTriggered = false;
+            });
+        }
     }
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridWithRendererWorkaround.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridWithRendererWorkaround.java
@@ -1,0 +1,76 @@
+package com.vaadin.tests.components.grid;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.data.provider.DataProvider;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.RadioButtonGroup;
+import com.vaadin.ui.Slider;
+
+public class GridWithRendererWorkaround extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        List<Pojo> content = new ArrayList<>();
+        for (int i = 0; i < 100; ++i) {
+            content.add(new Pojo(i % 3 == 0, i));
+        }
+
+        Grid<Pojo> grid = new Grid<>(DataProvider.ofCollection(content));
+        grid.setSizeFull();
+        grid.setSelectionMode(Grid.SelectionMode.NONE);
+        grid.setBodyRowHeight(70);
+        grid.addComponentColumn(this::radioButtonResponse)
+                .setCaption("Boolean");
+        grid.addComponentColumn(this::sliderResponse).setCaption("Integer");
+
+        addComponent(grid);
+        getLayout().setSizeFull();
+        getLayout().getParent().setSizeFull();
+    }
+
+    private RadioButtonGroup<Boolean> radioButtonResponse(Pojo item) {
+        RadioButtonGroup<Boolean> yesNoRadioButtonGroup = new RadioButtonGroup<>();
+        yesNoRadioButtonGroup.setItems(Boolean.TRUE, Boolean.FALSE);
+        yesNoRadioButtonGroup.setSelectedItem(item.isBoolean());
+        return yesNoRadioButtonGroup;
+    }
+
+    private Slider sliderResponse(Pojo item) {
+        Slider s = new Slider(0, 4);
+        s.setValue((double) ((item.getInt() % 4) + 1));
+        return s;
+    }
+
+    private class Pojo {
+        boolean b;
+        int i;
+
+        public Pojo(boolean b, int i) {
+            this.b = b;
+            this.i = i;
+        }
+
+        public boolean isBoolean() {
+            return b;
+        }
+
+        public int getInt() {
+            return i;
+        }
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Resizing should not hide RadioButtonGroup selections, "
+                + "scrolling should not reveal Sliders with zero value.";
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 11911;
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridWithRendererWorkaroundTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridWithRendererWorkaroundTest.java
@@ -1,0 +1,66 @@
+package com.vaadin.tests.components.grid;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.testbench.elements.GridElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class GridWithRendererWorkaroundTest extends MultiBrowserTest {
+
+    private GridElement grid;
+    private String pseudoClassPropertyScript = "return window.getComputedStyle(arguments[0], ':%s').getPropertyValue('%s');";
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        openTestURL();
+        grid = $(GridElement.class).first();
+    }
+
+    @Test
+    public void testRadioButtonGroupAfterGridResize() {
+        String afterScript = String.format(pseudoClassPropertyScript, "after",
+                "background-color");
+        WebElement radioButton = grid.getCell(0, 0)
+                .findElement(By.className("v-select-option-selected"));
+        WebElement label = radioButton.findElement(By.tagName("label"));
+        String bgColor = ((JavascriptExecutor) driver)
+                .executeScript(afterScript, label).toString();
+        assertFalse("Unexpected selection color before resize: " + bgColor,
+                bgColor.contains("0"));
+
+        getDriver().manage().window().setSize(new Dimension(600, 800));
+
+        assertEquals("Unexpected selection color after resize,", bgColor,
+                ((JavascriptExecutor) driver).executeScript(afterScript, label)
+                        .toString());
+    }
+
+    @Test
+    public void testSliderAfterGridScrolling() {
+        // scroll in increments to slow down the process
+        for (int i = 10; i <= 60; i = i + 10) {
+            grid.scrollToRow(i);
+        }
+        // test that all visible sliders have a non-zero position
+        List<WebElement> sliders = grid
+                .findElements(By.className("v-slider-handle"));
+        for (WebElement slider : sliders) {
+            String marginString = slider.getCssValue("margin-left");
+            Double margin = Double.valueOf(
+                    marginString.substring(0, marginString.indexOf("px")));
+            assertThat("Unexpected margin width.", margin, greaterThan(0d));
+        }
+    }
+}


### PR DESCRIPTION
Experimental workaround for RadioButtonGroup selection disappearing when
Grid is resized, due to :checked pseudo class getting lost in the
process.

Fixes #11911

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11914)
<!-- Reviewable:end -->
