### PR TITLE
When a Grid gets scroll-locked, cancel the scrollInProgress handler.

### DIFF
--- a/client/src/main/java/com/vaadin/client/widget/escalator/ScrollbarBundle.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/ScrollbarBundle.java
@@ -790,9 +790,16 @@ public abstract class ScrollbarBundle implements DeferredWorker {
         if (!isLocked()) {
             scrollPos = newScrollPos;
             scrollEventFirer.scheduleEvent();
-        } else if (scrollPos != newScrollPos) {
-            // we need to actually undo the setting of the scroll.
-            internalSetScrollPos(toInt32(scrollPos));
+        } else {
+            if (scrollPos != newScrollPos) {
+                // we need to actually undo the setting of the scroll.
+                internalSetScrollPos(toInt32(scrollPos));
+            }
+            if (scrollInProgress != null) {
+                // cancel the in-progress indicator
+                scrollInProgress.removeHandler();
+                scrollInProgress = null;
+            }
         }
     }
 


### PR DESCRIPTION
Otherwise opening a Grid editor can cause ApplicationConnection to get
stuck in 'active' state even if no actual scroll position processing is
ongoing, which in turn causes TestBench delays when it tries to wait
until ApplicationConnection indicates that everything necessary has been
processed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12116)
<!-- Reviewable:end -->
