### PR TITLE
Fix possible NPE with MPR (#12040)

### DIFF
--- a/server/src/main/java/com/vaadin/server/Page.java
+++ b/server/src/main/java/com/vaadin/server/Page.java
@@ -996,11 +996,22 @@ public class Page implements Serializable {
      *             set to {@code false}
      */
     public URI getLocation() throws IllegalStateException {
-        if (location == null && !uI.getSession().getConfiguration()
-                .isSendUrlsAsParameters()) {
-            throw new IllegalStateException("Location is not available as the "
-                    + Constants.SERVLET_PARAMETER_SENDURLSASPARAMETERS
-                    + " parameter is configured as false");
+        if (location == null) {
+            if (uI.getSession() != null && !uI.getSession().getConfiguration()
+                       .isSendUrlsAsParameters()) {
+                throw new IllegalStateException("Location is not available as the "
+                        + Constants.SERVLET_PARAMETER_SENDURLSASPARAMETERS
+                        + " parameter is configured as false");
+            } else if (VaadinSession.getCurrent() == null) {
+                throw new IllegalStateException("Location is not available as the "
+                        + Constants.SERVLET_PARAMETER_SENDURLSASPARAMETERS
+                        + " parameter state cannot be determined");
+            } else if (!VaadinSession.getCurrent().getConfiguration()
+                       .isSendUrlsAsParameters()) {
+                throw new IllegalStateException("Location is not available as the "
+                        + Constants.SERVLET_PARAMETER_SENDURLSASPARAMETERS
+                        + " parameter is configured as false");
+            }
         }
         return location;
     }

--- a/server/src/test/java/com/vaadin/server/communication/ServletUIInitHandlerTest.java
+++ b/server/src/test/java/com/vaadin/server/communication/ServletUIInitHandlerTest.java
@@ -54,6 +54,7 @@ public class ServletUIInitHandlerTest {
                     session);
             session.setCommunicationManager(communicationManager);
             session.setConfiguration(deploymentConfiguration);
+            session.setCurrent(session);
             session.addUIProvider(new UIProvider() {
 
                 @Override


### PR DESCRIPTION
It is possible when Vaadin 8 is used with MPR, that ui.getCurrent().getSession() returns null.

See: https://github.com/vaadin/multiplatform-runtime/issues/5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12066)
<!-- Reviewable:end -->
