### PR TITLE
Add asMultiSelect() to Tree class

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Tree.java
+++ b/server/src/main/java/com/vaadin/ui/Tree.java
@@ -573,6 +573,18 @@ public class Tree<T> extends Composite
     public Registration addSelectionListener(SelectionListener<T> listener) {
         return treeGrid.addSelectionListener(listener);
     }
+    
+    /**
+     * Use this tree as a multi select in {@link Binder}. Throws
+     * {@link IllegalStateException} if the tree is not using
+     * {@link SelectionMode#MULTI}.
+     *
+     * @return the multi select wrapper that can be used in binder
+     * @since 8.11
+     */
+    public MultiSelect<T> asMultiSelect() {
+        return treeGrid.asMultiSelect();
+    }
 
     /**
      * Use this tree as a single select in {@link Binder}. Throws


### PR DESCRIPTION
Tree class doesn't currently provide an obvious way that would enable a Tree object to be treated as a multi select. This commit extends the Tree API, enabling it to be used as a multi select, which would importantly facilitate the selection/deselection of multiple items in trees whose SelectionMode is MULTI.

closes #11948

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11949)
<!-- Reviewable:end -->
