### PR TITLE
Trigger re-measure after updating ElementResizeListeners. (#11912)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/orderedlayout/AbstractOrderedLayoutConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/orderedlayout/AbstractOrderedLayoutConnector.java
@@ -570,11 +570,13 @@ public abstract class AbstractOrderedLayoutConnector
         }
 
         // Add all necessary listeners
+        boolean listenersAdded = false;
         if (needsFixedHeight()) {
             slot.setWidgetResizeListener(childComponentResizeListener);
             if (slot.hasCaption()) {
                 slot.setCaptionResizeListener(slotCaptionResizeListener);
             }
+            listenersAdded = true;
         } else if ((hasChildrenWithRelativeHeight
                 || hasChildrenWithRelativeWidth) && slot.hasCaption()) {
             /*
@@ -586,6 +588,7 @@ public abstract class AbstractOrderedLayoutConnector
              * as the relative size?
              */
             slot.setCaptionResizeListener(slotCaptionResizeListener);
+            listenersAdded = true;
         }
 
         if (needsExpand()) {
@@ -594,6 +597,13 @@ public abstract class AbstractOrderedLayoutConnector
             if (slot.hasSpacing()) {
                 slot.setSpacingResizeListener(spacingResizeListener);
             }
+            listenersAdded = true;
+        }
+
+        if (listenersAdded) {
+            // removing these listeners makes widget unmeasurable and resets the
+            // measured height, measure again if listeners got added back
+            getLayoutManager().setNeedsMeasure(child);
         }
     }
 

--- a/uitest/src/main/java/com/vaadin/tests/layouts/UpdateComponentWithinExpandRatio.java
+++ b/uitest/src/main/java/com/vaadin/tests/layouts/UpdateComponentWithinExpandRatio.java
@@ -1,0 +1,37 @@
+package com.vaadin.tests.layouts;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.ProgressBar;
+
+public class UpdateComponentWithinExpandRatio extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        ProgressBar progress = new ProgressBar();
+        progress.setWidth(100, Unit.PERCENTAGE);
+        Button button = new Button("Progress", e -> {
+            float value = progress.getValue();
+            value = (value >= 1) ? 0 : value + 0.1f;
+            progress.setValue(value);
+        });
+
+        HorizontalLayout layout = new HorizontalLayout(progress, button);
+        layout.setExpandRatio(progress, 1);
+        layout.setWidth(100, Unit.PERCENTAGE);
+        getLayout().addComponent(layout);
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Clicking the button to update the progress bar (expanded) "
+                + "shouldn't push the button (fixed width) to the right";
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 10734;
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/layouts/UpdateComponentWithinExpandRatioTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/layouts/UpdateComponentWithinExpandRatioTest.java
@@ -1,0 +1,29 @@
+package com.vaadin.tests.layouts;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.ProgressBarElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class UpdateComponentWithinExpandRatioTest extends MultiBrowserTest {
+
+    @Test
+    public void updateProgressShouldNotMoveButton() {
+        openTestURL();
+        ProgressBarElement pb = $(ProgressBarElement.class).first();
+        ButtonElement button = $(ButtonElement.class).first();
+
+        int initialX = button.getLocation().getX();
+        int initialWidth = pb.getSize().getWidth();
+
+        button.click();
+
+        assertEquals("Button's position changed unexpectedly", initialX,
+                button.getLocation().getX());
+        assertEquals("ProgressBar's width changed unexpectedly", initialWidth,
+                pb.getSize().getWidth());
+    }
+}


### PR DESCRIPTION
Removing ElementResizeListeners from an element makes it unmeasurable
and clears any saved measured values. Adding the listeners back makes
the element measurable again but doesn't add it to measuring queue.
Measuring needs to happen or any updates to expanded components within a
layout (without changes that would trigger full re-measuring of the
layout itself) lead to broken expand size calculations with any fixed
size elements assumed to have no size.

Fixes #10734

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11922)
<!-- Reviewable:end -->
