### PR TITLE
Fix link to Valo API documentation

### DIFF
--- a/documentation/themes/themes-valo.asciidoc
+++ b/documentation/themes/themes-valo.asciidoc
@@ -18,7 +18,7 @@ The true power of Valo lies in its configurability with parameters, functions,
 and Sass mixins. You can use the built-in definitions in your own themes or
 override the defaults. Detailed documentation of the available mixins,
 functions, and variables can be found in the Valo API documentation available at
-http://vaadin.com/valo.
+https://vaadin.com/api/valo/.
 
 [[themes.valo.use]]
 == Basic Use


### PR DESCRIPTION
The current link in then Valo documentation goes to the Lumo page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12080)
<!-- Reviewable:end -->
