### PR TITLE
Bump jetty.version from 9.4.17.v20190418 to 9.4.34.v20201102 (#12149)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <!-- Dependency unpack directory -->
         <dependency.unpack.directory>${project.build.directory}/dependency-unpack</dependency.unpack.directory>
  
-        <jetty.version>9.4.17.v20190418</jetty.version>
+        <jetty.version>9.4.34.v20201102</jetty.version>
 
         <!-- Sonar properties -->
         <sonar.java.source>8</sonar.java.source>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <jetty.version>9.3.7.v20160115</jetty.version>
+        <jetty.version>9.4.34.v20201102</jetty.version>
         <phantomjs.version>2.1.1</phantomjs.version>
         <vaadin.version>${project.version}</vaadin.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>

--- a/uitest/src/test/java/com/vaadin/tests/applicationservlet/NoApplicationClassTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/applicationservlet/NoApplicationClassTest.java
@@ -12,7 +12,7 @@ public class NoApplicationClassTest extends SingleBrowserTest {
     @Test
     public void testInvalidApplicationClass() {
         openTestURL();
-        String exceptionMessage = getDriver().findElement(By.xpath("//pre[2]"))
+        String exceptionMessage = getDriver().findElement(By.xpath("//pre[1]"))
                 .getText();
         String expected = "ServletException: java.lang.ClassNotFoundException: ClassThatIsNotPresent";
         assertTrue(String.format(

--- a/uitest/src/test/java/com/vaadin/tests/components/ui/InvalidViewportTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ui/InvalidViewportTest.java
@@ -1,6 +1,6 @@
 package com.vaadin.tests.components.ui;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -16,7 +16,8 @@ public class InvalidViewportTest extends SingleBrowserTest {
 
         WebElement heading = findElement(By.tagName("h2"));
 
-        assertEquals("HTTP ERROR 500", heading.getText());
+        assertTrue("Unexpected heading: " + heading.getText(),
+                heading.getText().startsWith("HTTP ERROR 500"));
     }
 
 }

--- a/uitest/src/test/java/com/vaadin/tests/requesthandlers/AppResource404Test.java
+++ b/uitest/src/test/java/com/vaadin/tests/requesthandlers/AppResource404Test.java
@@ -39,7 +39,10 @@ public class AppResource404Test extends MultiBrowserTest {
         assertTrue("Page does not contain the given text",
                 driver.getPageSource().contains("HTTP ERROR 404"));
         assertTrue("Page does not contain the given text",
-                driver.getPageSource().contains("Problem accessing /run/APP/"));
+                driver.getPageSource().contains("/run/APP/"));
+        assertTrue("Page does not contain the given text",
+                driver.getPageSource().contains(
+                        "Request was not handled by any registered handler."));
     }
 
     @Test


### PR DESCRIPTION
Bumps `jetty.version` from 9.4.17.v20190418 to 9.4.34.v20201102.

Updates `jetty-server` from 9.4.17.v20190418 to 9.4.34.v20201102
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.17.v20190418...jetty-9.4.34.v20201102)

Updates `jetty-servlets` from 9.4.17.v20190418 to 9.4.34.v20201102
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.17.v20190418...jetty-9.4.34.v20201102)

Updates `websocket-server` from 9.4.17.v20190418 to 9.4.34.v20201102

Updates `jetty-webapp` from 9.4.17.v20190418 to 9.4.34.v20201102
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.17.v20190418...jetty-9.4.34.v20201102)

Updates `jetty-util` from 9.4.17.v20190418 to 9.4.34.v20201102
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.17.v20190418...jetty-9.4.34.v20201102)

Updates `jetty-proxy` from 9.4.17.v20190418 to 9.4.34.v20201102
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.17.v20190418...jetty-9.4.34.v20201102)

Updates `jetty-maven-plugin` from 9.4.17.v20190418 to 9.4.34.v20201102
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.17.v20190418...jetty-9.4.34.v20201102)

Signed-off-by: dependabot[bot] <support@github.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12160)
<!-- Reviewable:end -->
