### PR TITLE
Explicitly remove old dataprovider listener when new one is set

### DIFF
--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -887,6 +887,17 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
 
         // Update icon for ConnectorResource
         updateSelectedItemIcon(getValue());
+
+        DataProvider<T, ?> dataProvider = getDataProvider();
+        if (dataProvider != null && dataProviderListener != null) {
+            setupDataProviderListener(dataProvider);
+        }
+    }
+
+    @Override
+    public void detach() {
+        super.detach();
+        dataProviderListener.remove();
     }
 
     @Override
@@ -972,6 +983,11 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
         filterSlot = filter -> providerFilterSlot
                 .accept(convertOrNull.apply(filter));
 
+        setupDataProviderListener(dataProvider);
+    }
+
+    private <C> void setupDataProviderListener(
+            DataProvider<T, C> dataProvider) {
         // This workaround is done to fix issue #11642 for unpaged comboboxes.
         // Data sources for on the client need to be updated after data provider
         // refreshAll so that serverside selection works even before the

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -979,13 +979,15 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
         // is opened. Only done for in-memory data providers for performance
         // reasons.
         if (dataProvider instanceof InMemoryDataProvider) {
-            if (dataProviderListener != null) dataProviderListener.remove();
-            dataProviderListener = dataProvider.addDataProviderListener(event -> {
-                if ((!(event instanceof DataChangeEvent.DataRefreshEvent))
-                        && (getPageLength() == 0)) {
-                    getState().forceDataSourceUpdate = true;
-                }
-            });
+            if (dataProviderListener != null)
+                dataProviderListener.remove();
+            dataProviderListener = dataProvider
+                    .addDataProviderListener(event -> {
+                        if ((!(event instanceof DataChangeEvent.DataRefreshEvent))
+                                && (getPageLength() == 0)) {
+                            getState().forceDataSourceUpdate = true;
+                        }
+                    });
         }
     }
 

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -896,8 +896,10 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
 
     @Override
     public void detach() {
-        dataProviderListener.remove();
-        dataProviderListener = null;
+        if (dataProviderListener != null) {
+            dataProviderListener.remove();
+            dataProviderListener = null;
+        }
         super.detach();
     }
 

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -958,7 +958,10 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
 
     @Override
     public DataProvider<T, ?> getDataProvider() {
-        return internalGetDataProvider();
+        if (this.getDataCommunicator() != null) {
+            return internalGetDataProvider();
+        }
+        return null;
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -897,6 +897,7 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
     @Override
     public void detach() {
         dataProviderListener.remove();
+        dataProviderListener = null;
         super.detach();
     }
 

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -896,8 +896,8 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
 
     @Override
     public void detach() {
-        super.detach();
         dataProviderListener.remove();
+        super.detach();
     }
 
     @Override

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -889,7 +889,7 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
         updateSelectedItemIcon(getValue());
 
         DataProvider<T, ?> dataProvider = getDataProvider();
-        if (dataProvider != null && dataProviderListener != null) {
+        if (dataProvider != null && dataProviderListener == null) {
             setupDataProviderListener(dataProvider);
         }
     }

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -979,8 +979,9 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
         // is opened. Only done for in-memory data providers for performance
         // reasons.
         if (dataProvider instanceof InMemoryDataProvider) {
-            if (dataProviderListener != null)
+            if (dataProviderListener != null) {
                 dataProviderListener.remove();
+            }
             dataProviderListener = dataProvider
                     .addDataProviderListener(event -> {
                         if ((!(event instanceof DataChangeEvent.DataRefreshEvent))

--- a/server/src/main/java/com/vaadin/ui/ComboBox.java
+++ b/server/src/main/java/com/vaadin/ui/ComboBox.java
@@ -245,6 +245,8 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
         // Just ignore when neither setDataProvider nor setItems has been called
     };
 
+    private Registration dataProviderListener = null;
+
     /**
      * Constructs an empty combo box without a caption. The content of the combo
      * box can be set with {@link #setDataProvider(DataProvider)} or
@@ -977,7 +979,8 @@ public class ComboBox<T> extends AbstractSingleSelect<T>
         // is opened. Only done for in-memory data providers for performance
         // reasons.
         if (dataProvider instanceof InMemoryDataProvider) {
-            dataProvider.addDataProviderListener(event -> {
+            if (dataProviderListener != null) dataProviderListener.remove();
+            dataProviderListener = dataProvider.addDataProviderListener(event -> {
                 if ((!(event instanceof DataChangeEvent.DataRefreshEvent))
                         && (getPageLength() == 0)) {
                     getState().forceDataSourceUpdate = true;


### PR DESCRIPTION
If not done, this can cause memory leakage

Fixes: https://github.com/vaadin/framework/issues/12065

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12064)
<!-- Reviewable:end -->
