### PR TITLE
Updated the version of vaadin-context-menu

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,7 +20,7 @@
         <vaadin.spring.version>3.2.1</vaadin.spring.version>
         <vaadin.testbench.version>5.2.0</vaadin.testbench.version>
         <vaadin.cdi.version>3.0.1</vaadin.cdi.version>
-        <vaadin.context-menu.version>3.0.2</vaadin.context-menu.version>
+        <vaadin.context-menu.version>3.1.0</vaadin.context-menu.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Moving to new version removes the warning
com.vaadin.event.EventRouter addListener WARNING: Adding listeners with type Object is deprecated, event listener should extend SerializableEventListener