### PR TITLE
Add detection of HCL Digital Experience rebranding (#12242)

### DIFF
--- a/server/src/main/java/com/vaadin/server/VaadinPortlet.java
+++ b/server/src/main/java/com/vaadin/server/VaadinPortlet.java
@@ -574,7 +574,7 @@ public class VaadinPortlet extends GenericPortlet
             return new VaadinLiferayRequest(request, service);
         }
 
-        if (portalInfo.contains("websphere portal")) {
+        if (portalInfo.contains("websphere portal") || portalInfo.contains("hcl digital experience")) {
             return new VaadinWebSpherePortalRequest(request, service);
         }
         if (portalInfo.contains("weblogic portal")) {


### PR DESCRIPTION
On HCL Digital Experience 8.5.5 CF19, the `getPortalInfo()` method
returns "hcl digital experience/8.5", breaking detection of the servlet
engine.

This ultimately leads to methods such as `getHeader()` to return NULL,
as the upstream HTTP request is not retrieved.