### PR TITLE
Checkstyle fixes

### DIFF
--- a/client/src/main/java/com/vaadin/client/connectors/grid/ColumnConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/ColumnConnector.java
@@ -38,6 +38,9 @@ import elemental.json.JsonValue;
 @Connect(com.vaadin.ui.Grid.Column.class)
 public class ColumnConnector extends AbstractExtensionConnector {
 
+    /**
+     * Class for representing a custom column.
+     */
     public abstract static class CustomColumn
             extends Column<Object, JsonObject> {
 
@@ -48,6 +51,11 @@ public class ColumnConnector extends AbstractExtensionConnector {
             this.connectorId = connectorId;
         }
 
+        /**
+         * Returns the id for the corresponding connector.
+         *
+         * @return the id for the connector
+         */
         public String getConnectorId() {
             return connectorId;
         }

--- a/client/src/main/java/com/vaadin/client/connectors/grid/ComponentRendererConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/ComponentRendererConnector.java
@@ -17,7 +17,6 @@ package com.vaadin.client.connectors.grid;
 
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.logging.Logger;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -28,7 +27,6 @@ import com.vaadin.client.ConnectorMap;
 import com.vaadin.client.renderers.Renderer;
 import com.vaadin.client.renderers.WidgetRenderer;
 import com.vaadin.client.ui.AbstractComponentConnector;
-import com.vaadin.client.ui.AbstractConnector;
 import com.vaadin.client.widget.grid.RendererCellReference;
 import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.ui.grid.renderers.ComponentRendererState;
@@ -119,9 +117,9 @@ public class ComponentRendererConnector
     }
 
     private void unregisterHierarchyHandler() {
-        if (this.handlerRegistration != null) {
-            this.handlerRegistration.removeHandler();
-            this.handlerRegistration = null;
+        if (handlerRegistration != null) {
+            handlerRegistration.removeHandler();
+            handlerRegistration = null;
         }
     }
 

--- a/client/src/main/java/com/vaadin/client/connectors/grid/EditorConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/EditorConnector.java
@@ -47,9 +47,6 @@ import elemental.json.JsonObject;
 @Connect(EditorImpl.class)
 public class EditorConnector extends AbstractExtensionConnector {
 
-    private Integer currentEditedRow = null;
-    private boolean waitingForAvailableData = false;
-
     /**
      * EditorHandler for communicating with the server-side implementation.
      */
@@ -132,7 +129,6 @@ public class EditorConnector extends AbstractExtensionConnector {
                 // a confirmation from the server
                 rpc.cancel(afterBeingSaved);
             }
-            currentEditedRow = null;
         }
 
         @Override

--- a/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/GridConnector.java
@@ -497,7 +497,7 @@ public class GridConnector extends AbstractListingConnector
     }
 
     private void updateStaticRow(RowState rowState,
-            Grid.StaticSection.StaticRow row) {
+            Grid.StaticSection.StaticRow<?> row) {
         rowState.cells
                 .forEach((columnId, cellState) -> updateStaticCellFromState(
                         row.getCell(getColumn(columnId)), cellState));
@@ -794,11 +794,11 @@ public class GridConnector extends AbstractListingConnector
         return null;
     }
 
-    private TooltipInfo getHeaderFooterTooltip(CellReference cell) {
+    private TooltipInfo getHeaderFooterTooltip(CellReference<?> cell) {
         Section section = Section.BODY;
         if (cell instanceof EventCellReference) {
             // Header or footer
-            section = ((EventCellReference) cell).getSection();
+            section = ((EventCellReference<?>) cell).getSection();
         }
         StaticCell staticCell = null;
         if (section == Section.HEADER) {

--- a/client/src/main/java/com/vaadin/client/connectors/grid/TreeRendererConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/TreeRendererConnector.java
@@ -33,6 +33,7 @@ import elemental.json.JsonObject;
  * @author Vaadin Ltd
  * @since 8.1
  */
+@SuppressWarnings("deprecation")
 @Connect(TreeRenderer.class)
 public class TreeRendererConnector
         extends AbstractGridRendererConnector<String> {

--- a/client/src/main/java/com/vaadin/client/connectors/grid/UnsafeHtmlRendererConnector.java
+++ b/client/src/main/java/com/vaadin/client/connectors/grid/UnsafeHtmlRendererConnector.java
@@ -30,6 +30,9 @@ import com.vaadin.shared.ui.grid.renderers.HtmlRendererState;
 public class UnsafeHtmlRendererConnector
         extends AbstractGridRendererConnector<String> {
 
+    /**
+     * Constructs a renderer for unsafe html content.
+     */
     public static class UnsafeHtmlRenderer implements Renderer<String> {
         @Override
         public void render(RendererCellReference cell, String data) {

--- a/client/src/main/java/com/vaadin/client/renderers/ButtonRenderer.java
+++ b/client/src/main/java/com/vaadin/client/renderers/ButtonRenderer.java
@@ -39,10 +39,23 @@ public class ButtonRenderer extends ClickableRenderer<String, Button> {
         return b;
     }
 
+    /**
+     * Sets whether HTML content is allowed.
+     *
+     * @param htmlContentAllowed
+     *            {@code true} if HTML content allowed, {@code false} if
+     *            contents should be rendered as plain text
+     */
     public void setHtmlContentAllowed(boolean htmlContentAllowed) {
         this.htmlContentAllowed = htmlContentAllowed;
     }
 
+    /**
+     * Returns whether HTML content is allowed.
+     *
+     * @return {@code true} if HTML content allowed, {@code false} if contents
+     *         are rendered as plain text
+     */
     public boolean isHtmlContentAllowed() {
         return htmlContentAllowed;
     }

--- a/client/src/main/java/com/vaadin/client/renderers/ClickableRenderer.java
+++ b/client/src/main/java/com/vaadin/client/renderers/ClickableRenderer.java
@@ -211,6 +211,8 @@ public abstract class ClickableRenderer<T, W extends Widget>
      *
      * @param handler
      *            the click handler to be added
+     * @return the handler registration, can be stored in order to remove the
+     *         handler later
      */
     public HandlerRegistration addClickHandler(
             RendererClickHandler<?> handler) {

--- a/client/src/main/java/com/vaadin/client/renderers/ComplexRenderer.java
+++ b/client/src/main/java/com/vaadin/client/renderers/ComplexRenderer.java
@@ -37,6 +37,9 @@ import com.vaadin.client.widget.grid.RendererCellReference;
  * Also provides a helper method for hiding the cell contents by overriding
  * {@link #setContentVisible(FlyweightCell, boolean)}
  *
+ * @param <T>
+ *            the column data type
+ *
  * @since 7.4.0
  * @author Vaadin Ltd
  */

--- a/client/src/main/java/com/vaadin/client/renderers/DateRenderer.java
+++ b/client/src/main/java/com/vaadin/client/renderers/DateRenderer.java
@@ -37,14 +37,29 @@ public class DateRenderer implements Renderer<Date> {
     private TimeZone timeZone = TimeZone
             .createTimeZone(new Date().getTimezoneOffset());
 
+    /**
+     * Constructs a renderer for displaying date data.
+     */
     public DateRenderer() {
         this(PredefinedFormat.DATE_TIME_SHORT);
     }
 
+    /**
+     * Constructs a renderer for displaying date data.
+     *
+     * @param format
+     *            the required display format
+     */
     public DateRenderer(PredefinedFormat format) {
         this(DateTimeFormat.getFormat(format));
     }
 
+    /**
+     * Constructs a renderer for displaying date data.
+     *
+     * @param format
+     *            the required display format
+     */
     public DateRenderer(DateTimeFormat format) {
         setFormat(format);
     }

--- a/client/src/main/java/com/vaadin/client/renderers/HierarchyRenderer.java
+++ b/client/src/main/java/com/vaadin/client/renderers/HierarchyRenderer.java
@@ -91,6 +91,7 @@ public class HierarchyRenderer extends ClickableRenderer<Object, Widget> {
     private static final String CLASS_EXPANDED = "expanded";
     private static final String CLASS_DEPTH = "depth-";
 
+    @SuppressWarnings("rawtypes")
     private Renderer innerRenderer;
 
     /**
@@ -148,6 +149,7 @@ public class HierarchyRenderer extends ClickableRenderer<Object, Widget> {
         return new HierarchyItem(nodeStyleName);
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public void render(RendererCellReference cell, Object data, Widget widget) {
 
@@ -234,6 +236,7 @@ public class HierarchyRenderer extends ClickableRenderer<Object, Widget> {
      * @param innerRenderer
      *            Renderer to be wrapped.
      */
+    @SuppressWarnings("rawtypes")
     public void setInnerRenderer(Renderer innerRenderer) {
         this.innerRenderer = innerRenderer;
     }
@@ -243,12 +246,18 @@ public class HierarchyRenderer extends ClickableRenderer<Object, Widget> {
      *
      * @return Wrapped renderer.
      */
+    @SuppressWarnings("rawtypes")
     public Renderer getInnerRenderer() {
         return innerRenderer;
     }
 
     /**
      * Decides whether the element was rendered by {@link HierarchyRenderer}.
+     *
+     * @param element
+     *            the element to check
+     * @return {@code true} if the element was rendered by a HierarchyRenderer,
+     *         {@code false} otherwise.
      */
     public static boolean isElementInHierarchyWidget(Element element) {
         Widget w = WidgetUtil.findWidget(element);

--- a/client/src/main/java/com/vaadin/client/renderers/ImageRenderer.java
+++ b/client/src/main/java/com/vaadin/client/renderers/ImageRenderer.java
@@ -29,6 +29,7 @@ import com.vaadin.client.widget.grid.RendererCellReference;
  */
 public class ImageRenderer extends ClickableRenderer<String, Image> {
 
+    /** Placeholder URL for the image. Used if URL data is set to null. */
     public static final String TRANSPARENT_GIF_1PX = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
     @Override

--- a/client/src/main/java/com/vaadin/client/renderers/NumberRenderer.java
+++ b/client/src/main/java/com/vaadin/client/renderers/NumberRenderer.java
@@ -30,10 +30,19 @@ public class NumberRenderer implements Renderer<Number> {
 
     private NumberFormat format;
 
+    /**
+     * Constructs a renderer for presenting number data.
+     */
     public NumberRenderer() {
         this(NumberFormat.getDecimalFormat());
     }
 
+    /**
+     * Constructs a renderer for presenting number data.
+     *
+     * @param format
+     *            the format to use when the number is displayed
+     */
     public NumberRenderer(NumberFormat format) {
         setFormat(format);
     }

--- a/client/src/main/java/com/vaadin/client/renderers/WidgetRenderer.java
+++ b/client/src/main/java/com/vaadin/client/renderers/WidgetRenderer.java
@@ -26,7 +26,7 @@ import com.vaadin.client.widget.grid.RendererCellReference;
  * @since 7.4
  * @author Vaadin Ltd
  * @param <T>
- *            the row data type
+ *            the column data type
  * @param <W>
  *            the Widget type
  */
@@ -96,6 +96,8 @@ public abstract class WidgetRenderer<T, W extends Widget>
      * is not an instance of the given class. Cannot be called for cells that do
      * not contain a widget.
      *
+     * @param <W>
+     *            the Widget type
      * @param e
      *            the element inside to find a widget
      * @param klass

--- a/client/src/main/java/com/vaadin/client/widget/escalator/FlyweightCell.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/FlyweightCell.java
@@ -38,6 +38,7 @@ import com.vaadin.client.widgets.Escalator;
  * @author Vaadin Ltd
  */
 public class FlyweightCell {
+    /** The column span property name. */
     public static final String COLSPAN_ATTR = "colSpan";
 
     private final int column;
@@ -46,6 +47,17 @@ public class FlyweightCell {
     private TableCellElement element = null;
     private CellIterator currentIterator = null;
 
+    /**
+     * Creates a cell representation that follows the
+     * <code>Flyweight</code>-pattern.
+     *
+     * @param row
+     *            representation of the row that contains the cell
+     * @param column
+     *            the column index of the cell
+     *
+     * @see FlyweightCell
+     */
     public FlyweightCell(final FlyweightRow row, final int column) {
         this.row = row;
         this.column = column;
@@ -53,6 +65,8 @@ public class FlyweightCell {
 
     /**
      * Returns the row index of the cell.
+     *
+     * @return the row index
      */
     public int getRow() {
         assertSetup();
@@ -61,6 +75,8 @@ public class FlyweightCell {
 
     /**
      * Returns the column index of the cell.
+     *
+     * @return the column index
      */
     public int getColumn() {
         assertSetup();
@@ -70,6 +86,8 @@ public class FlyweightCell {
     /**
      * Returns the element of the cell. Can be either a <code>TD</code> element
      * or a <code>TH</code> element.
+     *
+     * @return the element
      */
     public TableCellElement getElement() {
         assertSetup();
@@ -78,6 +96,8 @@ public class FlyweightCell {
 
     /**
      * Return the colspan attribute of the element of the cell.
+     *
+     * @return the colspan attribute
      */
     public int getColSpan() {
         assertSetup();
@@ -148,6 +168,12 @@ public class FlyweightCell {
                 + "inappropriately.";
     }
 
+    /**
+     * Set the colspan attribute for the element of the cell.
+     *
+     * @param numberOfCells
+     *            spanned cell count, must be at least 1
+     */
     public void setColSpan(final int numberOfCells) {
         if (numberOfCells < 1) {
             throw new IllegalArgumentException(

--- a/client/src/main/java/com/vaadin/client/widget/escalator/FlyweightRow.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/FlyweightRow.java
@@ -144,6 +144,18 @@ public class FlyweightRow implements Row {
     private double[] columnWidths = null;
     private final List<FlyweightCell> cells = new ArrayList<>();
 
+    /**
+     * Configure this FlyweightRow for the current use. This method is expected
+     * to be called multiple times during the Grid's life-cycle.
+     *
+     * @param e
+     *            the root element for this row
+     * @param row
+     *            the row index
+     * @param columnWidths
+     *            widths for each column on the row
+     * @see FlyweightRow
+     */
     public void setup(final TableRowElement e, final int row,
             double[] columnWidths) {
         element = e;
@@ -186,6 +198,15 @@ public class FlyweightRow implements Row {
         return element;
     }
 
+    /**
+     * Adds cell representations (i.e. new columns) for the indicated cell range
+     * and updates the subsequent indexing.
+     *
+     * @param index
+     *            start index of the range
+     * @param numberOfColumns
+     *            length of the range
+     */
     public void addCells(final int index, final int numberOfColumns) {
         for (int i = 0; i < numberOfColumns; i++) {
             final int col = index + i;
@@ -194,6 +215,15 @@ public class FlyweightRow implements Row {
         updateRestOfCells(index + numberOfColumns);
     }
 
+    /**
+     * Removes cell representations (i.e. removed columns) from the indicated
+     * cell range and updates the subsequent indexing.
+     *
+     * @param index
+     *            start index of the range
+     * @param numberOfColumns
+     *            length of the range
+     */
     public void removeCells(final int index, final int numberOfColumns) {
         cells.subList(index, index + numberOfColumns).clear();
         updateRestOfCells(index);

--- a/client/src/main/java/com/vaadin/client/widget/escalator/ScrollbarBundle.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/ScrollbarBundle.java
@@ -111,6 +111,7 @@ public abstract class ScrollbarBundle implements DeferredWorker {
      * The orientation of the scrollbar.
      */
     public enum Direction {
+        /** Scrollbar orientation, indicated by the name. */
         VERTICAL, HORIZONTAL;
     }
 
@@ -147,8 +148,12 @@ public abstract class ScrollbarBundle implements DeferredWorker {
         void visibilityChanged(VisibilityChangeEvent event);
     }
 
+    /**
+     * Event for scrollbar visibility changes.
+     */
     public static class VisibilityChangeEvent
             extends GwtEvent<VisibilityHandler> {
+        /** Event type. */
         public static final Type<VisibilityHandler> TYPE = new Type<ScrollbarBundle.VisibilityHandler>() {
             @Override
             public String toString() {
@@ -335,8 +340,14 @@ public abstract class ScrollbarBundle implements DeferredWorker {
         }
     }
 
+    /** Root element for the scrollbar-composition. */
     protected final Element root = DOM.createDiv();
+    /**
+     * Scroll size element. The size of this element determines the number of
+     * pixels the scrollbar is able to scroll through
+     */
     protected final Element scrollSizeElement = DOM.createDiv();
+    /** Is the scrollbar "invisible" (thickness set to 0). */
     protected boolean isInvisibleScrollbar = false;
 
     private double scrollPos = 0;
@@ -362,6 +373,12 @@ public abstract class ScrollbarBundle implements DeferredWorker {
         root.setTabIndex(-1);
     }
 
+    /**
+     * Returns the width (for horizontal) or height (for vertical) css property
+     * for the scroll size element.
+     *
+     * @return the relevant size property based on orientation
+     */
     protected abstract String internalGetScrollSize();
 
     /**
@@ -495,6 +512,10 @@ public abstract class ScrollbarBundle implements DeferredWorker {
      * is hidden, so the event must be fired manually.
      * <p>
      * When IE8 support is dropped, this should really be simplified.
+     *
+     * @param enable
+     *            {@code true} if the scrollbar should be forced to be visible,
+     *            {@code false} otherwise.
      */
     protected void forceScrollbar(boolean enable) {
         if (enable) {
@@ -512,6 +533,15 @@ public abstract class ScrollbarBundle implements DeferredWorker {
         internalForceScrollbar(enable);
     }
 
+    /**
+     * Sets the overflow-x (for horizontal) or overflow-y (for vertical)
+     * property to {@code "scroll"} if enabled, or clears the property if
+     * disabled.
+     *
+     * @param enable
+     *            {@code true} if the overflow property should be set,
+     *            {@code false} otherwise.
+     */
     protected abstract void internalForceScrollbar(boolean enable);
 
     /**
@@ -523,6 +553,12 @@ public abstract class ScrollbarBundle implements DeferredWorker {
         return parseCssDimensionToPixels(internalGetOffsetSize());
     }
 
+    /**
+     * Returns the width (for horizontal) or height (for vertical) css property
+     * for the root element.
+     *
+     * @return the relevant size property based on orientation
+     */
     public abstract String internalGetOffsetSize();
 
     /**
@@ -765,6 +801,10 @@ public abstract class ScrollbarBundle implements DeferredWorker {
         return getScrollSize() - getOffsetSize() > WidgetUtil.PIXEL_EPSILON;
     }
 
+    /**
+     * Calculates and sets maximum scroll position based on the current scroll
+     * size and the scrollbar's length.
+     */
     public void recalculateMaxScrollPos() {
         double scrollSize = getScrollSize();
         double offsetSize = getOffsetSize();
@@ -804,6 +844,11 @@ public abstract class ScrollbarBundle implements DeferredWorker {
         }
     }
 
+    /**
+     * Returns the handler manager for this scrollbar bundle.
+     *
+     * @return the handler manager
+     */
     protected HandlerManager getHandlerManager() {
         if (handlerManager == null) {
             handlerManager = new HandlerManager(this);

--- a/client/src/main/java/com/vaadin/client/widget/escalator/Spacer.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/Spacer.java
@@ -35,6 +35,8 @@ public interface Spacer {
 
     /**
      * Gets the decorative element for this spacer.
+     *
+     * @return the decorative element
      */
     Element getDecoElement();
 

--- a/client/src/main/java/com/vaadin/client/widget/escalator/events/RowHeightChangedEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/events/RowHeightChangedEvent.java
@@ -31,6 +31,11 @@ public class RowHeightChangedEvent extends GwtEvent<RowHeightChangedHandler> {
      */
     public static final Type<RowHeightChangedHandler> TYPE = new Type<>();
 
+    /**
+     * Returns the associated handler type.
+     *
+     * @return the handler type
+     */
     public static final Type<RowHeightChangedHandler> getType() {
         return TYPE;
     }

--- a/client/src/main/java/com/vaadin/client/widget/escalator/events/SpacerIndexChangedEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/events/SpacerIndexChangedEvent.java
@@ -31,6 +31,11 @@ public class SpacerIndexChangedEvent
      */
     public static final Type<SpacerIndexChangedHandler> TYPE = new Type<>();
 
+    /**
+     * Returns the associated handler type.
+     *
+     * @return the handler type
+     */
     public static final Type<SpacerIndexChangedHandler> getType() {
         return TYPE;
     }

--- a/client/src/main/java/com/vaadin/client/widget/escalator/events/SpacerVisibilityChangedEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/escalator/events/SpacerVisibilityChangedEvent.java
@@ -31,6 +31,11 @@ public class SpacerVisibilityChangedEvent
      */
     public static final Type<SpacerVisibilityChangedHandler> TYPE = new Type<>();
 
+    /**
+     * Returns the associated handler type.
+     *
+     * @return the handler type
+     */
     public static final Type<SpacerVisibilityChangedHandler> getType() {
         return TYPE;
     }

--- a/client/src/main/java/com/vaadin/client/widget/grid/AutoScroller.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/AutoScroller.java
@@ -73,7 +73,11 @@ public class AutoScroller {
         void onAutoScrollReachedMax();
     }
 
+    /**
+     * Scroll direction for automatic scrolling.
+     */
     public enum ScrollAxis {
+        /** Scroll should happen to the direction indicated by the name. */
         VERTICAL, HORIZONTAL
     }
 
@@ -130,6 +134,9 @@ public class AutoScroller {
             case Event.ONTOUCHCANCEL:
                 // TODO investigate if this works as desired
                 stop();
+                break;
+            default:
+                // NOP
                 break;
             }
         }
@@ -437,6 +444,9 @@ public class AutoScroller {
         case Event.ONTOUCHCANCEL:
             stop();
             break;
+        default:
+            // NOP
+            break;
         }
     };
 
@@ -606,6 +616,11 @@ public class AutoScroller {
         }
     }
 
+    /**
+     * Returns how wide the frozen columns are all counted together.
+     *
+     * @return the width of frozen columns
+     */
     public double getFrozenColumnsWidth() {
         double value = 0;
 

--- a/client/src/main/java/com/vaadin/client/widget/grid/CellReference.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/CellReference.java
@@ -38,6 +38,12 @@ public class CellReference<T> {
     private Grid.Column<?, T> column;
     private final RowReference<T> rowReference;
 
+    /**
+     * Constructs a new cell reference for the given row.
+     *
+     * @param rowReference
+     *            the row that requires a new cell
+     */
     public CellReference(RowReference<T> rowReference) {
         this.rowReference = rowReference;
     }

--- a/client/src/main/java/com/vaadin/client/widget/grid/DataAvailableEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/DataAvailableEvent.java
@@ -27,8 +27,15 @@ import com.vaadin.shared.Range;
 public class DataAvailableEvent extends GwtEvent<DataAvailableHandler> {
 
     private Range rowsAvailable;
+    /** Handler type for DataAvailableEvents. */
     public static final Type<DataAvailableHandler> TYPE = new Type<>();
 
+    /**
+     * Constructs a data availability event for the given row range.
+     *
+     * @param rowsAvailable
+     *            the range of available rows
+     */
     public DataAvailableEvent(Range rowsAvailable) {
         this.rowsAvailable = rowsAvailable;
     }

--- a/client/src/main/java/com/vaadin/client/widget/grid/DefaultEditorEventHandler.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/DefaultEditorEventHandler.java
@@ -38,15 +38,24 @@ import com.vaadin.client.widgets.Grid.EditorDomEvent;
  * The default handler for Grid editor events. Offers several overridable
  * protected methods for easier customization.
  *
+ * @param <T>
+ *            The row type of the grid. The row type is the POJO type from where
+ *            the data is retrieved into the column cells.
+ *
  * @since 7.6
  * @author Vaadin Ltd
  */
 public class DefaultEditorEventHandler<T> implements Editor.EventHandler<T> {
 
+    /** Default key code for showing the editor. */
     public static final int KEYCODE_OPEN = KeyCodes.KEY_ENTER;
+    /** Default key code for moving the editor up or down. */
     public static final int KEYCODE_MOVE_VERTICAL = KeyCodes.KEY_ENTER;
+    /** Default key code for hiding the editor. */
     public static final int KEYCODE_CLOSE = KeyCodes.KEY_ESCAPE;
+    /** Default key code for moving cursor horizontally within the editor. */
     public static final int KEYCODE_MOVE_HORIZONTAL = KeyCodes.KEY_TAB;
+    /** Default key code for triggering save in buffered mode. */
     public static final int KEYCODE_BUFFERED_SAVE = KeyCodes.KEY_ENTER;
 
     private double lastTouchEventTime = 0;
@@ -134,9 +143,12 @@ public class DefaultEditorEventHandler<T> implements Editor.EventHandler<T> {
      * Specifies the direction at which the focus should move.
      */
     public enum CursorMoveDelta {
+        /** Move focus one step to the direction indicated by name. */
         UP(-1, 0), RIGHT(0, 1), DOWN(1, 0), LEFT(0, -1);
 
+        /** Vertical change. */
         public final int rowDelta;
+        /** Horizontal change. */
         public final int colDelta;
 
         CursorMoveDelta(int rowDelta, int colDelta) {
@@ -144,6 +156,12 @@ public class DefaultEditorEventHandler<T> implements Editor.EventHandler<T> {
             this.colDelta = colDelta;
         }
 
+        /**
+         * Returns whether the cursor move has either horizontal or vertical
+         * changes.
+         *
+         * @return {@code true} if there are changes, {@code false} otherwise
+         */
         public boolean isChanged() {
             return rowDelta != 0 || colDelta != 0;
         }
@@ -267,6 +285,15 @@ public class DefaultEditorEventHandler<T> implements Editor.EventHandler<T> {
         return -1;
     }
 
+    /**
+     * Checks whether the field within the given editor column is editable.
+     *
+     * @param grid
+     *            the grid that is being edited
+     * @param column
+     *            the column to investigate
+     * @return {@code true} if the field is editable, {@code false} otherwise
+     */
     protected boolean isEditable(Grid<T> grid, Grid.Column<?, T> column) {
         if (!column.isEditable()) {
             return false;
@@ -403,6 +430,19 @@ public class DefaultEditorEventHandler<T> implements Editor.EventHandler<T> {
         return false;
     }
 
+    /**
+     * Opens the editor over the row with the given index and attempts to focus
+     * the editor widget in the given column index. If the given indices are
+     * outside of the existing range, the closest value within the range is
+     * used.
+     *
+     * @param event
+     *            the wrapped DOM event
+     * @param rowIndex
+     *            index of the row to edit
+     * @param colIndex
+     *            index of the editor column to focus
+     */
     protected void editRow(EditorDomEvent<T> event, int rowIndex,
             int colIndex) {
         int rowCount = event.getGrid().getDataSource().size();

--- a/client/src/main/java/com/vaadin/client/widget/grid/EventCellReference.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/EventCellReference.java
@@ -29,6 +29,10 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
  * this object is subject to change without the user knowing it and so should
  * not be stored anywhere outside of the method providing these instances.
  *
+ * @param <T>
+ *            The row type of the grid. The row type is the POJO type from where
+ *            the data is retrieved into the column cells.
+ *
  * @since 7.4
  * @author Vaadin Ltd
  */
@@ -37,15 +41,27 @@ public class EventCellReference<T> extends CellReference<T> {
     private Section section;
     private TableCellElement element;
 
+    /**
+     * Constructs a cell reference for an event targeting a grid cell. Needs to
+     * be populated using {@link #set(Cell, Section)}.
+     *
+     * @param grid
+     *            the grid the event originates from
+     *
+     * @see EventCellReference
+     */
     public EventCellReference(Grid<T> grid) {
         super(new RowReference<>(grid));
     }
 
     /**
-     * Sets the RowReference and CellReference to point to given Cell.
+     * Configures this CellReference and its internal RowReference to point to
+     * the given Cell.
      *
      * @param targetCell
-     *            cell to point to
+     *            the cell to point to
+     * @param section
+     *            the section the cell belongs to
      */
     public void set(Cell targetCell, Section section) {
         Grid<T> grid = getGrid();

--- a/client/src/main/java/com/vaadin/client/widget/grid/RendererCellReference.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/RendererCellReference.java
@@ -54,6 +54,7 @@ public class RendererCellReference extends CellReference<Object> {
      * @param column
      *            the column to reference
      */
+    @SuppressWarnings("unchecked")
     public void set(FlyweightCell cell, int columnIndex,
             Grid.Column<?, ?> column) {
         this.cell = cell;

--- a/client/src/main/java/com/vaadin/client/widget/grid/datasources/ListDataSource.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/datasources/ListDataSource.java
@@ -56,6 +56,9 @@ import com.vaadin.shared.util.SharedUtil;
  * ds.asList().addAll(Arrays.asList(5, 6, 7));
  * </pre>
  *
+ * @param <T>
+ *            the type of the items in the grid
+ *
  * @since 7.4
  * @author Vaadin Ltd
  */
@@ -356,6 +359,7 @@ public class ListDataSource<T> implements DataSource<T> {
      * @param rows
      *            The rows to initially add to the data source
      */
+    @SuppressWarnings("unchecked")
     public ListDataSource(T... rows) {
         if (rows == null) {
             ds = new ArrayList<>();

--- a/client/src/main/java/com/vaadin/client/widget/grid/datasources/ListSorter.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/datasources/ListSorter.java
@@ -43,6 +43,12 @@ public class ListSorter<T> {
     private Map<Grid.Column<?, T>, Comparator<?>> comparators;
     private HandlerRegistration sortHandlerRegistration;
 
+    /**
+     * Constructs a sorting facility for the given Grid.
+     *
+     * @param grid
+     *            the Grid that needs sort handling
+     */
     public ListSorter(Grid<T> grid) {
 
         if (grid == null) {
@@ -76,6 +82,8 @@ public class ListSorter<T> {
      * and Dates). Any existing comparator can be removed by passing in a
      * non-null GridColumn and a null Comparator.
      *
+     * @param <C>
+     *            the column data type
      * @param column
      *            a grid column. May not be null.
      * @param comparator
@@ -98,6 +106,8 @@ public class ListSorter<T> {
     /**
      * Retrieve the comparator assigned for a specific grid column.
      *
+     * @param <C>
+     *            the column data type
      * @param column
      *            a grid column. May not be null.
      * @return a comparator, or null if no comparator for the specified grid
@@ -126,6 +136,7 @@ public class ListSorter<T> {
      * @param order
      *            the sort order list provided by the grid sort event
      */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     private void sort(final List<SortOrder> order) {
         DataSource<T> ds = grid.getDataSource();
         if (!(ds instanceof ListDataSource)) {

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/AbstractGridKeyEventHandler.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/AbstractGridKeyEventHandler.java
@@ -26,18 +26,48 @@ import com.vaadin.client.widgets.Grid.AbstractGridKeyEvent;
  */
 public abstract interface AbstractGridKeyEventHandler extends EventHandler {
 
+    /**
+     * Handler for Grid key down events.
+     */
     public abstract interface GridKeyDownHandler
             extends AbstractGridKeyEventHandler {
+        /**
+         * Perform actions that should happen when a key down event is triggered
+         * within a Grid.
+         *
+         * @param event
+         *            the key down event
+         */
         public void onKeyDown(GridKeyDownEvent event);
     }
 
+    /**
+     * Handler for Grid key up events.
+     */
     public abstract interface GridKeyUpHandler
             extends AbstractGridKeyEventHandler {
+        /**
+         * Perform actions that should happen when a key up event is triggered
+         * within a Grid.
+         *
+         * @param event
+         *            the key up event
+         */
         public void onKeyUp(GridKeyUpEvent event);
     }
 
+    /**
+     * Handler for Grid key press events.
+     */
     public abstract interface GridKeyPressHandler
             extends AbstractGridKeyEventHandler {
+        /**
+         * Perform actions that should happen when a key press event is
+         * triggered within a Grid.
+         *
+         * @param event
+         *            the key press event
+         */
         public void onKeyPress(GridKeyPressEvent event);
     }
 

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/AbstractGridMouseEventHandler.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/AbstractGridMouseEventHandler.java
@@ -26,13 +26,31 @@ import com.vaadin.client.widgets.Grid.AbstractGridMouseEvent;
  */
 public abstract interface AbstractGridMouseEventHandler extends EventHandler {
 
+    /**
+     * Handler for Grid click events.
+     */
     public abstract interface GridClickHandler
             extends AbstractGridMouseEventHandler {
+        /**
+         * Perform actions that should happen when the Grid is clicked.
+         *
+         * @param event
+         *            the click event
+         */
         public void onClick(GridClickEvent event);
     }
 
+    /**
+     * Handler for Grid double-click events.
+     */
     public abstract interface GridDoubleClickHandler
             extends AbstractGridMouseEventHandler {
+        /**
+         * Perform actions that should happen when the Grid is double-clicked.
+         *
+         * @param event
+         *            the double-click event
+         */
         public void onDoubleClick(GridDoubleClickEvent event);
     }
 

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/ColumnReorderEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/ColumnReorderEvent.java
@@ -36,6 +36,11 @@ public class ColumnReorderEvent<T> extends GwtEvent<ColumnReorderHandler<T>> {
      */
     private static final Type<ColumnReorderHandler<?>> TYPE = new Type<>();
 
+    /**
+     * Returns the associated handler type.
+     *
+     * @return the handler type
+     */
     public static final Type<ColumnReorderHandler<?>> getType() {
         return TYPE;
     }
@@ -46,6 +51,17 @@ public class ColumnReorderEvent<T> extends GwtEvent<ColumnReorderHandler<T>> {
 
     private final boolean userOriginated;
 
+    /**
+     * Constructs a reorder event for grid columns.
+     *
+     * @param oldColumnOrder
+     *            the old order
+     * @param newColumnOrder
+     *            the new order
+     * @param userOriginated
+     *            {@code true} if the event was triggered by user interaction,
+     *            {@code false} otherwise
+     */
     public ColumnReorderEvent(List<Column<?, T>> oldColumnOrder,
             List<Column<?, T>> newColumnOrder, boolean userOriginated) {
         this.oldColumnOrder = oldColumnOrder;

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/ColumnResizeEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/ColumnResizeEvent.java
@@ -37,12 +37,20 @@ public class ColumnResizeEvent<T> extends GwtEvent<ColumnResizeHandler<T>> {
     private Column<?, T> column;
 
     /**
+     * Constructs a resize event for a grid column.
+     *
      * @param column
+     *            the updated column
      */
     public ColumnResizeEvent(Column<?, T> column) {
         this.column = column;
     }
 
+    /**
+     * Returns the associated handler type.
+     *
+     * @return the handler type
+     */
     public static final Type<ColumnResizeHandler<?>> getType() {
         return TYPE;
     }

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/ColumnVisibilityChangeEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/ColumnVisibilityChangeEvent.java
@@ -33,6 +33,11 @@ public class ColumnVisibilityChangeEvent<T>
 
     private static final Type<ColumnVisibilityChangeHandler<?>> TYPE = new Type<>();
 
+    /**
+     * Returns the associated handler type.
+     *
+     * @return the handler type
+     */
     public static final Type<ColumnVisibilityChangeHandler<?>> getType() {
         return TYPE;
     }
@@ -43,6 +48,18 @@ public class ColumnVisibilityChangeEvent<T>
 
     private final boolean hidden;
 
+    /**
+     * Constructs a visibility change event for a grid column.
+     *
+     * @param column
+     *            the updated column
+     * @param hidden
+     *            {@code true} if the column is now hidden, {@code false}
+     *            otherwise
+     * @param userOriginated
+     *            {@code true} if the event was triggered by user interaction,
+     *            {@code false} otherwise
+     */
     public ColumnVisibilityChangeEvent(Column<?, T> column, boolean hidden,
             boolean userOriginated) {
         this.column = column;

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/ColumnVisibilityChangeHandler.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/ColumnVisibilityChangeHandler.java
@@ -21,9 +21,9 @@ import com.google.gwt.event.shared.EventHandler;
  * Handler for a Grid column visibility change event, called when the Grid's
  * columns have changed visibility to hidden or visible.
  *
- * @param<T> The
- *               row type of the grid. The row type is the POJO type from where
- *               the data is retrieved into the column cells.
+ * @param <T>
+ *            The row type of the grid. The row type is the POJO type from where
+ *            the data is retrieved into the column cells.
  *
  * @since 7.5.0
  * @author Vaadin Ltd

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridClickEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridClickEvent.java
@@ -30,6 +30,7 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
  */
 public class GridClickEvent extends AbstractGridMouseEvent<GridClickHandler> {
 
+    /** DOM event type. */
     public static final Type<GridClickHandler> TYPE = new Type<GridClickHandler>(
             BrowserEvents.CLICK, new GridClickEvent());
 
@@ -42,6 +43,11 @@ public class GridClickEvent extends AbstractGridMouseEvent<GridClickHandler> {
     /**
      * @deprecated This constructor's arguments are no longer used. Use the
      *             no-args constructor instead.
+     *
+     * @param grid
+     *            the grid the event occurred in, not used
+     * @param targetCell
+     *            the cell the event targets, not used
      */
     @Deprecated
     public GridClickEvent(Grid<?> grid, CellReference<?> targetCell) {

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridDoubleClickEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridDoubleClickEvent.java
@@ -31,6 +31,7 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
 public class GridDoubleClickEvent
         extends AbstractGridMouseEvent<GridDoubleClickHandler> {
 
+    /** DOM event type. */
     public static final Type<GridDoubleClickHandler> TYPE = new Type<GridDoubleClickHandler>(
             BrowserEvents.DBLCLICK, new GridDoubleClickEvent());
 
@@ -43,6 +44,11 @@ public class GridDoubleClickEvent
     /**
      * @deprecated This constructor's arguments are no longer used. Use the
      *             no-args constructor instead.
+     *
+     * @param grid
+     *            the grid the event occurred in, not used
+     * @param targetCell
+     *            the cell the event targets, not used
      */
     @Deprecated
     public GridDoubleClickEvent(Grid<?> grid, CellReference<?> targetCell) {

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridEnabledEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridEnabledEvent.java
@@ -30,6 +30,13 @@ public class GridEnabledEvent extends GwtEvent<GridEnabledHandler> {
     public static final Type<GridEnabledHandler> TYPE = new Type<>();
     private final boolean enabled;
 
+    /**
+     * Constructs an event that informs about Grid's enabled status change.
+     *
+     * @param enabled
+     *            {@code true} if the Grid is now enabled, {@code false} if the
+     *            Grid is now disabled
+     */
     public GridEnabledEvent(boolean enabled) {
         this.enabled = enabled;
     }

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyDownEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyDownEvent.java
@@ -31,6 +31,7 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
  */
 public class GridKeyDownEvent extends AbstractGridKeyEvent<GridKeyDownHandler> {
 
+    /** DOM event type. */
     public static final Type<GridKeyDownHandler> TYPE = new Type<GridKeyDownHandler>(
             BrowserEvents.KEYDOWN, new GridKeyDownEvent());
 
@@ -43,6 +44,11 @@ public class GridKeyDownEvent extends AbstractGridKeyEvent<GridKeyDownHandler> {
     /**
      * @deprecated This constructor's arguments are no longer used. Use the
      *             no-args constructor instead.
+     *
+     * @param grid
+     *            the grid the event occurred in, not used
+     * @param targetCell
+     *            the cell the event targets, not used
      */
     @Deprecated
     public GridKeyDownEvent(Grid<?> grid, CellReference<?> targetCell) {

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyPressEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyPressEvent.java
@@ -31,6 +31,7 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
 public class GridKeyPressEvent
         extends AbstractGridKeyEvent<GridKeyPressHandler> {
 
+    /** DOM event type. */
     public static final Type<GridKeyPressHandler> TYPE = new Type<GridKeyPressHandler>(
             BrowserEvents.KEYPRESS, new GridKeyPressEvent());
 
@@ -43,6 +44,11 @@ public class GridKeyPressEvent
     /**
      * @deprecated This constructor's arguments are no longer used. Use the
      *             no-args constructor instead.
+     *
+     * @param grid
+     *            the grid the event occurred in, not used
+     * @param targetCell
+     *            the cell the event targets, not used
      */
     @Deprecated
     public GridKeyPressEvent(Grid<?> grid, CellReference<?> targetCell) {

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyUpEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/GridKeyUpEvent.java
@@ -31,6 +31,7 @@ import com.vaadin.shared.ui.grid.GridConstants.Section;
  */
 public class GridKeyUpEvent extends AbstractGridKeyEvent<GridKeyUpHandler> {
 
+    /** DOM event type. */
     public static final Type<GridKeyUpHandler> TYPE = new Type<GridKeyUpHandler>(
             BrowserEvents.KEYUP, new GridKeyUpEvent());
 
@@ -43,6 +44,11 @@ public class GridKeyUpEvent extends AbstractGridKeyEvent<GridKeyUpHandler> {
     /**
      * @deprecated This constructor's arguments are no longer used. Use the
      *             no-args constructor instead.
+     *
+     * @param grid
+     *            the grid the event occurred in, not used
+     * @param targetCell
+     *            the cell the event targets, not used
      */
     @Deprecated
     public GridKeyUpEvent(Grid<?> grid, CellReference<?> targetCell) {

--- a/client/src/main/java/com/vaadin/client/widget/grid/events/SelectAllHandler.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/events/SelectAllHandler.java
@@ -21,6 +21,9 @@ import com.google.gwt.event.shared.EventHandler;
  * Handler for a Grid select all event, called when the Grid needs all rows in
  * data source to be selected.
  *
+ * @param <T>
+ *            the type of the items in the Grid
+ *
  * @since 7.4
  * @author Vaadin Ltd
  */

--- a/client/src/main/java/com/vaadin/client/widget/grid/selection/ClickSelectHandler.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/selection/ClickSelectHandler.java
@@ -23,6 +23,9 @@ import com.vaadin.client.widgets.Grid;
 /**
  * Generic class to perform selections when clicking on cells in body of Grid.
  *
+ * @param <T>
+ *            the type of the items in the Grid
+ *
  * @since 7.4
  * @author Vaadin Ltd
  */
@@ -39,6 +42,7 @@ public class ClickSelectHandler<T> {
             if (!grid.getSelectionModel().isSelectionAllowed()) {
                 return;
             }
+            @SuppressWarnings("unchecked")
             T row = (T) event.getTargetCell().getRow();
             if (!grid.isSelected(row)) {
                 grid.select(row);

--- a/client/src/main/java/com/vaadin/client/widget/grid/selection/HasSelectionHandlers.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/selection/HasSelectionHandlers.java
@@ -20,6 +20,9 @@ import com.google.gwt.event.shared.HandlerRegistration;
 /**
  * Marker interface for widgets that fires selection events.
  *
+ * @param <T>
+ *            the type of the items in the Grid
+ *
  * @author Vaadin Ltd
  * @since 7.4
  */

--- a/client/src/main/java/com/vaadin/client/widget/grid/selection/MultiSelectionRenderer.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/selection/MultiSelectionRenderer.java
@@ -42,7 +42,6 @@ import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.user.client.ui.CheckBox;
-import com.vaadin.client.VConsole;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.renderers.ClickableRenderer;
 import com.vaadin.client.widget.grid.CellReference;
@@ -58,7 +57,7 @@ import com.vaadin.client.widgets.Grid;
  *
  * @author Vaadin Ltd
  * @param <T>
- *            the type of the associated grid
+ *            the type of the items in the associated Grid
  * @since 7.4
  */
 public class MultiSelectionRenderer<T>
@@ -195,6 +194,9 @@ public class MultiSelectionRenderer<T>
                     removeNativeHandler();
                     event.cancel();
                 }
+                break;
+            default:
+                // NOP
                 break;
             }
         }
@@ -525,6 +527,9 @@ public class MultiSelectionRenderer<T>
             case Event.ONTOUCHCANCEL:
                 stop();
                 break;
+            default:
+                // NOP
+                break;
             }
         };
 
@@ -599,6 +604,13 @@ public class MultiSelectionRenderer<T>
 
     private final AutoScrollHandler autoScrollHandler = new AutoScrollHandler();
 
+    /**
+     * Constructs a renderer for a selection column with multi-selection
+     * CheckBoxes.
+     *
+     * @param grid
+     *            the parent grid
+     */
     public MultiSelectionRenderer(final Grid<T> grid) {
         this.grid = grid;
     }
@@ -785,10 +797,27 @@ public class MultiSelectionRenderer<T>
                 + getTheadElement().getOffsetHeight() + 1;
     }
 
+    /**
+     * Checks whether the given row is selected.
+     *
+     * @param logicalRow
+     *            logical index of the row to check
+     * @return {@code true} if the current selection model considers the row
+     *         selected, {@code false} otherwise
+     */
     protected boolean isSelected(final int logicalRow) {
         return grid.isSelected(grid.getDataSource().getRow(logicalRow));
     }
 
+    /**
+     * Updates selection status for the given row.
+     *
+     * @param logicalRow
+     *            logical index of the row to update
+     * @param select
+     *            {@code true} if the row should be marked selected,
+     *            {@code false} otherwise
+     */
     protected void setSelected(final int logicalRow, final boolean select) {
         T row = grid.getDataSource().getRow(logicalRow);
         if (select) {

--- a/client/src/main/java/com/vaadin/client/widget/grid/selection/SelectionEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/selection/SelectionEvent.java
@@ -26,6 +26,9 @@ import com.vaadin.client.widgets.Grid;
 /**
  * Event object describing a change in Grid row selection state.
  *
+ * @param <T>
+ *            the type of the items in the Grid
+ *
  * @since 7.4
  * @author Vaadin Ltd
  */

--- a/client/src/main/java/com/vaadin/client/widget/grid/selection/SelectionModel.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/selection/SelectionModel.java
@@ -26,11 +26,17 @@ import elemental.json.JsonObject;
  * @author Vaadin Ltd.
  *
  * @param <T>
- *            the type of the items to select
+ *            the type of the items in the Grid
  * @since 8.0
  */
 public interface SelectionModel<T> {
 
+    /**
+     * Selection model that does not allow any selection.
+     *
+     * @param <T>
+     *            the type of the items to select
+     */
     public static class NoSelectionModel<T> implements SelectionModel<T> {
 
         @Override

--- a/client/src/main/java/com/vaadin/client/widget/grid/sort/SortEvent.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/sort/SortEvent.java
@@ -24,6 +24,10 @@ import com.vaadin.client.widgets.Grid;
  * A sort event, fired by the Grid when it needs its data source to provide data
  * sorted in a specific manner.
  *
+ * @param <T>
+ *            The row type of the Grid. The row type is the POJO type from where
+ *            the data is retrieved into the column cells.
+ *
  * @since 7.4
  * @author Vaadin Ltd
  */

--- a/client/src/main/java/com/vaadin/client/widget/grid/sort/SortHandler.java
+++ b/client/src/main/java/com/vaadin/client/widget/grid/sort/SortHandler.java
@@ -21,6 +21,10 @@ import com.google.gwt.event.shared.EventHandler;
  * Handler for a Grid sort event, called when the Grid needs its data source to
  * provide data sorted in a specific manner.
  *
+ * @param <T>
+ *            The row type of the Grid. The row type is the POJO type from where
+ *            the data is retrieved into the column cells.
+ *
  * @since 7.4
  * @author Vaadin Ltd
  */

--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -229,6 +229,7 @@ import com.vaadin.shared.util.SharedUtil;
  * @since 7.4
  * @author Vaadin Ltd
  */
+@SuppressWarnings("deprecation")
 public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         SubPartAware, DeferredWorker, Focusable,
         com.google.gwt.user.client.ui.Focusable, HasWidgets, HasEnabled {
@@ -293,11 +294,22 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 return (String) content;
             }
 
+            /**
+             * Returns the section where this cell belongs.
+             *
+             * @return the section
+             */
             protected StaticSection<?> getSection() {
                 assert section != null;
                 return section;
             }
 
+            /**
+             * Sets the section where this cell belongs. Should not be null.
+             *
+             * @param section
+             *            the section to set
+             */
             protected void setSection(StaticSection<?> section) {
                 this.section = section;
             }
@@ -609,6 +621,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
              * @return The remaining visible cell after the merge, or the first
              *         cell if all columns are hidden
              */
+            @SuppressWarnings("unchecked")
             public CELLTYPE join(CELLTYPE... cells) {
                 if (cells.length <= 1) {
                     throw new IllegalArgumentException(
@@ -644,6 +657,14 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 return null;
             }
 
+            /**
+             * Returns the size of the cell group for the given column. Zero if
+             * no cell group is set.
+             *
+             * @param column
+             *            the column whose cell group size is being investigated
+             * @return size of the cell group, default is {@code 0}
+             */
             protected int getSizeOfCellGroup(Column<?, ?> column) {
                 for (Entry<CELLTYPE, Set<Column<?, ?>>> entry : cellGroups
                         .entrySet()) {
@@ -704,22 +725,50 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 return false;
             }
 
+            /**
+             * Creates and adds a cell to this row for the given column.
+             *
+             * @param column
+             *            the column that requires a new cell
+             */
             protected void addCell(Column<?, ?> column) {
                 CELLTYPE cell = createCell();
                 cell.setSection(getSection());
                 cells.put(column, cell);
             }
 
+            /**
+             * Removes a cell for the given column from this row.
+             *
+             * @param column
+             *            the column that should have its cell reference cleared
+             */
             protected void removeCell(Column<?, ?> column) {
                 cells.remove(column);
             }
 
+            /**
+             * Creates a cell of a type that matches this row.
+             *
+             * @return a new cell
+             */
             protected abstract CELLTYPE createCell();
 
+            /**
+             * Returns the section where this row belongs.
+             *
+             * @return the section
+             */
             protected StaticSection<?> getSection() {
                 return section;
             }
 
+            /**
+             * Sets the section where this row belongs. Should not be null.
+             *
+             * @param section
+             *            the section to set
+             */
             protected void setSection(StaticSection<?> section) {
                 this.section = section;
             }
@@ -929,35 +978,74 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             return rows.size();
         }
 
+        /**
+         * Returns the current list of rows within this section.
+         *
+         * @return list of rows
+         */
         protected List<ROWTYPE> getRows() {
             return rows;
         }
 
+        /**
+         * Returns how many visible rows there are within this section (all or
+         * nothing, visibility cannot be set on the row level).
+         *
+         * @return amount of visible rows
+         */
         protected int getVisibleRowCount() {
             return isVisible() ? getRowCount() : 0;
         }
 
+        /**
+         * Adds cells for the given column to all the rows within this section.
+         *
+         * @param column
+         *            the column that requires cells
+         */
         protected void addColumn(Column<?, ?> column) {
             for (ROWTYPE row : rows) {
                 row.addCell(column);
             }
         }
 
+        /**
+         * Removes cells for the given column from all the rows within this
+         * section.
+         *
+         * @param column
+         *            the column that should have its cells removed
+         */
         protected void removeColumn(Column<?, ?> column) {
             for (ROWTYPE row : rows) {
                 row.removeCell(column);
             }
         }
 
+        /**
+         * Sets the grid this section belongs to. Should not be null.
+         *
+         * @param grid
+         *            the parent grid
+         */
         protected void setGrid(Grid<?> grid) {
             this.grid = grid;
         }
 
+        /**
+         * Returns the grid this section belongs to.
+         *
+         * @return the parent grid
+         */
         protected Grid<?> getGrid() {
             assert grid != null;
             return grid;
         }
 
+        /**
+         * Triggers column span calculation for all the rows within this section
+         * that contain spanned cells.
+         */
         protected void updateColSpans() {
             for (ROWTYPE row : rows) {
                 if (row.hasSpannedCells()) {
@@ -1077,6 +1165,16 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
         private boolean isDefault = false;
 
+        /**
+         * Sets whether this is the default header row or not. Setting this
+         * value to {@code true} resets the cell contents for this row to column
+         * header captions. Setting this value to {@code false} doesn't update
+         * the cell contents.
+         *
+         * @param isDefault
+         *            {@code true} if this row should be default header row,
+         *            {@code false} otherwise
+         */
         protected void setDefault(boolean isDefault) {
             this.isDefault = isDefault;
             if (isDefault) {
@@ -1086,6 +1184,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
         }
 
+        /**
+         * Returns whether this is the default header row or not.
+         *
+         * @return {@code true} if this row is the default header row,
+         *         {@code false} otherwise
+         */
         public boolean isDefault() {
             return isDefault;
         }
@@ -1271,6 +1375,14 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         private EventCellReference<T> cell;
         private boolean handled = false;
 
+        /**
+         * Constructs a new {@link GridEvent}.
+         *
+         * @param event
+         *            a native event
+         * @param cell
+         *            the cell the event targets
+         */
         protected GridEvent(Event event, EventCellReference<T> cell) {
             this.event = event;
             this.cell = cell;
@@ -1317,6 +1429,8 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
          * marks this event as having already been handled.
          *
          * @param handled
+         *            {@code true} if the event has already been handled,
+         *            {@code false} otherwise
          */
         public void setHandled(boolean handled) {
             this.handled = handled;
@@ -1335,6 +1449,16 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
         private final Widget editorWidget;
 
+        /**
+         * Constructs a new {@link EditorDomEvent}.
+         *
+         * @param event
+         *            a native event
+         * @param cell
+         *            the cell the event targets
+         * @param editorWidget
+         *            the editor widget of that cell
+         */
         protected EditorDomEvent(Event event, EventCellReference<T> cell,
                 Widget editorWidget) {
             super(event, cell);
@@ -1390,7 +1514,17 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     public static class Editor<T> implements DeferredWorker {
 
+        /**
+         * @deprecated use {@link DefaultEditorEventHandler#KEYCODE_OPEN}
+         *             instead
+         */
+        @Deprecated
         public static final int KEYCODE_SHOW = KeyCodes.KEY_ENTER;
+        /**
+         * @deprecated use {@link DefaultEditorEventHandler#KEYCODE_CLOSE}
+         *             instead
+         */
+        @Deprecated
         public static final int KEYCODE_HIDE = KeyCodes.KEY_ESCAPE;
 
         private static final String ERROR_CLASS_NAME = "error";
@@ -1427,8 +1561,29 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             void confirmValidity(boolean isValid);
         }
 
+        /**
+         * The internal state options for the editor.
+         */
         protected enum State {
-            INACTIVE, ACTIVATING, BINDING, ACTIVE, SAVING
+            /** Editor is closed or disabled and as such not in edit mode. */
+            INACTIVE,
+            /**
+             * Editor is getting activated. If activation is successful, next
+             * state will be {@link State#BINDING} .
+             */
+            ACTIVATING,
+            /**
+             * Editor binding is being set up. If binding is successful, next
+             * state will be {@link State#ACTIVE}.
+             */
+            BINDING,
+            /** Editor is open and enabled and in edit mode. */
+            ACTIVE,
+            /**
+             * Editor is saving changes. If saving is successful, state will be
+             * updated to {@link State#INACTIVE}.
+             */
+            SAVING
         }
 
         private Grid<T> grid;
@@ -1554,6 +1709,9 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         private double originalScrollTop;
         private RowHandle<T> pinnedRowHandle;
 
+        /**
+         * Constructs a new {@link Editor}.
+         */
         public Editor() {
             saveButton = new Button();
             saveButton.setText(GridConstants.DEFAULT_SAVE_CAPTION);
@@ -1570,6 +1728,19 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             });
         }
 
+        /**
+         * Sets an error message for the editor, or removes it if the given
+         * message is {@code null}. If the editor is in edit mode or currently
+         * processing a save operation, updates the editor cells to show error
+         * styles for the given columns and clears error styles from any other
+         * columns.
+         *
+         * @param errorMessage
+         *            the message to set, or {@code null} if no message should
+         *            be shown
+         * @param errorColumns
+         *            the columns that currently contain errors
+         */
         public void setEditorError(String errorMessage,
                 Collection<Column<?, T>> errorColumns) {
 
@@ -1594,6 +1765,14 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
         }
 
+        /**
+         * Returns the index of the row that is currently assigned to the
+         * editor. If the editor is open and in the edit mode, that row's
+         * contents can be edited via the editor cells. -1 if the editor is
+         * closed.
+         *
+         * @return currently assigned row index, or -1 if not set
+         */
         public int getRow() {
             return rowIndex;
         }
@@ -1605,6 +1784,9 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
          *
          * If a Grid cell was not focused prior to calling this method, it will
          * be equivalent to {@code editRow(rowIndex, -1)}.
+         *
+         * @param rowIndex
+         *            the index of the row to be edited
          *
          * @see #editRow(int, int)
          */
@@ -1813,6 +1995,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             handler = rowHandler;
         }
 
+        /**
+         * Returns the enabled state of this editor.
+         *
+         * @return {@code true} if enabled, {@code false} otherwise
+         */
         public boolean isEnabled() {
             return enabled;
         }
@@ -1821,7 +2008,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
          * Sets the enabled state of this editor.
          *
          * @param enabled
-         *            true if enabled, false otherwise
+         *            {@code true} if enabled, {@code false} otherwise
          *
          * @throws IllegalStateException
          *             if in edit mode and trying to disable
@@ -1839,6 +2026,17 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             this.enabled = enabled;
         }
 
+        /**
+         * If the Editor is still activating, proceeds to the binding phase.
+         * Otherwise does nothing.
+         *
+         * @param rowIndex
+         *            the index of the row to be edited
+         * @param columnIndex
+         *            the column index (excluding hidden columns) of the editor
+         *            widget that should be initially focused or -1 to not set
+         *            focus
+         */
         protected void show(int rowIndex, int columnIndex) {
             if (state == State.ACTIVATING) {
                 state = State.BINDING;
@@ -1852,6 +2050,13 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
         }
 
+        /**
+         * Sets the grid this editor belongs to. Should not be null. Should only
+         * be called once.
+         *
+         * @param grid
+         *            the parent grid
+         */
         protected void setGrid(final Grid<T> grid) {
             assert grid != null : "Grid cannot be null";
             assert this.grid == null : "Can only attach editor to Grid once";
@@ -1859,10 +2064,21 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             this.grid = grid;
         }
 
+        /**
+         * Returns the internal state of the editor.
+         *
+         * @return the state
+         */
         protected State getState() {
             return state;
         }
 
+        /**
+         * Sets the internal state of the editor.
+         *
+         * @param state
+         *            the state to set
+         */
         protected void setState(State state) {
             this.state = state;
         }
@@ -1895,7 +2111,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         }
 
         /**
-         * Opens the editor overlay over the table row indicated by
+         * Opens the editor overlay over the grid row indicated by
          * {@link #getRow()}.
          *
          * @since 7.5
@@ -2098,6 +2314,9 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             return bottomOfButtons < tfootPageTop;
         }
 
+        /**
+         * Hides the editor overlay and clears its contents.
+         */
         protected void hideOverlay() {
             if (editorOverlay.getParentElement() == null) {
                 return;
@@ -2143,6 +2362,13 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
         }
 
+        /**
+         * Sets the editor's primary style name and updates all dependent style
+         * names.
+         *
+         * @param primaryName
+         *            the new primary style name
+         */
         protected void setStylePrimaryName(String primaryName) {
             if (styleName != null) {
                 editorOverlay.removeClassName(styleName);
@@ -2239,6 +2465,15 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             editorOverlay.getStyle().setTop(newTop, Unit.PX);
         }
 
+        /**
+         * Sets the editor's buttons enabled. Does not update the enabled status
+         * of the grid this editor belongs to, nor ask the enabled status from
+         * it.
+         *
+         * @param enabled
+         *            {@code true} to enable the buttons, {@code false} to
+         *            disable them
+         */
         protected void setGridEnabled(boolean enabled) {
             // TODO: This should be informed to handler as well so possible
             // fields can be disabled.
@@ -2250,6 +2485,14 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             cancelButton.setEnabled(enabled);
         }
 
+        /**
+         * Sets the caption of the save button. Should not be {@code null}.
+         *
+         * @param saveCaption
+         *            the new caption text
+         * @throws IllegalArgumentException
+         *             if the given text is {@code null}
+         */
         public void setSaveCaption(String saveCaption)
                 throws IllegalArgumentException {
             if (saveCaption == null) {
@@ -2259,10 +2502,23 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             saveButton.setText(saveCaption);
         }
 
+        /**
+         * Returns the caption of the save button.
+         *
+         * @return the caption text
+         */
         public String getSaveCaption() {
             return saveButton.getText();
         }
 
+        /**
+         * Sets the caption of the cancel button. Should not be {@code null}.
+         *
+         * @param cancelCaption
+         *            the new caption text
+         * @throws IllegalArgumentException
+         *             if the given text is {@code null}
+         */
         public void setCancelCaption(String cancelCaption)
                 throws IllegalArgumentException {
             if (cancelCaption == null) {
@@ -2272,10 +2528,29 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             cancelButton.setText(cancelCaption);
         }
 
+        /**
+         * Returns the caption of the cancel button.
+         *
+         * @return the caption text
+         */
         public String getCancelCaption() {
             return cancelButton.getText();
         }
 
+        /**
+         * If the given column is indicated to have an error in the editor, sets
+         * the error styles to the corresponding editor cell and lists the
+         * column as having an error. Otherwise removes the error styles from
+         * the cell and removes the column from the error collection.
+         *
+         * @param column
+         *            the column which should have its editor error status
+         *            updated
+         * @param hasError
+         *            {@code true} if the cell should get error styles,
+         *            {@code false} if the error styles should be removed from
+         *            the cell
+         */
         public void setEditorColumnError(Column<?, T> column,
                 boolean hasError) {
             if (state != State.ACTIVE && state != State.SAVING) {
@@ -2298,6 +2573,10 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
         }
 
+        /**
+         * Clears all editor error styles from the editor cells and clears the
+         * error column collection.
+         */
         public void clearEditorColumnErrors() {
 
             /*
@@ -2313,15 +2592,39 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             columnErrors.clear();
         }
 
+        /**
+         * Returns true if the column has been listed as containing an error.
+         *
+         * @param column
+         *            the column whose error status is checked
+         * @return {@code true} if the column is listed as containing an error,
+         *         {@code false} otherwise
+         */
         public boolean isEditorColumnError(Column<?, T> column) {
             return columnErrors.contains(column);
         }
 
+        /**
+         * Sets the buffered mode. When the editor is in buffered mode, edits
+         * are only committed when the user clicks the save button. In
+         * unbuffered mode valid changes are automatically committed.
+         *
+         * @param buffered
+         *            {@code true} if editor should be buffered, {@code false}
+         *            otherwise
+         */
         public void setBuffered(boolean buffered) {
             this.buffered = buffered;
             setMessageAndButtonsWrapperVisible(buffered);
         }
 
+        /**
+         * Returns whether this editor is buffered or not.
+         *
+         * @return {@code true} if editor is buffered, {@code false} otherwise
+         *
+         * @see #setBuffered(boolean)
+         */
         public boolean isBuffered() {
             return buffered;
         }
@@ -2360,6 +2663,15 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             return saveTimeout.isRunning() || bindTimeout.isRunning();
         }
 
+        /**
+         * Returns the column index of the editor cell that contains the given
+         * element, or -1 if the element can't be found within the editor cells.
+         *
+         * @param e
+         *            the element to be located
+         * @return the column index of the associated editor cell, or -1 if not
+         *         found
+         */
         protected int getElementColumn(Element e) {
             int frozenCells = frozenCellWrapper.getChildCount();
             if (frozenCellWrapper.isOrHasChild(e)) {
@@ -2382,6 +2694,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         }
     }
 
+    /**
+     * Event class for key events that happen within the grid.
+     *
+     * @param <HANDLER>
+     *            the event handler type
+     */
     public abstract static class AbstractGridKeyEvent<HANDLER extends AbstractGridKeyEventHandler>
             extends KeyEvent<HANDLER> {
 
@@ -2392,6 +2710,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         }
 
         /**
+         * @param grid
+         *            the grid where the event occurred
+         * @param targetCell
+         *            the cell that the event targeted
+         *
          * @deprecated This constructor's arguments are no longer used. Use the
          *             no-args constructor instead.
          */
@@ -2399,6 +2722,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         public AbstractGridKeyEvent(Grid<?> grid, CellReference<?> targetCell) {
         }
 
+        /**
+         * Returns the {@link BrowserEvents} type that corresponds with this
+         * event.
+         *
+         * @return the browser event type
+         */
         protected abstract String getBrowserEventType();
 
         /**
@@ -2463,9 +2792,24 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
         }
 
+        /**
+         * The given handler processes the event if the handler type matches the
+         * given section.
+         *
+         * @param handler
+         *            handler
+         * @param section
+         *            the section where the target element is located
+         */
         protected abstract void doDispatch(HANDLER handler, Section section);
     }
 
+    /**
+     * Event class for mouse events that happen within the grid.
+     *
+     * @param <HANDLER>
+     *            the event handler type
+     */
     public abstract static class AbstractGridMouseEvent<HANDLER extends AbstractGridMouseEventHandler>
             extends MouseEvent<HANDLER> {
 
@@ -2476,6 +2820,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         }
 
         /**
+         * @param grid
+         *            the grid where the event occurred
+         * @param targetCell
+         *            the cell that the event targeted
+         *
          * @deprecated This constructor's arguments are no longer used. Use the
          *             no-args constructor instead.
          */
@@ -2484,6 +2833,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 CellReference<?> targetCell) {
         }
 
+        /**
+         * Returns the {@link BrowserEvents} type that corresponds with this
+         * event.
+         *
+         * @return the browser event type
+         */
         protected abstract String getBrowserEventType();
 
         /**
@@ -2584,6 +2939,15 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             return childWidget && !handleWidgetEvent;
         }
 
+        /**
+         * The given handler processes the event if the handler type matches the
+         * given section.
+         *
+         * @param handler
+         *            handler
+         * @param section
+         *            the section where the target element is located
+         */
         protected abstract void doDispatch(HANDLER handler, Section section);
     }
 
@@ -2599,6 +2963,10 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
     private EventCellReference<T> eventCell = new EventCellReference<T>(this);
 
+    /**
+     * Focus handler for Grid's cells. Updates focus style names and handles
+     * focus scrolling.
+     */
     private class CellFocusHandler {
 
         private RowContainer containerWithFocus = escalator.getBody();
@@ -3018,6 +3386,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         }
     }
 
+    /**
+     * A column that contains CheckBoxes for representing Grid's row selection.
+     * By default only used with MultiSelectionModel.
+     *
+     */
     public final class SelectionColumn extends Column<Boolean, T>
             implements GridEnabledHandler, GridSelectionAllowedHandler {
 
@@ -3378,7 +3751,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     private class AutoColumnWidthsRecalculator {
         private double lastCalculatedInnerWidth = -1;
-        private double lastCalculatedInnerHeight = -1;
 
         private final ScheduledCommand calculateCommand = new ScheduledCommand() {
 
@@ -3471,7 +3843,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
             // Update latest width to prevent recalculate on height change.
             lastCalculatedInnerWidth = escalator.getInnerWidth();
-            lastCalculatedInnerHeight = escalator.getInnerHeight();
         }
 
         private boolean columnsAreGuaranteedToBeWiderThanGrid() {
@@ -3503,7 +3874,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             return freeSpace < 0;
         }
 
-        @SuppressWarnings("boxing")
         private void applyColumnWidths() {
 
             /* Step 1: Apply all column widths as they are. */
@@ -4394,6 +4764,10 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      */
     private SelectionModel<T> selectionModel;
 
+    /**
+     * Focus handler for Grid's cells. Updates focus style names and handles
+     * focus scrolling.
+     */
     protected final CellFocusHandler cellFocusHandler;
 
     private final UserSorter sorter = new UserSorter();
@@ -4449,6 +4823,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     private RowStyleGenerator<T> rowStyleGenerator;
     private RowReference<T> rowReference = new RowReference<>(this);
     private CellReference<T> cellReference = new CellReference<>(rowReference);
+    @SuppressWarnings("unchecked")
     private RendererCellReference rendererCellReference = new RendererCellReference(
             (RowReference<Object>) rowReference);
 
@@ -4722,13 +5097,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                             .indexOf(getVisibleColumn(focusedCell.getColumn()));
                 }
 
+                @SuppressWarnings("unchecked")
                 Column<?, T>[] array = reordered
                         .toArray(new Column[reordered.size()]);
                 setColumnOrder(true, array);
                 transferCellFocusOnDrop();
-            } // else
-              // no
-              // reordering
+            } // else no reordering
         }
 
         private void transferCellFocusOnDrop() {
@@ -4794,7 +5168,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
         }
 
-        @SuppressWarnings("boxing")
         private void calculatePossibleDropPositions() {
             possibleDropPositions.clear();
 
@@ -5195,7 +5568,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
                 // Complex renderers need to be destroyed.
                 if (bodyRenderer instanceof ComplexRenderer) {
-                    ((ComplexRenderer) bodyRenderer).destroy();
+                    ((ComplexRenderer<? super C>) bodyRenderer).destroy();
                 }
 
                 bodyRenderer = renderer;
@@ -5790,6 +6163,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
 
     }
 
+    /**
+     * EscalatorUpdater implementation for Grid's body section.
+     *
+     * @see EscalatorUpdater
+     *
+     */
     protected class BodyUpdater implements EscalatorUpdater {
 
         @Override
@@ -5848,6 +6227,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public void update(Row row, Iterable<FlyweightCell> cellsToUpdate) {
             int rowIndex = row.getRow();
             TableRowElement rowElement = row.getElement();
@@ -5934,13 +6314,15 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                     setCustomStyleName(cell.getElement(), null);
                 }
 
+                @SuppressWarnings("rawtypes")
                 Renderer renderer = column.getRenderer();
 
                 try {
                     rendererCellReference.set(cell, columnIndex, column);
                     if (renderer instanceof ComplexRenderer) {
                         // Hide cell content if needed
-                        ComplexRenderer clxRenderer = (ComplexRenderer) renderer;
+                        @SuppressWarnings("rawtypes")
+                        ComplexRenderer clxRenderer = (ComplexRenderer<?>) renderer;
                         if (hasData) {
                             if (!usedToHaveData) {
                                 // Prepare cell for rendering
@@ -6015,7 +6397,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                                 cell.getColumn());
                         rendererCellReference.set(cell,
                                 getColumns().indexOf(column), column);
-                        ((ComplexRenderer) renderer)
+                        ((ComplexRenderer<?>) renderer)
                                 .destroy(rendererCellReference);
                     } catch (RuntimeException e) {
                         getLogger().log(Level.SEVERE,
@@ -6028,11 +6410,26 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         }
     }
 
+    /**
+     * EscalatorUpdater implementation for Grid's static sections (header and
+     * footer).
+     *
+     * @see EscalatorUpdater
+     *
+     */
     protected class StaticSectionUpdater implements EscalatorUpdater {
 
         private StaticSection<?> section;
         private RowContainer container;
 
+        /**
+         * Constructs an updater instance for the given section.
+         *
+         * @param section
+         *            the section that needs an updater
+         * @param container
+         *            the row container of the given section
+         */
         public StaticSectionUpdater(StaticSection<?> section,
                 RowContainer container) {
             super();
@@ -6069,7 +6466,8 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 // Wrap text or html content in default header to isolate
                 // the content from the possible column resize drag handle
                 // next to it
-                if (metadata.getType() != GridStaticCellType.WIDGET) {
+                GridStaticCellType metaDataType = metadata.getType();
+                if (metaDataType != GridStaticCellType.WIDGET) {
                     content = DOM.createDiv();
 
                     if (staticRow instanceof HeaderRow) {
@@ -6093,7 +6491,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                     content = td;
                 }
 
-                switch (metadata.getType()) {
+                switch (metaDataType) {
                 case TEXT:
                     content.setInnerText(metadata.getText());
                     break;
@@ -6104,6 +6502,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                     preDetach(row, Arrays.asList(cell));
                     content.setInnerHTML("");
                     postAttach(row, Arrays.asList(cell));
+                    break;
+                default:
+                    getLogger().severe("Unhandled metadata type: "
+                            + (metaDataType == null ? "null"
+                                    : metaDataType.name()));
                     break;
                 }
 
@@ -6437,6 +6840,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
             }
         }
 
+        /**
+         * Returns the Grid instance for this updater.
+         *
+         * @return the grid that is being updated
+         */
+        @SuppressWarnings("rawtypes")
         protected Grid getGrid() {
             return section.grid;
         }
@@ -6770,6 +7179,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      * @param columns
      *            the columns to add
      */
+    @SuppressWarnings("unchecked")
     public void addColumns(Column<?, T>... columns) {
         if (columns.length == 0) {
             // Nothing to add.
@@ -6782,6 +7192,8 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     /**
      * Adds a column as the last column in the grid.
      *
+     * @param <C>
+     *            class that extends Column
      * @param column
      *            the column to add
      * @return given column
@@ -6794,10 +7206,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     /**
      * Inserts a column into a specific position in the grid.
      *
-     * @param index
-     *            the index where the column should be inserted into
+     * @param <C>
+     *            class that extends Column
      * @param column
      *            the column to add
+     * @param index
+     *            the index where the column should be inserted into
      * @return given column
      *
      * @throws IllegalStateException
@@ -7279,6 +7693,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         return footer.isVisible();
     }
 
+    /**
+     * Returns the {@link Editor} for this Grid.
+     *
+     * @return editor
+     */
     public Editor<T> getEditor() {
         return editor;
     }
@@ -7528,6 +7947,15 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         return frozenColumnCount;
     }
 
+    /**
+     * Adds an event handler that gets notified when the range of visible rows
+     * changes e.g. because of scrolling, row resizing or spacers
+     * appearing/disappearing.
+     *
+     * @param handler
+     *            the event handler
+     * @return a handler registration for the added handler
+     */
     public HandlerRegistration addRowVisibilityChangeHandler(
             RowVisibilityChangeHandler handler) {
         /*
@@ -8284,7 +8712,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     };
 
     @Override
-    @SuppressWarnings("deprecation")
     public com.google.gwt.user.client.Element getSubPartElement(
             String subPart) {
 
@@ -8356,7 +8783,6 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public String getSubPartName(
             com.google.gwt.user.client.Element subElement) {
 
@@ -8554,6 +8980,8 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     /**
      * Sorts the Grid data in ascending order along one column.
      *
+     * @param <C>
+     *            the column type
      * @param column
      *            a grid column reference
      */
@@ -8564,6 +8992,8 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
     /**
      * Sorts the Grid data along one column.
      *
+     * @param <C>
+     *            the column type
      * @param column
      *            a grid column reference
      * @param direction
@@ -8630,7 +9060,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            a sort event handler
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addSortHandler(SortHandler<T> handler) {
         return addHandler(handler, SortEvent.getType());
@@ -8646,7 +9076,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            a select all event handler
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addSelectAllHandler(
             SelectAllHandler<T> handler) {
@@ -8665,7 +9095,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            a data available event handler
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addDataAvailableHandler(
             final DataAvailableHandler handler) {
@@ -8686,7 +9116,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the key handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addBodyKeyDownHandler(
             BodyKeyDownHandler handler) {
@@ -8700,7 +9130,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the key handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addBodyKeyUpHandler(BodyKeyUpHandler handler) {
         return addHandler(handler, GridKeyUpEvent.TYPE);
@@ -8713,7 +9143,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the key handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addBodyKeyPressHandler(
             BodyKeyPressHandler handler) {
@@ -8727,7 +9157,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the key handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addHeaderKeyDownHandler(
             HeaderKeyDownHandler handler) {
@@ -8741,7 +9171,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the key handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addHeaderKeyUpHandler(
             HeaderKeyUpHandler handler) {
@@ -8755,7 +9185,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the key handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addHeaderKeyPressHandler(
             HeaderKeyPressHandler handler) {
@@ -8769,7 +9199,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the key handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addFooterKeyDownHandler(
             FooterKeyDownHandler handler) {
@@ -8783,7 +9213,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the key handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addFooterKeyUpHandler(
             FooterKeyUpHandler handler) {
@@ -8797,7 +9227,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the key handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addFooterKeyPressHandler(
             FooterKeyPressHandler handler) {
@@ -8810,7 +9240,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the click handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addBodyClickHandler(BodyClickHandler handler) {
         return addHandler(handler, GridClickEvent.TYPE);
@@ -8822,7 +9252,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the click handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addHeaderClickHandler(
             HeaderClickHandler handler) {
@@ -8835,7 +9265,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the click handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addFooterClickHandler(
             FooterClickHandler handler) {
@@ -8849,7 +9279,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the double click handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addBodyDoubleClickHandler(
             BodyDoubleClickHandler handler) {
@@ -8863,7 +9293,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the double click handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addHeaderDoubleClickHandler(
             HeaderDoubleClickHandler handler) {
@@ -8877,7 +9307,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the double click handler to register
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addFooterDoubleClickHandler(
             FooterDoubleClickHandler handler) {
@@ -8891,7 +9321,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      * @since 7.5.0
      * @param handler
      *            the handler for the event
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addColumnReorderHandler(
             ColumnReorderHandler<T> handler) {
@@ -8905,7 +9335,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      * @since 7.5.0
      * @param handler
      *            the handler for the event
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addColumnVisibilityChangeHandler(
             ColumnVisibilityChangeHandler<T> handler) {
@@ -8919,7 +9349,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      * @since 7.6
      * @param handler
      *            the handler for the event
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addColumnResizeHandler(
             ColumnResizeHandler<T> handler) {
@@ -8933,7 +9363,7 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the handler for the event
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addEnabledHandler(GridEnabledHandler handler) {
         return addHandler(handler, GridEnabledEvent.TYPE);
@@ -8946,13 +9376,22 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      *
      * @param handler
      *            the handler for the event
-     * @return the registration for the event
+     * @return the registration for the handler
      */
     public HandlerRegistration addSelectionAllowedHandler(
             GridSelectionAllowedHandler handler) {
         return addHandler(handler, GridSelectionAllowedEvent.TYPE);
     }
 
+    /**
+     * Register a row height changed handler to this Grid. The event for this
+     * handler is fired when the row height is changed in the Grid's header,
+     * body or footer.
+     *
+     * @param handler
+     *            the handler for the event
+     * @return the registration for the handler
+     */
     public HandlerRegistration addRowHeightChangedHandler(
             RowHeightChangedHandler handler) {
         return escalator.addHandler(handler, RowHeightChangedEvent.TYPE);
@@ -9081,10 +9520,12 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
      * @param orderedColumns
      *            array of columns in wanted order
      */
+    @SuppressWarnings("unchecked")
     public void setColumnOrder(Column<?, T>... orderedColumns) {
         setColumnOrder(false, orderedColumns);
     }
 
+    @SuppressWarnings("unchecked")
     private void setColumnOrder(boolean isUserOriginated,
             Column<?, T>... orderedColumns) {
         List<Column<?, T>> newOrder = new ArrayList<>();

--- a/server/src/main/java/com/vaadin/ui/dnd/FileDropTarget.java
+++ b/server/src/main/java/com/vaadin/ui/dnd/FileDropTarget.java
@@ -169,18 +169,15 @@ public class FileDropTarget<T extends AbstractComponent>
      * @return Extended component.
      */
     @Override
-    @SuppressWarnings("unchecked")
     public T getParent() {
         return super.getParent();
     }
 
     private class FileReceiver implements StreamVariable {
 
-        private final String id;
         private Html5File file;
 
         public FileReceiver(String id, Html5File file) {
-            this.id = id;
             this.file = file;
         }
 


### PR DESCRIPTION
- Added missing default sections to switch blocks.
- Added missing JavaDocs and JavaDoc parameters.
- Added wildcards where possible.
- Deprecated unused method.
- Fixed JavaDoc formatting.
- Removed inner assignments.
- Removed unused imports.
- Removed unused variables.
- Removed warning suppressions that were unnecessary or about boxing
(not tracked by coding conventions).
- Suppressed warnings about rawtypes, deprecation, and unchecked where
couldn't be avoided.