### PR TITLE
Fix IndexOutOfBoundsException  when adding columns in Grid

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -6540,8 +6540,14 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
         }
         if (visibleNewColumns > 0) {
+            int escalatorIndex = index;
+            for (int existingColumn = 0; existingColumn < index; existingColumn++) {
+                if (getColumn(existingColumn).isHidden()) {
+                    escalatorIndex--;
+                }
+            }
             final ColumnConfiguration columnConfiguration = this.escalator.getColumnConfiguration();
-            columnConfiguration.insertColumns(index, visibleNewColumns);
+            columnConfiguration.insertColumns(escalatorIndex, visibleNewColumns);
         }
 
         for (final Column<?, T> column : columnCollection) {


### PR DESCRIPTION
There is regression in Vaadin 7.7.16 and later, which is due patch  https://github.com/vaadin/framework/commit/eafd44672650e076fc4a43362e11b47ffb0dbff1 that can lead to IndexOutOfBoundsException when there is hidden columns while adding new columns, which is similiar issue than earlier reported in https://github.com/vaadin/framework/issues/6784. Essentially the performance improvement patch overwrite some of the fix logic of https://github.com/vaadin/framework/commit/84533057435a99b0d0dfa9ea791de81921c1e260 This fix bring overwriten escalator index compensation back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12095)
<!-- Reviewable:end -->
