### PR TITLE
Refactor how resync request is made

### DIFF
--- a/client/src/main/java/com/vaadin/client/communication/MessageSender.java
+++ b/client/src/main/java/com/vaadin/client/communication/MessageSender.java
@@ -47,6 +47,7 @@ public class MessageSender {
 
     private ApplicationConnection connection;
     private boolean hasActiveRequest = false;
+    private boolean resynchronizeRequested = false;
 
     /**
      * Counter for the messages send to the server. First sent message has id 0.
@@ -123,6 +124,11 @@ public class MessageSender {
             extraJson.put(ApplicationConstants.WIDGETSET_VERSION_ID,
                     Version.getFullVersion());
             connection.getConfiguration().setWidgetsetVersionSent();
+        }
+        if (resynchronizeRequested) {
+            getLogger().info("Resynchronizing from server");
+            extraJson.put(ApplicationConstants.RESYNCHRONIZE_ID, true);
+            resynchronizeRequested = false;
         }
         if (showLoadingIndicator) {
             connection.getLoadingIndicator().trigger();
@@ -239,7 +245,8 @@ public class MessageSender {
         hasActiveRequest = false;
 
         if (connection.isApplicationRunning()) {
-            if (getServerRpcQueue().isFlushPending()) {
+            if (getServerRpcQueue().isFlushPending()
+                    || resynchronizeRequested) {
                 sendInvocationsToServer();
             }
             runPostRequestHooks(connection.getConfiguration().getRootPanelId());
@@ -350,10 +357,9 @@ public class MessageSender {
      */
     public void resynchronize() {
         getMessageHandler().onResynchronize();
-        getLogger().info("Resynchronizing from server");
-        JsonObject resyncParam = Json.createObject();
-        resyncParam.put(ApplicationConstants.RESYNCHRONIZE_ID, true);
-        send(Json.createArray(), resyncParam);
+        getLogger().info("Resynchronize from server requested");
+        resynchronizeRequested = true;
+        sendInvocationsToServer();
     }
 
     /**


### PR DESCRIPTION
When e.g. UIConnector is requesting resync after theme change, there may be pending requests in the queue.

Send resync request via sendInvocationsToServer(); instead.

This ensures that request is put properly in the queue and handled without conflict.

The same scenario can happen possibly in other ways too.

Fixes #11954

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12039)
<!-- Reviewable:end -->
