### PR TITLE
Determine Push transport before re-connect

### DIFF
--- a/server/src/main/java/com/vaadin/server/communication/PushHandler.java
+++ b/server/src/main/java/com/vaadin/server/communication/PushHandler.java
@@ -190,18 +190,16 @@ public class PushHandler {
      *            the atmosphere resource for the current request
      * @param callback
      *            the push callback to call when a UI is found and locked
-     * @param websocket
-     *            true if this is a websocket message (as opposed to a HTTP
-     *            request)
      */
     private void callWithUi(final AtmosphereResource resource,
-            final PushEventCallback callback, boolean websocket) {
+            final PushEventCallback callback) {
         AtmosphereRequest req = resource.getRequest();
         VaadinServletRequest vaadinRequest = new VaadinServletRequest(req,
                 service);
         VaadinSession session = null;
 
-        if (websocket) {
+        boolean isWebsocket = resource.transport() == TRANSPORT.WEBSOCKET;
+        if (isWebsocket) {
             // For any HTTP request we have already started the request in the
             // servlet
             service.requestStart(vaadinRequest, null);
@@ -273,7 +271,7 @@ public class PushHandler {
             }
         } finally {
             try {
-                if (websocket) {
+                if (isWebsocket) {
                     service.requestEnd(vaadinRequest, null, session);
                 }
             } catch (Exception e) {
@@ -499,7 +497,7 @@ public class PushHandler {
      *            The related atmosphere resources
      */
     void onConnect(AtmosphereResource resource) {
-        callWithUi(resource, establishCallback, false);
+        callWithUi(resource, establishCallback);
     }
 
     /**
@@ -510,8 +508,7 @@ public class PushHandler {
      *            The related atmosphere resources
      */
     void onMessage(AtmosphereResource resource) {
-        callWithUi(resource, receiveCallback,
-                resource.transport() == TRANSPORT.WEBSOCKET);
+        callWithUi(resource, receiveCallback);
     }
 
     /**


### PR DESCRIPTION
onConnect was allways called with websocket = false. I think this is wrong, since if there was connection loss in websocket, now connection cannot be re-established in websocket mode.

Fixes: https://github.com/vaadin/framework/issues/7190

Cherry pick of https://github.com/vaadin/framework/pull/11884

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11988)
<!-- Reviewable:end -->
