### PR TITLE
fix: Avoid processing value change event due writing back of converted value

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1103,6 +1103,7 @@ public class Binder<BEAN> implements Serializable {
 
         private Registration onValueChange;
         private boolean valueInit = false;
+        private boolean convertedBack = false;
 
         /**
          * Contains all converters and validators chained together in the
@@ -1283,7 +1284,8 @@ public class Binder<BEAN> implements Serializable {
         private void handleFieldValueChange(
                 ValueChangeEvent<FIELDVALUE> event) {
             // Don't handle change events when setting initial value
-            if (valueInit) {
+            if (valueInit || convertedBack) {
+                convertedBack = false;
                 return;
             }
 
@@ -1313,6 +1315,7 @@ public class Binder<BEAN> implements Serializable {
                     if (convertBackToPresentation && value != null) {
                         FIELDVALUE converted = convertToFieldType(value);
                         if (!Objects.equals(field.getValue(), converted)) {
+                            convertedBack = true;
                             getField().setValue(converted);
                         }
                     }

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -1490,9 +1490,9 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     // See: https://github.com/vaadin/framework/issues/12356
     @Test
     public void validationShouldNotRunTwice() {
-        0TextField salaryField = new TextField();
-    	count = 0;
-    	item.setSalaryDouble(100d);
+        TextField salaryField = new TextField();
+        count = 0;
+        item.setSalaryDouble(100d);
         binder.forField(ageField)
             .withConverter(new StringToDoubleConverter(""))
             .bind(Person::getSalaryDouble, Person::setSalaryDouble);

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -1518,31 +1518,31 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
     // See: https://github.com/vaadin/framework/issues/12356
     @Test
-    public void twoConvertedFieldsChanged() {
+    public void validationShouldNotRunTwice() {
         TextField salaryField = new TextField();
-        item.setSalary(100);
+    	count = 0;
+    	item.setSalaryDouble(100d);
         binder.forField(ageField)
-            .withConverter(new StringToIntegerConverter(""))
-            .bind(Person::getAge, Person::setAge);
-        binder.forField(salaryField)
-            .withConverter(new StringToIntegerConverter(""))
-            .bind(Person::getSalary, Person::setSalary);
+            .withConverter(new StringToDoubleConverter(""))
+            .bind(Person::getSalaryDouble, Person::setSalaryDouble);
         binder.setBean(item);
+        binder.addValueChangeListener(event -> {
+        	count++;
+        });
 
-        ageField.setValue("10");
-        salaryField.setValue("1000");
+        ageField.setValue("1000");
         assertTrue(binder.isValid());
 
-        ageField.setValue("age");
-        salaryField.setValue("salary");
+        ageField.setValue("salary");
         assertFalse(binder.isValid());
 
-        ageField.setValue("20");
-        salaryField.setValue("2000");
-        
-        assertEquals(20, item.getAge());
-        assertEquals(new Integer(2000), item.getSalary());
-    }    
+        ageField.setValue("2000");
+
+        // Without fix for #12356 count will be 5
+        assertEquals(3,count);
+
+        assertEquals(new Double(2000), item.getSalaryDouble());
+    }
 
     /**
      * A converter that adds/removes the euro sign and formats currencies with

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -1516,6 +1516,34 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         return binder;
     }
 
+    // See: https://github.com/vaadin/framework/issues/12356
+    @Test
+    public void twoConvertedFieldsChanged() {
+        TextField salaryField = new TextField();
+        item.setSalary(100);
+        binder.forField(ageField)
+            .withConverter(new StringToIntegerConverter(""))
+            .bind(Person::getAge, Person::setAge);
+        binder.forField(salaryField)
+            .withConverter(new StringToIntegerConverter(""))
+            .bind(Person::getSalary, Person::setSalary);
+        binder.setBean(item);
+
+        ageField.setValue("10");
+        salaryField.setValue("1000");
+        assertTrue(binder.isValid());
+
+        ageField.setValue("age");
+        salaryField.setValue("salary");
+        assertFalse(binder.isValid());
+
+        ageField.setValue("20");
+        salaryField.setValue("2000");
+        
+        assertEquals(20, item.getAge());
+        assertEquals(new Integer(2000), item.getSalary());
+    }    
+
     /**
      * A converter that adds/removes the euro sign and formats currencies with
      * two decimal places.

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -29,6 +29,7 @@ import org.junit.rules.ExpectedException;
 import com.vaadin.data.Binder.Binding;
 import com.vaadin.data.Binder.BindingBuilder;
 import com.vaadin.data.converter.StringToBigDecimalConverter;
+import com.vaadin.data.converter.StringToDoubleConverter;
 import com.vaadin.data.converter.StringToIntegerConverter;
 import com.vaadin.data.validator.IntegerRangeValidator;
 import com.vaadin.data.validator.NotEmptyValidator;
@@ -42,6 +43,8 @@ import org.apache.commons.lang.StringUtils;
 import org.hamcrest.CoreMatchers;
 
 public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
+
+    private int count;
 
     @Rule
     /*
@@ -1493,7 +1496,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         TextField salaryField = new TextField();
         count = 0;
         item.setSalaryDouble(100d);
-        binder.forField(ageField)
+        binder.forField(salaryField)
             .withConverter(new StringToDoubleConverter(""))
             .bind(Person::getSalaryDouble, Person::setSalaryDouble);
         binder.setBean(item);
@@ -1501,13 +1504,13 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         	count++;
         });
 
-        ageField.setValue("1000");
+        salaryField.setValue("1000");
         assertTrue(binder.isValid());
 
-        ageField.setValue("salary");
+        salaryField.setValue("salary");
         assertFalse(binder.isValid());
 
-        ageField.setValue("2000");
+        salaryField.setValue("2000");
 
         // Without fix for #12356 count will be 5
         assertEquals(3, count);


### PR DESCRIPTION
This is both a optimization by skipping duplicate validation round and avoids ConcurrentModificationExpectation being thrown certain corner cases.

Fixes: https://github.com/vaadin/framework/issues/12356