### PR TITLE
Open details rows shouldn't get removed when a new row is added to Grid

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -7311,12 +7311,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                         RowContainer body = escalator.getBody();
                         int oldSize = body.getRowCount();
 
-                        // Hide all details.
-                        Set<Integer> oldDetails = new HashSet<>(visibleDetails);
-                        for (int i : oldDetails) {
-                            setDetailsVisible(i, false);
-                        }
-
                         if (newSize > oldSize) {
                             if (oldSize == 0 && !isHeaderVisible()) {
                                 // Fixes framework/issues/11607

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridOpenDetailsAddRow.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridOpenDetailsAddRow.java
@@ -1,0 +1,53 @@
+package com.vaadin.tests.components.grid;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.data.provider.ListDataProvider;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.VerticalLayout;
+
+public class GridOpenDetailsAddRow extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        Grid<String> testGrid = new Grid<>();
+
+        testGrid.addColumn(item -> item).setCaption("column").setId("column");
+
+        List<String> list = new ArrayList<>();
+        list.add("row1");
+        list.add("row2");
+        list.add("row3");
+        ListDataProvider<String> dataProvider = new ListDataProvider<>(list);
+
+        testGrid.setDataProvider(dataProvider);
+        testGrid.setDetailsGenerator(item -> new Label("details - " + item));
+        list.forEach(item -> testGrid.setDetailsVisible(item, true));
+
+        Button addButton = new Button("add");
+        addButton.addClickListener(event -> {
+            String newItem = "row" + (list.size() + 1);
+            list.add(newItem);
+            testGrid.setDetailsVisible(newItem, true);
+            dataProvider.refreshAll();
+        });
+
+        VerticalLayout testLayout = new VerticalLayout(addButton, testGrid);
+        addComponent(testLayout);
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 12106;
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Already open details rows shouldn't disappear when a new row is added";
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridOpenDetailsAddRowTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridOpenDetailsAddRowTest.java
@@ -1,0 +1,40 @@
+package com.vaadin.tests.components.grid;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.testbench.By;
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class GridOpenDetailsAddRowTest extends MultiBrowserTest {
+
+    @Test
+    public void addRow() {
+        openTestURL();
+        waitUntilLoadingIndicatorNotVisible();
+
+        // confirm initial state
+        List<WebElement> spacers = findElements(By.className("v-grid-spacer"));
+        assertEquals("Unexpected initial amount of spacers", 3, spacers.size());
+
+        // add a row
+        $(ButtonElement.class).first().click();
+        waitUntilLoadingIndicatorNotVisible();
+
+        // ensure all existing spacers are still visible, as well as the new one
+        spacers = findElements(By.className("v-grid-spacer"));
+        assertEquals("Unexpected amount of spacers after adding a row", 4,
+                spacers.size());
+
+        assertEquals("Unexpected spacer contents for new row", "details - row4",
+                spacers.get(3).getText());
+
+        assertEquals("Unexpected spacer contents for first row",
+                "details - row1", spacers.get(0).getText());
+    }
+}


### PR DESCRIPTION
Fixes: #12106

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12109)
<!-- Reviewable:end -->
