### PR TITLE
Dependency check maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,22 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                  <groupId>org.owasp</groupId>
+                  <artifactId>dependency-check-maven</artifactId>
+                  <version>6.0.3</version>
+                    <configuration>
+                        <failBuildOnCVSS>8</failBuildOnCVSS>
+                    </configuration>
+                  <executions>
+                      <execution>
+                          <goals>
+                              <goal>check</goal>
+                          </goals>
+                      </execution>
+                  </executions>
+                </plugin>
+
+                <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
         <!-- Used version numbers for dependencies -->
         <liferay.portal-service.version>6.2.5</liferay.portal-service.version>
-        <liferay.portal-kernel.version>2.0.0</liferay.portal-kernel.version>
+        <liferay.portal-kernel.version>9.16.0</liferay.portal-kernel.version>
 
         <vaadin.gwt.version>2.8.2</vaadin.gwt.version>
         <vaadin.plugin.version>8.7-SNAPSHOT</vaadin.plugin.version>
@@ -144,7 +144,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.6.1</version>
+                <version>1.7.30</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
@@ -458,7 +458,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>2.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
dependency-check-maven finds that com.liferay.portal.kernel-2.0.0.jar has a CVE.
This PR is updating it.

```
com.liferay.portal.kernel-2.0.0.jar (pkg:maven/com.liferay.portal/com.liferay.portal.kernel@2.0.0, cpe:2.3:a:liferay:liferay:2.0.0:*:*:*:*:*:*:*, cpe:2.3:a:liferay:liferay_portal:2.0.0:*:*:*:*:*:*:*, cpe:2.3:a:liferay:portal:2.0.0:*:*:*:*:*:*:*) : CVE-2009-3742, CVE-2010-5327, CVE-2014-8349, CVE-2016-10404, CVE-2016-3670, CVE-2017-1000425, CVE-2017-12645, CVE-2017-12646, CVE-2017-12647, CVE-2017-12648, CVE-2017-12649, CVE-2018-10795, CVE-2019-16147, CVE-2019-16891, CVE-2019-6588, CVE-2020-15839, CVE-2020-15840, CVE-2020-15841, CVE-2020-15842, CVE-2020-24554, CVE-2020-7961
portal-service-6.2.5.jar (pkg:maven/com.liferay.portal/portal-service@6.2.5, cpe:2.3:a:liferay:liferay:6.2.5:*:*:*:*:*:*:*, cpe:2.3:a:liferay:liferay_portal:6.2.5:*:*:*:*:*:*:*, cpe:2.3:a:liferay:portal:6.2.5:*:*:*:*:*:*:*) : CVE-2010-5327, CVE-2016-10404, CVE-2017-1000425, CVE-2017-12645, CVE-2017-12646, CVE-2017-12647, CVE-2017-12648, CVE-2017-12649, CVE-2018-10795, CVE-2019-16147, CVE-2019-16891, CVE-2019-6588, CVE-2020-15839, CVE-2020-15840, CVE-2020-15841, CVE-2020-15842, CVE-2020-24554, CVE-2020-7961
vaadin-icons-3.0.2.jar (pkg:maven/com.vaadin/vaadin-icons@3.0.2, cpe:2.3:a:vaadin:vaadin:3.0.2:*:*:*:*:*:*:*) : CVE-2011-0509
vaadin-slf4j-jdk14-1.6.1.jar (pkg:maven/com.vaadin.external.slf4j/vaadin-slf4j-jdk14@1.6.1, cpe:2.3:a:slf4j:slf4j-ext:1.6.1:*:*:*:*:*:*:*) : CVE-2018-8088
```

The following have CVEs too. Updating if possible might be a good move.
```
ant-1.6.5.jar (pkg:maven/ant/ant@1.6.5, cpe:2.3:a:apache:ant:1.6.5:*:*:*:*:*:*:*) : CVE-2020-1945
apache-el-8.0.9.M3.jar (pkg:maven/org.mortbay.jasper/apache-el@8.0.9.M3) : CVE-2014-7810
apache-jsp-8.0.9.M3.jar (pkg:maven/org.mortbay.jasper/apache-jsp@8.0.9.M3, cpe:2.3:a:apache:tomcat:8.0.9:m3:*:*:*:*:*:*, cpe:2.3:a:apache_software_foundation:tomcat:8.0.9:m3:*:*:*:*:*:*) : CVE-2014-7810, CVE-2016-0762, CVE-2016-5018, CVE-2016-5388, CVE-2016-6794, CVE-2016-6796, CVE-2016-6797, CVE-2016-6816, CVE-2016-8735, CVE-2016-8745, CVE-2017-12617, CVE-2017-5647, CVE-2017-5648, CVE-2017-5664, CVE-2017-7674, CVE-2018-1304, CVE-2018-1305, CVE-2018-1336, CVE-2018-8014, CVE-2018-8034, CVE-2020-8022
apache-jsp-9.2.14.v20151106.jar (pkg:maven/org.eclipse.jetty/apache-jsp@9.2.14.v20151106, cpe:2.3:a:eclipse:jetty:9.2.14:20151106:*:*:*:*:*:*, cpe:2.3:a:jetty:jetty:9.2.14:20151106:*:*:*:*:*:*, cpe:2.3:a:mortbay_jetty:jetty:9.2.14:20151106:*:*:*:*:*:*) : CVE-2017-7656, CVE-2017-7657, CVE-2017-7658, CVE-2018-12536, CVE-2019-10241, CVE-2019-10247, CVE-2020-27216
htmlunit-2.19.jar (pkg:maven/net.sourceforge.htmlunit/htmlunit@2.19, cpe:2.3:a:htmlunit_project:htmlunit:2.19:*:*:*:*:*:*:*) : CVE-2020-5529
htmlunit-core-js-2.17.jar (pkg:maven/net.sourceforge.htmlunit/htmlunit-core-js@2.17, cpe:2.3:a:htmlunit_project:htmlunit:2.17:*:*:*:*:*:*:*) : CVE-2020-5529
httpclient-4.5.1.jar (pkg:maven/org.apache.httpcomponents/httpclient@4.5.1, cpe:2.3:a:apache:httpclient:4.5.1:*:*:*:*:*:*:*) : CVE-2020-13956
jetty-jndi-9.2.14.v20151106.jar (pkg:maven/org.eclipse.jetty/jetty-jndi@9.2.14.v20151106, cpe:2.3:a:eclipse:jetty:9.2.14:20151106:*:*:*:*:*:*, cpe:2.3:a:jetty:jetty:9.2.14:20151106:*:*:*:*:*:*, cpe:2.3:a:mortbay_jetty:jetty:9.2.14:20151106:*:*:*:*:*:*) : CVE-2017-7656, CVE-2017-7657, CVE-2017-7658, CVE-2018-12536, CVE-2019-10241, CVE-2019-10247, CVE-2020-27216
jetty-plus-9.2.14.v20151106.jar (pkg:maven/org.eclipse.jetty/jetty-plus@9.2.14.v20151106, cpe:2.3:a:eclipse:jetty:9.2.14:20151106:*:*:*:*:*:*, cpe:2.3:a:jetty:jetty:9.2.14:20151106:*:*:*:*:*:*, cpe:2.3:a:mortbay_jetty:jetty:9.2.14:20151106:*:*:*:*:*:*) : CVE-2017-7656, CVE-2017-7657, CVE-2017-7658, CVE-2017-9735, CVE-2018-12536, CVE-2019-10241, CVE-2019-10247, CVE-2020-27216
portal-service-6.2.5.jar (pkg:maven/com.liferay.portal/portal-service@6.2.5, cpe:2.3:a:liferay:liferay:6.2.5:*:*:*:*:*:*:*, cpe:2.3:a:liferay:liferay_portal:6.2.5:*:*:*:*:*:*:*, cpe:2.3:a:liferay:portal:6.2.5:*:*:*:*:*:*:*) : CVE-2010-5327, CVE-2016-10404, CVE-2017-1000425, CVE-2017-12645, CVE-2017-12646, CVE-2017-12647, CVE-2017-12648, CVE-2017-12649, CVE-2018-10795, CVE-2019-16147, CVE-2019-16891, CVE-2019-6588, CVE-2020-15839, CVE-2020-15840, CVE-2020-15841, CVE-2020-15842, CVE-2020-24554, CVE-2020-7961
tapestry-4.0.2.jar (pkg:maven/tapestry/tapestry@4.0.2, cpe:2.3:a:apache:tapestry:4.0.2:*:*:*:*:*:*:*) : CVE-2014-1972, CVE-2020-17531
vaadin-slf4j-jdk14-1.6.1.jar (pkg:maven/com.vaadin.external.slf4j/vaadin-slf4j-jdk14@1.6.1, cpe:2.3:a:slf4j:slf4j-ext:1.6.1:*:*:*:*:*:*:*) : CVE-2018-8088
websocket-client-9.2.13.v20150730.jar (pkg:maven/org.eclipse.jetty.websocket/websocket-client@9.2.13.v20150730, cpe:2.3:a:eclipse:jetty:9.2.13:20150730:*:*:*:*:*:*, cpe:2.3:a:jetty:jetty:9.2.13:20150730:*:*:*:*:*:*, cpe:2.3:a:mortbay_jetty:jetty:9.2.13:20150730:*:*:*:*:*:*) : CVE-2017-7656, CVE-2017-7657, CVE-2017-7658, CVE-2018-12536, CVE-2019-10241, CVE-2019-10247, CVE-2020-27216
xercesImpl-2.11.0.jar (pkg:maven/xerces/xercesImpl@2.11.0, cpe:2.3:a:apache:xerces2_java:2.11.0:*:*:*:*:*:*:*) : CVE-2012-0881
```

Often a combination of low-level exploits leads to a remote code execution. I think what can be updated should be updated.
Feel free to edit this PR or ignore it. If you want I'll expand it to update the other dependencies as well.

kind regards
Axel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12177)
<!-- Reviewable:end -->
