### PR TITLE
Added logging for generateArchetype in BuildHelpers

### DIFF
--- a/scripts/BuildHelpers.py
+++ b/scripts/BuildHelpers.py
@@ -106,12 +106,17 @@ def copyWarFiles(artifactId, resultDir = resultPath, name = None):
 def generateArchetype(archetype, artifactId, repo, logFile, group="testpkg", archetypeGroup="com.vaadin"):
 	# Generate the required command line for archetype generation
 	args = getArgs()
+	print("Parameters for archetype %s:" % (archetype))
+	print("using version %s" % (args.version))
 	cmd = [mavenCmd, "archetype:generate"]
 	cmd.append("-DarchetypeGroupId=%s" % (archetypeGroup))
 	cmd.append("-DarchetypeArtifactId=%s" % (archetype))
 	cmd.append("-DarchetypeVersion=%s" % (args.version))
 	if repo is not None:
 		cmd.append("-DarchetypeRepository=%s" % repo)
+		print("using repository %s" % (repo))
+	else:
+	    print("using no repository")
 	cmd.append("-DgroupId=%s" % (group))
 	cmd.append("-DartifactId=%s" % (artifactId))
 	cmd.append("-Dversion=1.0-SNAPSHOT")


### PR DESCRIPTION
Added extra logging for BuildHelpers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/11999)
<!-- Reviewable:end -->
