### PR TITLE
Bump jetty.version from 9.4.34.v20201102 to 9.4.35.v20201120 (#12164)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <!-- Dependency unpack directory -->
         <dependency.unpack.directory>${project.build.directory}/dependency-unpack</dependency.unpack.directory>
  
-        <jetty.version>9.4.34.v20201102</jetty.version>
+        <jetty.version>9.4.35.v20201120</jetty.version>
 
         <!-- Sonar properties -->
         <sonar.java.source>8</sonar.java.source>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <jetty.version>9.4.34.v20201102</jetty.version>
+        <jetty.version>9.4.35.v20201120</jetty.version>
         <phantomjs.version>2.1.1</phantomjs.version>
         <vaadin.version>${project.version}</vaadin.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>


### PR DESCRIPTION
Bumps `jetty.version` from 9.4.34.v20201102 to 9.4.35.v20201120.

Updates `jetty-server` from 9.4.34.v20201102 to 9.4.35.v20201120
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.34.v20201102...jetty-9.4.35.v20201120)

Updates `jetty-servlets` from 9.4.34.v20201102 to 9.4.35.v20201120
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.34.v20201102...jetty-9.4.35.v20201120)

Updates `websocket-server` from 9.4.34.v20201102 to 9.4.35.v20201120

Updates `jetty-webapp` from 9.4.34.v20201102 to 9.4.35.v20201120
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.34.v20201102...jetty-9.4.35.v20201120)

Updates `jetty-util` from 9.4.34.v20201102 to 9.4.35.v20201120
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.34.v20201102...jetty-9.4.35.v20201120)

Updates `jetty-proxy` from 9.4.34.v20201102 to 9.4.35.v20201120
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.34.v20201102...jetty-9.4.35.v20201120)

Updates `jetty-maven-plugin` from 9.4.34.v20201102 to 9.4.35.v20201120
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.34.v20201102...jetty-9.4.35.v20201120)

Signed-off-by: dependabot[bot] <support@github.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12167)
<!-- Reviewable:end -->
