### PR TITLE
fix: Update regexp pattern of legacy EmailValidator

### DIFF
--- a/compatibility-server/src/main/java/com/vaadin/v7/data/validator/EmailValidator.java
+++ b/compatibility-server/src/main/java/com/vaadin/v7/data/validator/EmailValidator.java
@@ -35,6 +35,11 @@ package com.vaadin.v7.data.validator;
 @Deprecated
 public class EmailValidator extends RegexpValidator {
 
+    private static final String PATTERN = "^" + "([a-zA-Z0-9_\\.\\-+])+" // local
+            + "@" + "[a-zA-Z0-9-.]+" // domain
+            + "\\." + "[a-zA-Z0-9-]{2,}" // tld
+            + "$";
+
     /**
      * Creates a validator for checking that a string is a syntactically valid
      * e-mail address.
@@ -43,7 +48,6 @@ public class EmailValidator extends RegexpValidator {
      *            the message to display in case the value does not validate.
      */
     public EmailValidator(String errorMessage) {
-        super("^([a-zA-Z0-9_\\.\\-+])+@(([a-zA-Z0-9-])+\\.)+([a-zA-Z0-9]{2,4})+$",
-                true, errorMessage);
+        super(PATTERN, true, errorMessage);
     }
 }

--- a/compatibility-server/src/test/java/com/vaadin/v7/tests/data/validator/EmailValidatorTest.java
+++ b/compatibility-server/src/test/java/com/vaadin/v7/tests/data/validator/EmailValidatorTest.java
@@ -33,6 +33,6 @@ public class EmailValidatorTest {
 
     @Test
     public void testEmailValidatorWithBadInput() {
-        Assert.assertFalse(validator.isValid("a@a.m5qRt8zLxQG4mMeu9yKZm5qRt8zLxQG4mMeu9yKZm5qRt8zLxQG4mMeu9yKZ&"));
+        assertFalse(validator.isValid("a@a.m5qRt8zLxQG4mMeu9yKZm5qRt8zLxQG4mMeu9yKZm5qRt8zLxQG4mMeu9yKZ&"));
     }
 }

--- a/compatibility-server/src/test/java/com/vaadin/v7/tests/data/validator/EmailValidatorTest.java
+++ b/compatibility-server/src/test/java/com/vaadin/v7/tests/data/validator/EmailValidatorTest.java
@@ -30,4 +30,9 @@ public class EmailValidatorTest {
     public void testEmailValidatorWithOkEmail() {
         assertTrue(validator.isValid("my.name@email.com"));
     }
+
+    @Test
+    public void testEmailValidatorWithBadInput() {
+        Assert.assertFalse(validator.isValid("a@a.m5qRt8zLxQG4mMeu9yKZm5qRt8zLxQG4mMeu9yKZm5qRt8zLxQG4mMeu9yKZ&"));
+    }
 }

--- a/uitest/src/test/java/com/vaadin/tests/VerifyBrowserVersionTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/VerifyBrowserVersionTest.java
@@ -25,7 +25,7 @@ public class VerifyBrowserVersionTest extends MultiBrowserTest {
             // Chrome version does not necessarily match the desired version
             // because of auto updates...
             browserIdentifier = getExpectedUserAgentString(
-                    getDesiredCapabilities()) + "87";
+                    getDesiredCapabilities()) + "89";
         } else if (BrowserUtil.isFirefox(getDesiredCapabilities())) {
             browserIdentifier = getExpectedUserAgentString(
                     getDesiredCapabilities()) + "81";


### PR DESCRIPTION
Fixes: https://github.com/vaadin/framework/issues/12240

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12241)
<!-- Reviewable:end -->
