### PR TITLE
Small updates to servlet container test setup.

### DIFF
--- a/test/servlet-containers/generic-ui/src/main/java/com/vaadin/tests/integration/ServletIntegrationUI.java
+++ b/test/servlet-containers/generic-ui/src/main/java/com/vaadin/tests/integration/ServletIntegrationUI.java
@@ -1,5 +1,7 @@
 package com.vaadin.tests.integration;
 
+import java.io.Serializable;
+
 import com.vaadin.annotations.DesignRoot;
 import com.vaadin.annotations.Widgetset;
 import com.vaadin.server.ClassResource;
@@ -15,7 +17,7 @@ import com.vaadin.ui.declarative.Design;
 @Widgetset("com.vaadin.DefaultWidgetSet")
 public class ServletIntegrationUI extends UI {
 
-    public static class Country {
+    public static class Country implements Serializable {
         private final String name;
         private final String id;
         private final Resource icon;

--- a/test/servlet-containers/pom.xml
+++ b/test/servlet-containers/pom.xml
@@ -110,7 +110,8 @@
                 <!-- Generic cargo plugin configuration. Define container to use in submodule. -->
                 <plugin>
                     <groupId>org.codehaus.cargo</groupId>
-                    <artifactId>cargo-maven2-plugin</artifactId>
+                    <artifactId>cargo-maven3-plugin</artifactId>
+                    <version>1.9.4</version>
                     <configuration>
                         <configuration>
                             <type>standalone</type>
@@ -194,6 +195,7 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
                     <configuration>
+                        <supportedPackagings>pom,jar,war</supportedPackagings>
                         <webApp>
                             <contextPath>${context.path}</contextPath>
                         </webApp>

--- a/test/servlet-containers/tomcat7/pom.xml
+++ b/test/servlet-containers/tomcat7/pom.xml
@@ -36,7 +36,7 @@
             <!-- Server configuration -->
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
-                <artifactId>cargo-maven2-plugin</artifactId>
+                <artifactId>cargo-maven3-plugin</artifactId>
                 <configuration>
                     <container>
                         <containerId>tomcat7x</containerId>

--- a/test/servlet-containers/tomcat80/pom.xml
+++ b/test/servlet-containers/tomcat80/pom.xml
@@ -36,7 +36,7 @@
             <!-- Server configuration -->
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
-                <artifactId>cargo-maven2-plugin</artifactId>
+                <artifactId>cargo-maven3-plugin</artifactId>
                 <configuration>
                     <container>
                         <containerId>tomcat8x</containerId>

--- a/test/servlet-containers/tomcat85/pom.xml
+++ b/test/servlet-containers/tomcat85/pom.xml
@@ -36,7 +36,7 @@
             <!-- Server configuration -->
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
-                <artifactId>cargo-maven2-plugin</artifactId>
+                <artifactId>cargo-maven3-plugin</artifactId>
                 <configuration>
                     <container>
                         <containerId>tomcat8x</containerId>

--- a/test/servlet-containers/tomcat9/pom.xml
+++ b/test/servlet-containers/tomcat9/pom.xml
@@ -36,7 +36,7 @@
             <!-- Server configuration -->
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
-                <artifactId>cargo-maven2-plugin</artifactId>
+                <artifactId>cargo-maven3-plugin</artifactId>
                 <configuration>
                     <container>
                         <containerId>tomcat9x</containerId>


### PR DESCRIPTION
- Upgraded to use cargo-maven3-plugin since cargo-maven2-plugin is now
EOL.
- Defined supported packagings as the current jetty-maven-plugin default
only covers war.
- Changed a test pojo to implement Serializable in order to prevent an
error in cargo-maven3-plugin stop-container phase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12318)
<!-- Reviewable:end -->
