### PR TITLE
Update ServletPortletHelper.java (#12087)

### DIFF
--- a/server/src/main/java/com/vaadin/server/ServletPortletHelper.java
+++ b/server/src/main/java/com/vaadin/server/ServletPortletHelper.java
@@ -98,6 +98,10 @@ public class ServletPortletHelper implements Serializable {
             prefix = '/' + prefix;
         }
 
+        if (!pathInfo.endsWith("/") && prefix.endsWith("/")) {
+            pathInfo += '/';
+        }
+
         if (pathInfo.startsWith(prefix)) {
             return true;
         }


### PR DESCRIPTION
This is needed to get /UIDL working behind a reverse proxy. Without the change pathInfo would be "/UIDL" but prefix would be "/UIDL/" in line 105.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12100)
<!-- Reviewable:end -->
