### PR TITLE
Bump jetty-servlets from 9.4.38.v20210224 to 9.4.41.v20210516 (#12322)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <!-- Dependency unpack directory -->
         <dependency.unpack.directory>${project.build.directory}/dependency-unpack</dependency.unpack.directory>
  
-        <jetty.version>9.4.38.v20210224</jetty.version>
+        <jetty.version>9.4.41.v20210516</jetty.version>
 
         <!-- Sonar properties -->
         <sonar.java.source>8</sonar.java.source>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework/12336)
<!-- Reviewable:end -->
