### PR TITLE
Better error handling trying to enable HTML5 DnD for mobile from thread

### DIFF
--- a/server/src/main/java/com/vaadin/ui/UI.java
+++ b/server/src/main/java/com/vaadin/ui/UI.java
@@ -1987,6 +1987,13 @@ public abstract class UI extends AbstractSingleComponentContainer
             getState().enableMobileHTML5DnD = enabled;
 
             if (isMobileHtml5DndEnabled()) {
+                if (VaadinService.getCurrentRequest() == null) {
+                    getState().enableMobileHTML5DnD = false;
+                    throw new IllegalStateException("HTML5 DnD cannot be "
+                            + "enabled for mobile devices when current "
+                            + "VaadinRequest cannot be accessed. Call this "
+                            + "method from init(VaadinRequest) to ensure access.");
+                }
                 loadMobileHtml5DndPolyfill();
             }
         }

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/MobileHtml5DndEnablingError.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/MobileHtml5DndEnablingError.java
@@ -1,0 +1,46 @@
+package com.vaadin.tests.components.ui;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Label;
+
+public class MobileHtml5DndEnablingError extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        final MobileHtml5DndEnablingError ui = MobileHtml5DndEnablingError.this;
+        new Thread() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                }
+                ui.access(() -> {
+                    Label label;
+                    try {
+                        ui.setMobileHtml5DndEnabled(true);
+                        label = new Label(
+                                "If you see this, there was no error.");
+                    } catch (Exception e) {
+                        label = new Label("Error message: " + e.getMessage());
+                    }
+                    label.setId("error");
+                    label.setSizeFull();
+                    ui.addComponent(label);
+                });
+            }
+        }.start();
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Attempting to set HTML5 DnD enabled for mobile devices from "
+                + "a thread should give an informative error message.";
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 12152;
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/ui/MobileHtml5DndEnablingErrorTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ui/MobileHtml5DndEnablingErrorTest.java
@@ -1,0 +1,19 @@
+package com.vaadin.tests.components.ui;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.vaadin.testbench.elements.LabelElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class MobileHtml5DndEnablingErrorTest extends SingleBrowserTest {
+
+    @Test
+    public void testErrorMessage() {
+        openTestURL();
+        LabelElement label = $(LabelElement.class).id("error");
+        assertTrue("Unexpected Label content: " + label.getText(),
+                label.getText().startsWith("Error message: HTML5 DnD cannot"));
+    }
+}


### PR DESCRIPTION
(#12170)

- Informative error message
- Reset back to disabled state when enabling fails
- Incorrect usage also detectable using non-mobile devices

Fixes #12152

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12175)
<!-- Reviewable:end -->
