### PR TITLE
Update Liferay kernel version (#11943)

### DIFF
--- a/server/bnd.bnd
+++ b/server/bnd.bnd
@@ -4,7 +4,7 @@ Bundle-Version: ${osgi.bundle.version}
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
 Import-Package: com.vaadin.sass.*;resolution:=optional,\
-  com.liferay.portal.kernel.util;resolution:=optional;version='[7.0.0,10.0.0)',\
+  com.liferay.portal.kernel.util;resolution:=optional;version='[7.0.0,11.0.0)',\
   javax.portlet*;resolution:=optional,\
   javax.validation*;resolution:=optional;version='${javax.validation.version}',\
   org.atmosphere*;resolution:=optional;version='${atmosphere.runtime.version}',\


### PR DESCRIPTION
Liferay 7.3 series have kernel version 10.x, i.e. limit needs to be extended from 10 -> 11

Fixes: https://github.com/vaadin/framework/issues/11938

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11965)
<!-- Reviewable:end -->
