### PR TITLE
Allow UIDL behind reverse proxy by updating hasPathPrefix

### DIFF
--- a/server/src/main/java/com/vaadin/server/ServletPortletHelper.java
+++ b/server/src/main/java/com/vaadin/server/ServletPortletHelper.java
@@ -87,7 +87,7 @@ public class ServletPortletHelper implements Serializable {
         }
     }
 
-    private static boolean hasPathPrefix(final VaadinRequest request, String prefix) {
+    private static boolean hasPathPrefix(VaadinRequest request, String prefix) {
         String pathInfo = request.getPathInfo();
 
         if (pathInfo == null) {

--- a/server/src/main/java/com/vaadin/server/ServletPortletHelper.java
+++ b/server/src/main/java/com/vaadin/server/ServletPortletHelper.java
@@ -87,15 +87,27 @@ public class ServletPortletHelper implements Serializable {
         }
     }
 
-    private static boolean hasPathPrefix(VaadinRequest request, String prefix) {
+    private static boolean hasPathPrefix(final VaadinRequest request, String prefix) {
         String pathInfo = request.getPathInfo();
 
         if (pathInfo == null) {
             return false;
         }
 
-        if (!prefix.startsWith("/")) {
-            prefix = '/' + prefix;
+        if (pathInfo.startsWith("/")){
+            pathInfo = pathInfo.substring(1);
+        }
+
+        if (pathInfo.endsWith("/")){
+            pathInfo = pathInfo.substring(0, pathInfo.length() - 1);
+        }
+
+        if (prefix.startsWith("/")){
+            prefix = prefix.substring(1);
+        }
+
+        if (prefix.endsWith("/")){
+            prefix = prefix.substring(0, prefix.length() - 1);
         }
 
         if (pathInfo.startsWith(prefix)) {


### PR DESCRIPTION
Vaadin-spring behind a reverse proxy did not work, because UIDL requests did not reach the UidlRequestHandler. The problem was that ServerletPortletHelper.hasPathPrefix(...) checked for "/UIDL/" but the incoming prefix was "/UIDL". With the changes vaadin-spring works behind a reverse proxy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11944)
<!-- Reviewable:end -->
