### PR TITLE
Change to using StringBuilder

### DIFF
--- a/server/src/main/java/com/vaadin/ui/declarative/Design.java
+++ b/server/src/main/java/com/vaadin/ui/declarative/Design.java
@@ -234,14 +234,14 @@ public class Design implements Serializable {
                 throw new DesignException("Unknown tag: " + tagName);
             }
             String[] classNameParts = parts[1].split("-");
-            String className = "";
+            StringBuilder className = new StringBuilder();
             for (String classNamePart : classNameParts) {
                 // Split will ignore trailing and multiple dashes but that
                 // should be
                 // ok
                 // <vaadin-button--> will be resolved to <vaadin-button>
                 // <vaadin--button> will be resolved to <vaadin-button>
-                className += SharedUtil.capitalize(classNamePart);
+                className.append(SharedUtil.capitalize(classNamePart));
             }
             String qualifiedClassName = packageName + "." + className;
 


### PR DESCRIPTION
Should use a StringBuilder to accumulate strings in a loop, to avoid the performance cost of repeatedly constructing strings.

No new tests needed to be added.

**Check when you have completed**
[x] Valid tests for the pull request
[x] Contributing guidelines implemented

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11941)
<!-- Reviewable:end -->
