### PR TITLE
MenuBar: Don't set openRootOnHover when on Android or IOS. (#12135)

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/menubar/MenuBarConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/menubar/MenuBarConnector.java
@@ -23,6 +23,7 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Timer;
 import com.vaadin.client.ApplicationConnection;
+import com.vaadin.client.BrowserInfo;
 import com.vaadin.client.Paintable;
 import com.vaadin.client.TooltipInfo;
 import com.vaadin.client.UIDL;
@@ -57,8 +58,14 @@ public class MenuBarConnector extends AbstractComponentConnector
         widget.htmlContentAllowed = uidl
                 .hasAttribute(MenuBarConstants.HTML_CONTENT_ALLOWED);
 
-        widget.openRootOnHover = uidl
-                .getBooleanAttribute(MenuBarConstants.OPEN_ROOT_MENU_ON_HOWER);
+        if (BrowserInfo.get().isAndroid() || BrowserInfo.get().isIOS()) {
+            // disable the auto-open on hover on devices that don't support hover.
+            // fixes https://github.com/vaadin/framework/issues/5873
+            widget.openRootOnHover = false;
+        } else {
+            widget.openRootOnHover = uidl
+                    .getBooleanAttribute(MenuBarConstants.OPEN_ROOT_MENU_ON_HOWER);
+        }
 
         widget.enabled = isEnabled();
 


### PR DESCRIPTION
Fixes #5873

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12166)
<!-- Reviewable:end -->
