### PR TITLE
DataProvider should be refreshed only once when reordering a Grid using GridRowDragger

### DIFF
--- a/server/src/main/java/com/vaadin/ui/components/grid/GridRowDragger.java
+++ b/server/src/main/java/com/vaadin/ui/components/grid/GridRowDragger.java
@@ -381,7 +381,11 @@ public class GridRowDragger<T> implements Serializable {
         }
 
         sourceItems.removeAll(droppedItems);
-        listDataProvider.refreshAll();
+
+        // if reordering the same grid, DataProvider's refresh will be done later
+        if (getGridDragSource().getGrid() != getGridDropTarget().getGrid()) {
+            listDataProvider.refreshAll();
+        }
     }
 
     private void handleTargetGridDrop(GridDropEvent<T> event, final int index,

--- a/server/src/test/java/com/vaadin/tests/server/component/grid/GridRowDraggerOneGridTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/grid/GridRowDraggerOneGridTest.java
@@ -128,6 +128,26 @@ public class GridRowDraggerOneGridTest {
     }
 
     @Test
+    public void listDataProvider_calledOnlyOnce() {
+    	
+    	final int[] times= new int[1];
+    	
+        source.setItems("0", "1", "2");
+        
+        source.getDataProvider().addDataProviderListener(ev->times[0]++);
+
+        dragger.setDropIndexCalculator(event -> {
+            return Integer.MAX_VALUE;
+        });
+
+        drop("1", DropLocation.ABOVE, "0");
+
+        verifyDataProvider("1", "2", "0");
+        
+        Assert.assertArrayEquals("DataProvider should be invoked only once", new int[] {1}, times);
+    }
+
+    @Test
     public void noopSourceUpdater() {
         source.setItems("0", "1", "2");
 

--- a/server/src/test/java/com/vaadin/tests/server/component/grid/GridRowDraggerOneGridTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/component/grid/GridRowDraggerOneGridTest.java
@@ -129,12 +129,12 @@ public class GridRowDraggerOneGridTest {
 
     @Test
     public void listDataProvider_calledOnlyOnce() {
-    	
-    	final int[] times= new int[1];
-    	
+
+        final int[] times = new int[1];
+
         source.setItems("0", "1", "2");
-        
-        source.getDataProvider().addDataProviderListener(ev->times[0]++);
+
+        source.getDataProvider().addDataProviderListener(ev -> times[0]++);
 
         dragger.setDropIndexCalculator(event -> {
             return Integer.MAX_VALUE;
@@ -143,8 +143,8 @@ public class GridRowDraggerOneGridTest {
         drop("1", DropLocation.ABOVE, "0");
 
         verifyDataProvider("1", "2", "0");
-        
-        Assert.assertArrayEquals("DataProvider should be invoked only once", new int[] {1}, times);
+
+        Assert.assertArrayEquals("DataProvider should be invoked only once", new int[] { 1 }, times);
     }
 
     @Test


### PR DESCRIPTION
Fixes #10844

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11981)
<!-- Reviewable:end -->
