### PR TITLE
Clear out ClientCache when UI is detached to prevent a minor memory leak

### DIFF
--- a/server/src/main/java/com/vaadin/server/LegacyCommunicationManager.java
+++ b/server/src/main/java/com/vaadin/server/LegacyCommunicationManager.java
@@ -232,8 +232,23 @@ public class LegacyCommunicationManager implements Serializable {
         if (cache == null) {
             cache = new ClientCache();
             uiToClientCache.put(uiId, cache);
+            uI.addDetachListener(event -> removeClientCache(uI));
         }
         return cache;
+    }
+
+    /**
+     * Clear out client cache for the given UI. This should be called when the
+     * UI is detached and the cache becomes obsolete.
+     *
+     * @param uI
+     *            the UI whose client cache should be removed
+     * @deprecated because this cleanup is only needed for a deprecated feature
+     */
+    @Deprecated
+    private void removeClientCache(UI uI) {
+        Integer uiId = Integer.valueOf(uI.getUIId());
+        uiToClientCache.remove(uiId);
     }
 
     /**


### PR DESCRIPTION
Implemented with a listener rather than direct call from UI.detach() in
order to avoid new public API, since the whole feature has been marked
for removal. This doesn't yet prevent the cache or the type map from
getting slightly bloated during the UI's lifetime.

See: #3705

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12199)
<!-- Reviewable:end -->
