### PR TITLE
Eliminate double rendering during initial compatibility Grid rendering.

### DIFF
--- a/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/GridConnector.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/connectors/GridConnector.java
@@ -911,6 +911,21 @@ public class GridConnector extends AbstractHasComponentsConnector
 
         initialChange = stateChangeEvent.isInitialStateChange();
 
+        if (initialChange) {
+            Scheduler.get().scheduleFinally(new ScheduledCommand() {
+                @Override
+                public void execute() {
+                    doUpdateFromStateChangeEvent(stateChangeEvent);
+                }
+            });
+        } else {
+            doUpdateFromStateChangeEvent(stateChangeEvent);
+        }
+    }
+
+    private void doUpdateFromStateChangeEvent(
+            final StateChangeEvent stateChangeEvent) {
+
         // Column updates
         if (stateChangeEvent.hasPropertyChanged("columns")) {
 
@@ -1120,7 +1135,6 @@ public class GridConnector extends AbstractHasComponentsConnector
         }
         cell.setStyleName(cellState.styleName);
     }
-
 
     /**
      * Update columns from the current state.


### PR DESCRIPTION
Performance improvement.

Cherry-pick of #11199

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12019)
<!-- Reviewable:end -->
