### PR TITLE
Fix sanitization of empty RTA input for Firefox & IE (#11937)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VRichTextArea.java
+++ b/client/src/main/java/com/vaadin/client/ui/VRichTextArea.java
@@ -365,7 +365,7 @@ public class VRichTextArea extends Composite implements Field, KeyPressHandler,
         BrowserInfo browser = BrowserInfo.get();
         String result = getValue();
         if (browser.isFirefox()) {
-            if ("<br>".equals(result)) {
+            if ("<br>".equals(result) || "<div><br></div>".equals(result)) {
                 result = "";
             }
         } else if (browser.isWebkit() || browser.isEdge()) {
@@ -373,7 +373,7 @@ public class VRichTextArea extends Composite implements Field, KeyPressHandler,
                 result = "";
             }
         } else if (browser.isIE()) {
-            if ("<P>&nbsp;</P>".equals(result)) {
+            if ("<P>&nbsp;</P>".equals(result) || "<p><br></p>".equals(result)) {
                 result = "";
             }
         } else if (browser.isOpera()) {


### PR DESCRIPTION
Browsers differ in what they return as the content of a visually empty rich text area (RTA). Accordingly, RTA sanitizes these different values ensuring an empty string is returned to the framework. However, existing sanitization criteria doesn't work for Firefox 74 and Internet Explorer 11.

This fix appends the sanitization criteria of Firefox 74 and IE 11, ensuring an empty string is returned to the framework for a a visually empty RTA.

Closes #10338

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11989)
<!-- Reviewable:end -->
