### PR TITLE
Fixed the JavaDoc

### DIFF
--- a/server/src/main/java/com/vaadin/data/provider/HierarchicalDataCommunicator.java
+++ b/server/src/main/java/com/vaadin/data/provider/HierarchicalDataCommunicator.java
@@ -381,11 +381,11 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
     }
 
     /**
-     * Returns parent index for the row or {@code null}.
+     * Returns parent index for the row or a negative value.
      *
      * @param item
      *            the item to find the parent of
-     * @return the parent index or {@code null} for top-level items
+     * @return the parent index or a negative value for top-level items
      */
     public Integer getParentIndex(T item) {
         return mapper.getParentIndex(item);


### PR DESCRIPTION
HierarchyMapper. getParentIndex() method has a different JavaDoc from the HierarchicalDataCommunicator. This is a simple fix for that.

https://github.com/vaadin/framework/blob/master/server/src/main/java/com/vaadin/data/provider/HierarchyMapper.java#L96

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11950)
<!-- Reviewable:end -->
