### PR TITLE
fix issue https://github.com/vaadin/framework/issues/11958 remove usage

### DIFF
--- a/server/src/main/java/com/vaadin/server/BootstrapHandler.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapHandler.java
@@ -712,8 +712,7 @@ public abstract class BootstrapHandler extends SynchronizedRequestHandler {
         appendMainScriptTagContents(context, builder);
 
         builder.append("//]]>");
-        mainScriptTag.appendChild(
-                new DataNode(builder.toString()));
+        mainScriptTag.appendChild(new DataNode(builder.toString()));
         fragmentNodes.add(mainScriptTag);
 
     }

--- a/server/src/main/java/com/vaadin/server/BootstrapHandler.java
+++ b/server/src/main/java/com/vaadin/server/BootstrapHandler.java
@@ -713,7 +713,7 @@ public abstract class BootstrapHandler extends SynchronizedRequestHandler {
 
         builder.append("//]]>");
         mainScriptTag.appendChild(
-                new DataNode(builder.toString(), mainScriptTag.baseUri()));
+                new DataNode(builder.toString()));
         fragmentNodes.add(mainScriptTag);
 
     }


### PR DESCRIPTION
of deprecated constructor


Constructor of used jsoup versions ignore baseUri 
    public DataNode(String data, String baseUri) {
        this(data);
    }

Fixes #11958

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11976)
<!-- Reviewable:end -->
