### PR TITLE
Fix an issue with frozen column count and unhiding.

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -5336,7 +5336,9 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                     int escalatorFrozenColumns = grid.escalator
                             .getColumnConfiguration().getFrozenColumnCount();
                     if (gridFrozenColumns > escalatorFrozenColumns
-                            && escalatorFrozenColumns == columnIndex) {
+                            && escalatorFrozenColumns == columnIndex
+                            && grid.getColumns()
+                                    .indexOf(this) < gridFrozenColumns) {
                         grid.escalator.getColumnConfiguration()
                                 .setFrozenColumnCount(++escalatorFrozenColumns);
                     }

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridUnhideColumnsWithFrozen.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridUnhideColumnsWithFrozen.java
@@ -1,0 +1,40 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.Label;
+
+public class GridUnhideColumnsWithFrozen extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        Grid<Integer> grid = new Grid<>();
+        for (int i = 0; i < 15; i++) {
+            String columnId = String.valueOf(i);
+            Grid.Column<Integer, Component> column = addColumn(grid, columnId);
+            column.setHidable(true);
+            if (i == 3 || i == 4) {
+                column.setHidden(true);
+            }
+            column.setCaption(columnId);
+            column.setId(columnId);
+        }
+        grid.setFrozenColumnCount(4);
+        grid.setItems(0);
+        addComponent(grid);
+    }
+
+    private Grid.Column<Integer, Component> addColumn(Grid<Integer> grid,
+            String columnId) {
+        return grid.addComponentColumn(i -> new Label(columnId));
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Columns 0-3 have been set frozen, unhiding column 4 before column 3"
+                + " should not make column 4 frozen.";
+    }
+
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridUnhideColumnsWithFrozenTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridUnhideColumnsWithFrozenTest.java
@@ -1,0 +1,38 @@
+package com.vaadin.tests.components.grid;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.testbench.elements.GridElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class GridUnhideColumnsWithFrozenTest extends SingleBrowserTest {
+
+    @Test
+    public void visibleFrozenColumnCount() {
+        openTestURL();
+
+        GridElement grid = $(GridElement.class).first();
+        List<WebElement> frozen = grid.getHeader()
+                .findElements(By.className("frozen"));
+        assertEquals("Unexpected frozen column count before unhiding", 3,
+                frozen.size());
+
+        grid.findElement(By.className("v-grid-sidebar-button")).click();
+        List<WebElement> hidden = findElement(
+                By.className("v-grid-sidebar-content"))
+                        .findElements(By.className("hidden"));
+        assertEquals("Unexpected amount of hidden columns", 2, hidden.size());
+        assertEquals("Unexpected hidden column", "4", hidden.get(1).getText());
+        hidden.get(1).click();
+
+        frozen = grid.getHeader().findElements(By.className("frozen"));
+        assertEquals("Unexpected frozen column count after unhiding", 3,
+                frozen.size());
+    }
+}


### PR DESCRIPTION
Unhiding logic should take into account that there can be hidden frozen
columns that are not the column currently getting shown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11929)
<!-- Reviewable:end -->
