### PR TITLE
Catch exception that is thrown when Grid is scrolled during operation

### DIFF
--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
@@ -2145,14 +2145,20 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
             // sometimes focus handling twists the editor row out of alignment
             // with the grid itself and the position needs to be compensated for
-            TableRowElement rowElement = grid.getEscalator().getBody()
-                .getRowElement(grid.getEditor().getRow());
-            int rowLeft = rowElement.getAbsoluteLeft();
-            int editorLeft = cellWrapper.getAbsoluteLeft();
-            if (editorLeft != rowLeft + frozenWidth) {
-                cellWrapper.getStyle().setLeft(newLeft + rowLeft - editorLeft,
-                    Unit.PX);
-            }
+            try {
+                TableRowElement rowElement = grid.getEscalator().getBody()
+                    .getRowElement(grid.getEditor().getRow());
+                int rowLeft = rowElement.getAbsoluteLeft();
+                int editorLeft = cellWrapper.getAbsoluteLeft();
+                if (editorLeft != rowLeft + frozenWidth) {
+                    cellWrapper.getStyle().setLeft(newLeft + rowLeft - editorLeft,
+                        Unit.PX);
+                }
+            } catch (IllegalStateException e) {
+                // IllegalStateException may occur if user has scrolled Grid so
+                // that Escalator has updated, and row under Editor is no longer
+                // there
+            }          
         }
 
         /**

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
@@ -2158,7 +2158,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 // IllegalStateException may occur if user has scrolled Grid so
                 // that Escalator has updated, and row under Editor is no longer
                 // there
-            }          
+            }
         }
 
         /**


### PR DESCRIPTION
IllegalStateException may occur if user has scrolled Grid (compatibility library version) so that Escalator has updated, and row under Editor is no longer there

Chrerry pick from https://github.com/vaadin/framework/pull/11467

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12002)
<!-- Reviewable:end -->
