### PR TITLE
Move call to getMessageHandler().onResynchronize(); to right place

### DIFF
--- a/client/src/main/java/com/vaadin/client/communication/MessageSender.java
+++ b/client/src/main/java/com/vaadin/client/communication/MessageSender.java
@@ -127,6 +127,7 @@ public class MessageSender {
         }
         if (resynchronizeRequested) {
             getLogger().info("Resynchronizing from server");
+            getMessageHandler().onResynchronize();
             extraJson.put(ApplicationConstants.RESYNCHRONIZE_ID, true);
             resynchronizeRequested = false;
         }
@@ -356,7 +357,6 @@ public class MessageSender {
      * state from the server
      */
     public void resynchronize() {
-        getMessageHandler().onResynchronize();
         getLogger().info("Resynchronize from server requested");
         resynchronizeRequested = true;
         sendInvocationsToServer();

--- a/uitest/src/main/java/com/vaadin/tests/push/PushWithPreserveOnRefresh.java
+++ b/uitest/src/main/java/com/vaadin/tests/push/PushWithPreserveOnRefresh.java
@@ -3,12 +3,13 @@ package com.vaadin.tests.push;
 import com.vaadin.annotations.PreserveOnRefresh;
 import com.vaadin.annotations.Push;
 import com.vaadin.server.VaadinRequest;
+import com.vaadin.shared.ui.ui.Transport;
 import com.vaadin.tests.components.AbstractReindeerTestUI;
 import com.vaadin.tests.util.Log;
 import com.vaadin.ui.Label;
 
 @PreserveOnRefresh
-@Push
+@Push(transport = Transport.WEBSOCKET_XHR)
 public class PushWithPreserveOnRefresh extends AbstractReindeerTestUI {
 
     private Log log = new Log(5);
@@ -16,6 +17,7 @@ public class PushWithPreserveOnRefresh extends AbstractReindeerTestUI {
 
     @Override
     protected void setup(VaadinRequest request) {
+        setTheme("valo");
         // Internal parameter sent by vaadinBootstrap.js,
         addComponent(new Label("window.name: " + request.getParameter("v-wn")));
         addComponent(new Label("UI id: " + getUIId()));


### PR DESCRIPTION
(#12178)

https://github.com/vaadin/framework/pull/12043 changed resync message sending to be deferred to queue. Now also the setting of the semaphor in message handler needs to be deferred to its right place. Otherwise there is possibility for a timing glitch. I.e. MessageHandler is set to resync handling mode before message is actually send.

Fixes: https://github.com/vaadin/framework/issues/12151

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12184)
<!-- Reviewable:end -->
