### PR TITLE
Fix hiding / un-hiding with frozen columns in multiselect mode (#11972)

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -5324,10 +5324,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
                     int columnIndex = grid.getVisibleColumns()
                             .indexOf(this);
-                    // Correct column index for multiselect mode
-                    if (grid.getSelectionColumn().isPresent()) {
-                        columnIndex--;
-                    }
                     grid.escalator.getColumnConfiguration()
                             .insertColumns(columnIndex, 1);
 
@@ -5335,6 +5331,10 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                     // escalator doesn't handle situation where the added column
                     // would be the last frozen column
                     int gridFrozenColumns = grid.getFrozenColumnCount();
+                    // Correct column index for multiselect mode
+                    if (grid.getSelectionColumn().isPresent()) {
+                        gridFrozenColumns++;
+                    }
                     int escalatorFrozenColumns = grid.escalator
                             .getColumnConfiguration().getFrozenColumnCount();
                     if (gridFrozenColumns > escalatorFrozenColumns


### PR DESCRIPTION
The previous patch https://github.com/vaadin/framework/pull/11951 did fix the problem (frozen column indicator wrongly positioned)  it was meant to, but caused a regression in hiding / un-hiding. 

This new fix addresses both problems, i.e. it applies multiselect column compensation in other way, without causing problem in hiding / un-hiding logic

Fixes https://github.com/vaadin/framework/issues/11970

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11975)
<!-- Reviewable:end -->
