### PR TITLE
Row Generator fixes

### DIFF
--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
@@ -6735,7 +6735,8 @@ public class VScrollTable extends FlowPanel
                             addSpannedCell(uidl, cell.toString(), aligns[0], "",
                                     htmlContentAllowed, false, null, colCount);
                         } else {
-                            addSpannedCell(uidl, (Widget) cell, aligns[0], "",
+                            final ComponentConnector cellContent = client.getPaintable((UIDL) cell);
+                            addSpannedCell(uidl, cellContent.getWidget(), aligns[0], "",
                                     false, colCount);
                         }
                         break;

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Table.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Table.java
@@ -2282,20 +2282,33 @@ public class Table extends AbstractSelect implements Action.Container,
             }
         }
 
-        GeneratedRow generatedRow = rowGenerator != null
-                ? rowGenerator.generateRow(this, id)
-                : null;
-        cells[CELL_GENERATED_ROW][i] = generatedRow;
+        int index = firstIndex + i;
+        int indexInOldBuffer = index - pageBufferFirstIndex;
+        boolean inPageBuffer = index < firstIndexNotInCache
+                && index >= pageBufferFirstIndex
+                && id.equals(pageBuffer[CELL_ITEMID][indexInOldBuffer]);
 
+        GeneratedRow generatedRow = null;
+        if (rowGenerator != null) {
+            if (inPageBuffer) {
+                generatedRow = (GeneratedRow) pageBuffer[CELL_GENERATED_ROW][indexInOldBuffer];
+            } else {
+                generatedRow = rowGenerator.generateRow(this, cells[CELL_ITEMID][i]);
+            }
+            cells[CELL_GENERATED_ROW][i] = generatedRow;
+        }
+
+        int firstNotCollapsed = -1;
         for (int j = 0; j < cols; j++) {
             if (isColumnCollapsed(colids[j])) {
                 continue;
+            } else if (firstNotCollapsed == -1) {
+                firstNotCollapsed = j;
             }
             Property<?> p = null;
             Object value = "";
-            boolean isGeneratedRow = generatedRow != null;
             boolean isGeneratedColumn = columnGenerators.containsKey(colids[j]);
-            boolean isGenerated = isGeneratedRow || isGeneratedColumn;
+            boolean isGenerated = isGeneratedColumn || generatedRow != null;
 
             if (!isGenerated) {
                 try {
@@ -2306,33 +2319,24 @@ public class Table extends AbstractSelect implements Action.Container,
                 }
             }
 
-            if (isGeneratedRow) {
-                if (generatedRow.isSpanColumns() && j > 0) {
-                    value = null;
-                } else if (generatedRow.isSpanColumns() && j == 0
-                        && generatedRow.getValue() instanceof Component) {
-                    value = generatedRow.getValue();
-                } else if (generatedRow.getText().length > j) {
-                    value = generatedRow.getText()[j];
-                }
-            } else {
-                // check if current pageBuffer already has row
-                int index = firstIndex + i;
-                if (p != null || isGenerated) {
-                    int indexInOldBuffer = index - pageBufferFirstIndex;
-                    if (index < firstIndexNotInCache
-                            && index >= pageBufferFirstIndex
-                            && pageBuffer[CELL_GENERATED_ROW][indexInOldBuffer] == null
-                            && id.equals(
-                                    pageBuffer[CELL_ITEMID][indexInOldBuffer])) {
-                        // we already have data in our cache,
-                        // recycle it instead of fetching it via
-                        // getValue/getPropertyValue
+            // check if current pageBuffer already has row
+            if (p != null || isGenerated) {
+                if (inPageBuffer) {
+                    // we already have data in our cache,
+                    // recycle it instead of fetching it via
+                    // getValue/getPropertyValue
+                    if (generatedRow != null) {
+                        value = extractGeneratedValue(generatedRow, j, j == firstNotCollapsed);
+                    } else {
                         value = pageBuffer[CELL_FIRSTCOL + j][indexInOldBuffer];
-                        if (!isGeneratedColumn && iscomponent[j]
-                                || !(value instanceof Component)) {
-                            listenProperty(p, oldListenedProperties);
-                        }
+                    }
+                    if (!isGeneratedColumn && iscomponent[j]
+                            || !(value instanceof Component)) {
+                        listenProperty(p, oldListenedProperties);
+                    }
+                } else {
+                    if (generatedRow != null) {
+                        value = extractGeneratedValue(generatedRow, j, j == firstNotCollapsed);
                     } else {
                         if (isGeneratedColumn) {
                             ColumnGenerator cg = columnGenerators
@@ -2393,6 +2397,20 @@ public class Table extends AbstractSelect implements Action.Container,
             }
             cells[CELL_FIRSTCOL + j][i] = value;
         }
+    }
+
+    private Object extractGeneratedValue(GeneratedRow generatedRow, int index, boolean firstVisibleColumn) {
+        if (generatedRow.isSpanColumns()) {
+            if (firstVisibleColumn) {
+                return generatedRow.getValue();
+            }
+            return null;
+        }
+        String[] text = generatedRow.getText();
+        if (text != null && text.length > index) {
+            return text[index];
+        }
+        return null;
     }
 
     protected void registerComponent(Component component) {
@@ -3990,8 +4008,9 @@ public class Table extends AbstractSelect implements Action.Container,
             target.addAttribute("gen_html",
                     generatedRow.isHtmlContentAllowed());
             target.addAttribute("gen_span", generatedRow.isSpanColumns());
+            // todo: actually gen_widget is never used
             target.addAttribute("gen_widget",
-                    generatedRow.getValue() instanceof Component);
+                    cells[CELL_FIRSTCOL][indexInRowBuffer] instanceof Component);
         }
     }
 

--- a/compatibility-server/src/main/java/com/vaadin/v7/ui/Table.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/ui/Table.java
@@ -2399,14 +2399,29 @@ public class Table extends AbstractSelect implements Action.Container,
         }
     }
 
+    /**
+     * Extracts cell value from generated row
+     *
+     * @param generatedRow generated row
+     * @param index column index
+     * @param firstVisibleColumn whether the column is first visible column in the table (i.e. previous columns are hidden)
+     * @return cell value
+     */
     private Object extractGeneratedValue(GeneratedRow generatedRow, int index, boolean firstVisibleColumn) {
+        Object value = generatedRow.getValue();
+        String[] text = generatedRow.getText();
         if (generatedRow.isSpanColumns()) {
             if (firstVisibleColumn) {
-                return generatedRow.getValue();
+                if (value instanceof Component) {
+                    return value;
+                }
+                if (text != null && text.length > 0) {
+                    return text[0];
+                }
             }
             return null;
         }
-        String[] text = generatedRow.getText();
+
         if (text != null && text.length > index) {
             return text[index];
         }


### PR DESCRIPTION
This PR fixes following issues in row generator feature (https://vaadin.com/api/framework/7.7.17/com/vaadin/ui/Table.RowGenerator.html):

- Class Cast exception on client side when rendering components in generated rows (vaadin#2360)
- "Widget is still attached to the DOM after the connector ... has been unregistered. Widget was removed" errors, caused by superfluous calls of RowGenerator#generateRow method in com.vaadin.v7.ui.Table#parseItemIdToCells (rowGenerator.generateRow(...) and successive  registerComponent(...) poisons pageBuffer and visibleComponents)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12027)
<!-- Reviewable:end -->
