### PR TITLE
Catch exception that is thrown when Grid is scrolled during operation

### DIFF
--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
@@ -2145,13 +2145,19 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
             // sometimes focus handling twists the editor row out of alignment
             // with the grid itself and the position needs to be compensated for
-            TableRowElement rowElement = grid.getEscalator().getBody()
-                .getRowElement(grid.getEditor().getRow());
-            int rowLeft = rowElement.getAbsoluteLeft();
-            int editorLeft = cellWrapper.getAbsoluteLeft();
-            if (editorLeft != rowLeft + frozenWidth) {
-                cellWrapper.getStyle().setLeft(newLeft + rowLeft - editorLeft,
-                    Unit.PX);
+            try {
+                TableRowElement rowElement = grid.getEscalator().getBody()
+                    .getRowElement(grid.getEditor().getRow());
+                int rowLeft = rowElement.getAbsoluteLeft();
+                int editorLeft = cellWrapper.getAbsoluteLeft();
+                if (editorLeft != rowLeft + frozenWidth) {
+                    cellWrapper.getStyle().setLeft(newLeft + rowLeft - editorLeft,
+                        Unit.PX);
+                }
+            } catch (IllegalStateException e) {
+                // IllegalStateException may occur if user has scrolled Grid so
+                // that Escalator has updated, and row under Editor is no longer
+                // there
             }
         }
 


### PR DESCRIPTION
(#12002)

IllegalStateException may occur if user has scrolled Grid (compatibility library version) so that Escalator has updated, and row under Editor is no longer there

Issue #11463

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12009)
<!-- Reviewable:end -->
