### PR TITLE
Moving disableBrowserAutocomplete to WidgetUtil and change widgets to use it

### DIFF
--- a/client/src/main/java/com/vaadin/client/WidgetUtil.java
+++ b/client/src/main/java/com/vaadin/client/WidgetUtil.java
@@ -42,6 +42,7 @@ import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.EventListener;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.shared.ui.ErrorLevel;
 import com.vaadin.shared.util.SharedUtil;
@@ -1961,5 +1962,26 @@ public class WidgetUtil {
             indicator.setClassName(StyleConstants.STYLE_NAME_ERROR_INDICATOR);
             return indicator;
         }
+    }
+
+    public static void disableBrowserAutocomplete(TextBox textBox) {
+        /*-
+         * Stop the browser from showing its own suggestion popup.
+         *
+         * Using an invalid value instead of "off" as suggested by
+         * https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
+         *
+         * Leaving the non-standard Safari options autocapitalize and
+         * autocorrect untouched since those do not interfere in the same
+         * way, and they might be useful in a combo box where new items are
+         * allowed.
+         */
+        if (BrowserInfo.get().isChrome()) {
+            // Chrome supports "off" and random number does not work with
+            // Chrome
+            textBox.getElement().setAttribute("autocomplete", "off");
+        } else {
+        	textBox.getElement().setAttribute("autocomplete", Math.random() + "");
+        }    	
     }
 }

--- a/client/src/main/java/com/vaadin/client/ui/VAbstractTextualDate.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractTextualDate.java
@@ -91,13 +91,7 @@ public abstract class VAbstractTextualDate<R extends Enum<R>>
             addDomHandler(this, KeyDownEvent.getType());
         }
         // Stop the browser from showing its own suggestion popup.
-        if (BrowserInfo.get().isChrome()) {
-            // Chrome supports "off" and random number does not work with
-            // Chrome
-            text.getElement().setAttribute("autocomplete", "off");
-        } else {
-            text.getElement().setAttribute("autocomplete", Math.random() + "");
-        }
+        WidgetUtil.disableBrowserAutocomplete(text);
         add(text);
         publishJSHelpers(getElement());
     }

--- a/client/src/main/java/com/vaadin/client/ui/VAbstractTextualDate.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractTextualDate.java
@@ -36,6 +36,7 @@ import com.vaadin.client.BrowserInfo;
 import com.vaadin.client.Focusable;
 import com.vaadin.client.LocaleNotLoadedException;
 import com.vaadin.client.LocaleService;
+import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.ui.aria.AriaHelper;
 import com.vaadin.client.ui.aria.HandlesAriaCaption;
 import com.vaadin.client.ui.aria.HandlesAriaInvalid;

--- a/client/src/main/java/com/vaadin/client/ui/VAbstractTextualDate.java
+++ b/client/src/main/java/com/vaadin/client/ui/VAbstractTextualDate.java
@@ -90,6 +90,14 @@ public abstract class VAbstractTextualDate<R extends Enum<R>>
         if (BrowserInfo.get().isIE()) {
             addDomHandler(this, KeyDownEvent.getType());
         }
+        // Stop the browser from showing its own suggestion popup.
+        if (BrowserInfo.get().isChrome()) {
+            // Chrome supports "off" and random number does not work with
+            // Chrome
+            text.getElement().setAttribute("autocomplete", "off");
+        } else {
+            text.getElement().setAttribute("autocomplete", Math.random() + "");
+        }
         add(text);
         publishJSHelpers(getElement());
     }

--- a/client/src/main/java/com/vaadin/client/ui/VComboBox.java
+++ b/client/src/main/java/com/vaadin/client/ui/VComboBox.java
@@ -1438,24 +1438,7 @@ public class VComboBox extends Composite implements Field, KeyDownHandler,
          * @since 7.6.4
          */
         public FilterSelectTextBox() {
-            /*-
-             * Stop the browser from showing its own suggestion popup.
-             *
-             * Using an invalid value instead of "off" as suggested by
-             * https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
-             *
-             * Leaving the non-standard Safari options autocapitalize and
-             * autocorrect untouched since those do not interfere in the same
-             * way, and they might be useful in a combo box where new items are
-             * allowed.
-             */
-            if (BrowserInfo.get().isChrome()) {
-                // Chrome supports "off" and random number does not work with
-                // Chrome
-                getElement().setAttribute("autocomplete", "off");
-            } else {
-                getElement().setAttribute("autocomplete", Math.random() + "");
-            }
+            WidgetUtil.disableBrowserAutocomplete(this);
         }
 
         /**

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VFilterSelect.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VFilterSelect.java
@@ -1409,23 +1409,8 @@ public class VFilterSelect extends Composite
          * @since 7.6.4
          */
         public FilterSelectTextBox() {
-            /*-
-             * Stop the browser from showing its own suggestion popup.
-             *
-             * Using an invalid value instead of "off" as suggested by
-             * https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
-             *
-             * Leaving the non-standard Safari options autocapitalize and
-             * autocorrect untouched since those do not interfere in the same
-             * way, and they might be useful in a combo box where new items are
-             * allowed.
-             */
-            if (BrowserInfo.get().isChrome()) {
-                // Chrome supports "off" and random number does not work with Chrome
-                getElement().setAttribute("autocomplete", "off");        		
-            } else {
-                getElement().setAttribute("autocomplete", Math.random() + "");
-            }
+            // Stop the browser from showing its own suggestion popup.
+            WidgetUtil.disableBrowserAutocomplete(this);
         }
 
         /**

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTextualDate.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTextualDate.java
@@ -35,6 +35,7 @@ import com.vaadin.client.BrowserInfo;
 import com.vaadin.client.Focusable;
 import com.vaadin.client.LocaleNotLoadedException;
 import com.vaadin.client.LocaleService;
+import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.ui.SubPartAware;
 import com.vaadin.client.ui.aria.AriaHelper;
 import com.vaadin.client.ui.aria.HandlesAriaCaption;

--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTextualDate.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VTextualDate.java
@@ -115,6 +115,8 @@ public class VTextualDate extends VDateField
         if (BrowserInfo.get().isIE()) {
             addDomHandler(this, KeyDownEvent.getType());
         }
+        // Stop the browser from showing its own suggestion popup.
+        WidgetUtil.disableBrowserAutocomplete(text);
         add(text);
     }
 


### PR DESCRIPTION
Autocomplete popup will interfere DateField's and ComboBox's own popups. The method to disable autocomplete has been unstable, thus refactored to one place, so that it is easier to apply change in the future when need arises.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12020)
<!-- Reviewable:end -->
