### PR TITLE
Expired session: use 403 Forbidden instead of 410 Gone (#11859)

### DIFF
--- a/client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
+++ b/client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
@@ -146,7 +146,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
         int statusCode = response.getStatusCode();
         getLogger().warning("Heartbeat request returned " + statusCode);
 
-        if (response.getStatusCode() == Response.SC_GONE) {
+        if (response.getStatusCode() == Response.SC_FORBIDDEN) {
             // Session expired
             getConnection().showSessionExpiredError(null);
             stopApplication();

--- a/server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/server/src/main/java/com/vaadin/server/VaadinService.java
@@ -1759,7 +1759,15 @@ public abstract class VaadinService implements Serializable {
                  * endless loop. This can at least happen if refreshing a
                  * resource when the session has expired.
                  */
-                response.sendError(HttpServletResponse.SC_GONE,
+
+                // Ensure that the browser does not cache expired responses.
+                // iOS 6 Safari requires this (#3226)
+                response.setHeader("Cache-Control", "no-cache");
+                // If Content-Type is not set, browsers assume text/html and may
+                // complain about the empty response body (#4167)
+                response.setHeader("Content-Type", "text/plain");
+
+                response.sendError(HttpServletResponse.SC_FORBIDDEN,
                         "Session expired");
             }
         } catch (IOException e) {

--- a/server/src/main/java/com/vaadin/server/communication/HeartbeatHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/HeartbeatHandler.java
@@ -62,10 +62,10 @@ public class HeartbeatHandler extends SynchronizedRequestHandler
         if (ui != null) {
             ui.setLastHeartbeatTimestamp(System.currentTimeMillis());
             // Ensure that the browser does not cache heartbeat responses.
-            // iOS 6 Safari requires this (#10370)
+            // iOS 6 Safari requires this (#3226)
             response.setHeader("Cache-Control", "no-cache");
             // If Content-Type is not set, browsers assume text/html and may
-            // complain about the empty response body (#12182)
+            // complain about the empty response body (#4167)
             response.setHeader("Content-Type", "text/plain");
         } else {
             response.sendError(HttpServletResponse.SC_NOT_FOUND,
@@ -88,15 +88,14 @@ public class HeartbeatHandler extends SynchronizedRequestHandler
         if (!ServletPortletHelper.isHeartbeatRequest(request)) {
             return false;
         }
-
-        // Ensure that the browser does not cache expired response.
-        // iOS 6 Safari requires this (#10370)
+        // Ensure that the browser does not cache expired heartbeat responses.
+        // iOS 6 Safari requires this (#3226)
         response.setHeader("Cache-Control", "no-cache");
         // If Content-Type is not set, browsers assume text/html and may
-        // complain about the empty response body (#12182)
+        // complain about the empty response body (#4167)
         response.setHeader("Content-Type", "text/plain");
 
-        response.sendError(HttpServletResponse.SC_NOT_FOUND, "Session expired");
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, "Session expired");
         return true;
     }
 }


### PR DESCRIPTION
Use 403 Forbidden instead of 410 Gone when session expired. Also prevent caching in more cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11964)
<!-- Reviewable:end -->
