### PR TITLE
Remove whitespace-maven-plugin and formatter-maven-plugin.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,8 +14,6 @@ Unless the issue is specific to a single version of the Framework, you should al
 
 In your repo, make a new branch from `master`. Make your code changes in that branch, and once you're done make a pull request to the `vaadin/framework` branch `master`.
 
-The `vaadin/framework` project uses `formatter-maven-plugin` to format the code. It will be executed as part of the Maven build. Make sure to run `mvn compile` before making the commit.
-
 We recommend making sure that the "Allow edits from maintainers" checkbox on the pull request page is checked. This allows us to commit minor fixes, like correcting typos, without bothering you.
 
 ### Getting feedback and responding to it

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -119,7 +119,6 @@ After that is done, you should have 9 of 28 save actions activated and listed as
 Run <code>install</code> maven goal for the project root to get started.
 In Eclipse this is done by right-clicking on the project root in Project Explorer and choosing *Run As* -> *Maven Build...*. If you choose to skip tests you may need to run the <code>install</code> maven goal for `vaadin-uitest` project separately.
 * Note that the first compilation takes a while to finish as Maven downloads dependencies used in the projects.
-* In some Windows environments the compilation doesn't respect the `core.autocrlf=false` and the workspace preferences listed in the previous section, and running <code>install</code> converts all line endings from six core projects (root, `vaadin-client`, `vaadin-server`,  `vaadin-shared`, `vaadin-testbench-api`, `vaadin-uitest`) to Windows-style. As a quick-and-dirty workaround you can change the line endings back through *File* -> *Convert Line Delimiters To* -> *Unix* and comment out references to plugins `net.revelc.code.formatter` and `com.github.dantwining.whitespace-maven-plugin` from each affected module's pom.xml (root project references them twice) to prevent it from happening again. *Do not* include those changes or any files with Windows-style line endings in any pull request. Because you consequently lose the formatting benefits of those plugins, you also need to be more careful about not including irrelevant formatting changes in your commits.
 
 Now the project should compile without further configuration.
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -47,15 +47,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.github.dantwining.whitespace-maven-plugin</groupId>
-                <artifactId>whitespace-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <!-- Copy .java files to package -->

--- a/pom.xml
+++ b/pom.xml
@@ -459,38 +459,6 @@
                     <version>${vaadin.plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>net.revelc.code.formatter</groupId>
-                    <artifactId>formatter-maven-plugin</artifactId>
-                    <version>2.7.2</version>
-                    <configuration>
-                        <configFile>${project.basedir}/../eclipse/VaadinJavaConventions.xml</configFile>
-                        <skipJsFormatting>true</skipJsFormatting>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>format-source</id>
-                            <goals>
-                                <goal>format</goal>
-                            </goals>
-                            <phase>process-sources</phase>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>com.github.dantwining.whitespace-maven-plugin</groupId>
-                    <artifactId>whitespace-maven-plugin</artifactId>
-                    <version>1.0.4</version>
-                    <executions>
-                        <execution>
-                            <id>trim-trailing-spaces-source</id>
-                            <goals>
-                                <goal>trim</goal>
-                            </goals>
-                            <phase>process-sources</phase>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>2.17</version>
@@ -537,44 +505,6 @@
                                         </versionRange>
                                         <goals>
                                             <goal>run</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore></ignore>
-                                    </action>
-                                </pluginExecution>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>
-                                            net.revelc.code.formatter
-                                        </groupId>
-                                        <artifactId>
-                                            formatter-maven-plugin
-                                        </artifactId>
-                                        <versionRange>
-                                            [2.7.2,)
-                                        </versionRange>
-                                        <goals>
-                                            <goal>format</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore></ignore>
-                                    </action>
-                                </pluginExecution>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>
-                                            com.github.dantwining.whitespace-maven-plugin
-                                        </groupId>
-                                        <artifactId>
-                                            whitespace-maven-plugin
-                                        </artifactId>
-                                        <versionRange>
-                                            [1.0.4,)
-                                        </versionRange>
-                                        <goals>
-                                            <goal>trim</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -140,14 +140,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.github.dantwining.whitespace-maven-plugin</groupId>
-                <artifactId>whitespace-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -37,15 +37,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.github.dantwining.whitespace-maven-plugin</groupId>
-                <artifactId>whitespace-maven-plugin</artifactId>
-            </plugin>
-
             <!-- Generated Version.java -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/testbench-api/pom.xml
+++ b/testbench-api/pom.xml
@@ -36,10 +36,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <executions>

--- a/uitest/pom.xml
+++ b/uitest/pom.xml
@@ -238,15 +238,6 @@
 
         <plugins>
             <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.github.dantwining.whitespace-maven-plugin</groupId>
-                <artifactId>whitespace-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
- These plugins cause significant problems for many Windows developers,
and since most active maintainers are currently included in that group,
the plugins have been deemed more trouble than they are worth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12213)
<!-- Reviewable:end -->
