### PR TITLE
Fix Window dragging on touch screen.

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/VWindow.java
+++ b/client/src/main/java/com/vaadin/client/ui/VWindow.java
@@ -1043,7 +1043,7 @@ public class VWindow extends VOverlay implements ShortcutActionHandlerOwner,
 
                     headerDragPending = event;
                     bubble = false;
-                } else if (type == Event.ONMOUSEMOVE
+                } else if ((type == Event.ONMOUSEMOVE || type == Event.ONTOUCHMOVE)
                         && headerDragPending != null) {
                     // ie won't work unless this is set here
                     dragging = true;
@@ -1051,7 +1051,7 @@ public class VWindow extends VOverlay implements ShortcutActionHandlerOwner,
                     onDragEvent(event);
                     headerDragPending = null;
                     bubble = false;
-                } else if (type != Event.ONMOUSEMOVE) {
+                } else if (type != Event.ONMOUSEMOVE && type != Event.ONTOUCHMOVE) {
                     // The event can propagate to the parent in case it is a
                     // mouse move event. This is needed for tooltips to work in
                     // header and footer, see Ticket #19073


### PR DESCRIPTION
- Added check for touch move event in order to allow the same flow for
both mouse and touch events when dragging a Window by its header.
- Can be tested with SubwindowDraggability class.

Fixes #12257

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12260)
<!-- Reviewable:end -->
