### PR TITLE
Clear thread local instances on connection lost in push handler (#12042)

### DIFF
--- a/server/src/test/java/com/vaadin/server/MockVaadinServletService.java
+++ b/server/src/test/java/com/vaadin/server/MockVaadinServletService.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.server;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.ServletException;
+
+import com.vaadin.tests.util.MockDeploymentConfiguration;
+
+/**
+ *
+ * @author Vaadin Ltd
+ */
+public class MockVaadinServletService extends VaadinServletService {
+
+    public MockVaadinServletService() throws ServiceException {
+        this(new MockDeploymentConfiguration());
+    }
+
+    public MockVaadinServletService(
+            DeploymentConfiguration deploymentConfiguration) throws ServiceException {
+        this(new VaadinServlet(), deploymentConfiguration);
+    }
+
+    public MockVaadinServletService(VaadinServlet servlet,
+            DeploymentConfiguration deploymentConfiguration) throws ServiceException {
+        super(servlet, deploymentConfiguration);
+
+        try {
+            servlet.init(new MockServletConfig());
+        } catch (ServletException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected List<RequestHandler> createRequestHandlers()
+            throws ServiceException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void init() {
+        try {
+            super.init();
+        } catch (ServiceException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/server/src/test/java/com/vaadin/server/MockVaadinSession.java
+++ b/server/src/test/java/com/vaadin/server/MockVaadinSession.java
@@ -22,6 +22,10 @@ public class MockVaadinSession extends VaadinSession {
         super(service);
     }
 
+    public MockVaadinSession() throws ServiceException {
+        super(new MockVaadinServletService());
+    }
+
     @Override
     public void close() {
         super.close();

--- a/server/src/test/java/com/vaadin/server/communication/PushHandlerTest.java
+++ b/server/src/test/java/com/vaadin/server/communication/PushHandlerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.server.communication;
+
+import java.util.concurrent.Future;
+
+import org.atmosphere.cpr.AtmosphereRequest;
+import org.atmosphere.cpr.AtmosphereResource;
+import org.atmosphere.cpr.AtmosphereResourceEvent;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.server.MockVaadinServletService;
+import com.vaadin.server.MockVaadinSession;
+import com.vaadin.server.ServiceException;
+import com.vaadin.server.SessionExpiredException;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.server.VaadinSession;
+import com.vaadin.ui.UI;
+
+public class PushHandlerTest {
+
+    MockVaadinSession session = null;
+
+    @Test
+    public void connectionLost_currentInstancesAreCleared()
+            throws SessionExpiredException, ServiceException {
+        session = new MockVaadinSession() {
+            @Override
+            public Future<Void> access(Runnable runnable) {
+                runnable.run();
+                return Mockito.mock(Future.class);
+            }
+        };
+        VaadinSession.setCurrent(session);
+        Assert.assertNotNull(VaadinSession.getCurrent());
+        MockVaadinServletService service = null;
+        service = new MockVaadinServletService() {
+            @Override
+            public com.vaadin.server.VaadinSession findVaadinSession(
+                    VaadinRequest request) throws SessionExpiredException {
+                 return session;
+            }
+
+            @Override
+            public UI findUI(VaadinRequest request) {
+                return null;
+            }
+        };
+
+        service.init();
+        PushHandler handler = new PushHandler(service);
+
+        AtmosphereResource resource = Mockito.mock(AtmosphereResource.class);
+        AtmosphereRequest request = Mockito.mock(AtmosphereRequest.class);
+        Mockito.when(resource.getRequest()).thenReturn(request);
+
+        AtmosphereResourceEvent event = Mockito
+                .mock(AtmosphereResourceEvent.class);
+        Mockito.when(event.getResource()).thenReturn(resource);
+        handler.connectionLost(event);
+
+        Assert.assertNull(VaadinSession.getCurrent());
+    }
+}

--- a/server/src/test/java/com/vaadin/tests/server/ClassesSerializableTest.java
+++ b/server/src/test/java/com/vaadin/tests/server/ClassesSerializableTest.java
@@ -45,6 +45,7 @@ public class ClassesSerializableTest {
             "com\\.vaadin\\.server\\.VaadinPortlet", //
             "com\\.vaadin\\.server\\.MockServletConfig", //
             "com\\.vaadin\\.server\\.MockServletContext", //
+            "com\\.vaadin\\.server\\.MockVaadinServletService", //
             "com\\.vaadin\\.server\\.Constants", //
             "com\\.vaadin\\.server\\.VaadinServiceClassLoaderUtil", //
             "com\\.vaadin\\.server\\.VaadinServiceClassLoaderUtil\\$GetClassLoaderPrivilegedAction", //


### PR DESCRIPTION
Adopted from https://github.com/vaadin/flow/pull/8567

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12201)
<!-- Reviewable:end -->
