### PR TITLE
Passing --release 8 to javac makes Vaadin compile on JDK 10+.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -656,7 +656,12 @@
             <!-- Default build profile that runs all modules. -->
             <id>default</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <!--
+                this way the profile stays active even if the jdk9 profile activates.
+                See https://stackoverflow.com/questions/5309379/how-to-keep-maven-profiles-which-are-activebydefault-active-even-if-another-prof
+                for more details.
+                -->
+                <file><exists>.</exists></file>
             </activation>
             <modules>
                 <module>shared</module>
@@ -967,6 +972,15 @@
             <id>measurements</id>
             <properties>
                 <skipTests>true</skipTests>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>[9,</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Thanks for submitting a pull request!
Please confirm that your pull request follows our guidelines found in CONTRIBUTING and that you provide enough information so that we can review your pull request.

Passing --release 8 to javac makes Vaadin compile on JDK 10+.

This has been suggested at https://bugs.openjdk.java.net/browse/JDK-8212636

The maven compiler plugin v-bump is necessary since the `release` config option is only available since maven-compiler-plugin 3.6: https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html

Fixes #10737 

**Check when you have completed**
[ ] Valid tests for the pull request
Not possible - the CI needs to be configured to build Vaadin on JDK 11 as well

[x] Contributing guidelines implemented

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12134)
<!-- Reviewable:end -->
