### PR TITLE
fix: Make it possible to add and remove shortcut listener in compatib…

### DIFF
--- a/uitest/src/main/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcut.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcut.java
@@ -5,6 +5,7 @@ import com.vaadin.event.ShortcutListener;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.shared.Registration;
 import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.Notification;
 import com.vaadin.v7.ui.TextField;
@@ -17,11 +18,12 @@ public class CompatibilityTextFieldShortcut extends AbstractTestUI {
     @Override
     protected void setup(VaadinRequest request) {
         TextField textField = new TextField("F8 shortcut when focused");
-        ShortcutListener c = new ShortcutListener("ShortcutForMAMedRemarks", ShortcutAction.KeyCode.F8, null) {
+        ShortcutListener c = new ShortcutListener("ShortcutForMAMedRemarks",
+                ShortcutAction.KeyCode.F8, null) {
 
             @Override
             public void handleAction(Object sender, Object target) {
-                Notification.show("Received F8: "+textField.getValue());
+                Notification.show("Received F8: " + textField.getValue());
             }
         };
 
@@ -36,7 +38,12 @@ public class CompatibilityTextFieldShortcut extends AbstractTestUI {
             listenerRegistration.remove();
         });
 
-        Label label = new Label("F8 will have an effect only if the following component is focused.");
+        Label label = new Label(
+                "F8 will have an effect only if the following component is focused.");
+        Button button = new Button("focus");
+        button.addClickListener(event -> {
+            textField.focus();
+        });
         addComponents(label, textField);
     }
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcut.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcut.java
@@ -1,0 +1,41 @@
+package com.vaadin.tests.components.textfield;
+
+import com.vaadin.event.ShortcutAction;
+import com.vaadin.event.ShortcutListener;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.shared.Registration;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.Notification;
+import com.vaadin.v7.ui.TextField;
+
+@SuppressWarnings("deprecation")
+public class CompatibilityTextFieldShortcut extends AbstractTestUI {
+
+    Registration listenerRegistration;
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        TextField textField = new TextField("F8 shortcut when focused");
+        ShortcutListener c = new ShortcutListener("ShortcutForMAMedRemarks", ShortcutAction.KeyCode.F8, null) {
+
+            @Override
+            public void handleAction(Object sender, Object target) {
+                Notification.show("Received F8: "+textField.getValue());
+            }
+        };
+
+        textField.addFocusListener(e -> {
+            System.out.println("Focused");
+            listenerRegistration = textField.addShortcutListener(c);
+        });
+
+        textField.addBlurListener(e -> {
+            System.out.println("Blurred");
+            listenerRegistration.remove();
+        });
+
+        Label label = new Label("F8 will have an effect only if the following component is focused.");
+        addComponents(label, textField);
+    }
+}

--- a/uitest/src/main/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcut.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcut.java
@@ -26,12 +26,13 @@ public class CompatibilityTextFieldShortcut extends AbstractTestUI {
         };
 
         textField.addFocusListener(e -> {
-            System.out.println("Focused");
             listenerRegistration = textField.addShortcutListener(c);
+            Label label = new Label("Focused");
+            label.addStyleName("focus-label");
+            addComponent(label);
         });
 
         textField.addBlurListener(e -> {
-            System.out.println("Blurred");
             listenerRegistration.remove();
         });
 

--- a/uitest/src/main/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcut.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcut.java
@@ -44,6 +44,6 @@ public class CompatibilityTextFieldShortcut extends AbstractTestUI {
         button.addClickListener(event -> {
             textField.focus();
         });
-        addComponents(label, textField);
+        addComponents(label, textField, button);
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
@@ -1,0 +1,34 @@
+package com.vaadin.tests.components.textfield;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.testbench.elements.NotificationElement;
+import com.vaadin.testbench.elements.TextFieldElement;
+import com.vaadin.tests.tb3.SingleBrowserTest;
+
+public class CompatibilityTextFieldShortcutTest extends SingleBrowserTest {
+
+    private static final String TEXTFIELD_VALUE = "input";
+    private static final String NOTIFICATION = "Received F8: "+TEXTFIELD_VALUE;
+
+    @Test
+    public void focusAndPressF8() {
+        openTestURL();
+
+        TextFieldElement textField = $(TextFieldElement.class).first();
+        textField.focus();
+        textField.setValue(TEXTFIELD_VALUE);
+
+        WebElement textFieldText = textField.findElement(By.tagName("input"));
+
+        textFieldText.sendKeys(Keys.F8);
+
+        assertEquals(NOTIFICATION,
+                $(NotificationElement.class).first().getCaption());
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.testbench.elements.ButtonElement;
 import com.vaadin.testbench.elements.NotificationElement;
 import com.vaadin.testbench.elements.TextFieldElement;
 import com.vaadin.tests.tb3.SingleBrowserTest;
@@ -14,7 +15,8 @@ import com.vaadin.tests.tb3.SingleBrowserTest;
 public class CompatibilityTextFieldShortcutTest extends SingleBrowserTest {
 
     private static final String TEXTFIELD_VALUE = "input";
-    private static final String NOTIFICATION = "Received F8: "+TEXTFIELD_VALUE;
+    private static final String NOTIFICATION = "Received F8: "
+            + TEXTFIELD_VALUE;
 
     @Test
     public void focusAndPressF8() {
@@ -22,8 +24,8 @@ public class CompatibilityTextFieldShortcutTest extends SingleBrowserTest {
 
         TextFieldElement textField = $(TextFieldElement.class).first();
         WebElement textFieldText = textField.findElement(By.tagName("input"));
-        textField.focus();
-        
+        $(ButtonElement.class).first().click();
+
         waitForElementVisible(By.className("focus-label"));
         textField.setValue(TEXTFIELD_VALUE);
 
@@ -33,4 +35,3 @@ public class CompatibilityTextFieldShortcutTest extends SingleBrowserTest {
                 $(NotificationElement.class).first().getCaption());
     }
 }
-

--- a/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
@@ -21,7 +21,7 @@ public class CompatibilityTextFieldShortcutTest extends SingleBrowserTest {
     public void focusAndPressF8() {
         openTestURL();
 
-        WebElement textFieldText = findElement(By.className("input"));
+        WebElement textFieldText = findElement(By.tagName("input"));
         $(ButtonElement.class).first().click();
 
         waitForElementVisible(By.className("focus-label"));

--- a/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
@@ -9,7 +9,6 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.testbench.elements.ButtonElement;
 import com.vaadin.testbench.elements.NotificationElement;
-import com.vaadin.testbench.elements.TextFieldElement;
 import com.vaadin.tests.tb3.SingleBrowserTest;
 
 public class CompatibilityTextFieldShortcutTest extends SingleBrowserTest {
@@ -22,12 +21,11 @@ public class CompatibilityTextFieldShortcutTest extends SingleBrowserTest {
     public void focusAndPressF8() {
         openTestURL();
 
-        TextFieldElement textField = $(TextFieldElement.class).first();
-        WebElement textFieldText = textField.findElement(By.tagName("input"));
+        WebElement textFieldText = findElement(By.className("input"));
         $(ButtonElement.class).first().click();
 
         waitForElementVisible(By.className("focus-label"));
-        textField.setValue(TEXTFIELD_VALUE);
+        textFieldText.sendKeys(TEXTFIELD_VALUE);
 
         textFieldText.sendKeys(Keys.F8);
 

--- a/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
@@ -21,10 +21,9 @@ public class CompatibilityTextFieldShortcutTest extends SingleBrowserTest {
         openTestURL();
 
         TextFieldElement textField = $(TextFieldElement.class).first();
-        textField.focus();
-        textField.setValue(TEXTFIELD_VALUE);
-
         WebElement textFieldText = textField.findElement(By.tagName("input"));
+        textFieldText.click();
+        textField.setValue(TEXTFIELD_VALUE);
 
         textFieldText.sendKeys(Keys.F8);
 

--- a/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/textfield/CompatibilityTextFieldShortcutTest.java
@@ -22,7 +22,9 @@ public class CompatibilityTextFieldShortcutTest extends SingleBrowserTest {
 
         TextFieldElement textField = $(TextFieldElement.class).first();
         WebElement textFieldText = textField.findElement(By.tagName("input"));
-        textFieldText.click();
+        textField.focus();
+        
+        waitForElementVisible(By.className("focus-label"));
         textField.setValue(TEXTFIELD_VALUE);
 
         textFieldText.sendKeys(Keys.F8);
@@ -31,3 +33,4 @@ public class CompatibilityTextFieldShortcutTest extends SingleBrowserTest {
                 $(NotificationElement.class).first().getCaption());
     }
 }
+


### PR DESCRIPTION
…ility TextField

There was regression due earlier bugfix https://github.com/vaadin/framework/pull/11871

Or more precisely the fix was not complete.

There was special handling of TextField and TextArea in Vaadin 7, which actually have functioning flush method in their connector

https://github.com/vaadin/framework/blob/7.7/client/src/main/java/com/vaadin/client/ui/ShortcutActionHandler.java#L161

This patch re-indroduces the special handling without of need of re-introducing BeforeShortcutActionListener mechanism.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12203)
<!-- Reviewable:end -->
