### PR TITLE
Fix updating Escalator's physical row index.

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Escalator.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Escalator.java
@@ -4834,13 +4834,16 @@ public class Escalator extends Widget
              * Start at -1 to include a spacer that is rendered above the
              * viewport, but its parent row is still not shown
              */
+            int addedSpacers = 0;
             for (int i = -1; i < visualRowOrder.size(); i++) {
                 SpacerContainer.SpacerImpl spacer = spacers
                         .remove(Integer.valueOf(getTopRowLogicalIndex() + i));
 
                 if (spacer != null) {
-                    orderedBodyRows.add(i + 1, spacer.getRootElement());
+                    orderedBodyRows.add(i + 1 + addedSpacers,
+                            spacer.getRootElement());
                     spacer.show();
+                    ++addedSpacers;
                 }
             }
             /*


### PR DESCRIPTION
- Physical index should take into account that more than one row can
have a spacer. Physical index has no practical effect on how Grid looks
like or behaves, since Escalator by design operates independently of it
and the visual positioning of elements is based on the logical and
visual indices. Physical index only affects the order of elements
within the DOM tree, where a mismatch can cause confusion during
debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12232)
<!-- Reviewable:end -->
