### PR TITLE
Updates to TreeGrid's ensureAvailability handling.

### DIFF
--- a/client/src/main/java/com/vaadin/client/ui/treegrid/TreeGridConnector.java
+++ b/client/src/main/java/com/vaadin/client/ui/treegrid/TreeGridConnector.java
@@ -207,13 +207,12 @@ public class TreeGridConnector extends GridConnector {
             public void dataRemoved(int firstRowIndex, int numberOfRows) {
                 if (awaitingRowsState == AwaitingRowsState.COLLAPSE) {
                     awaitingRowsState = AwaitingRowsState.NONE;
-                    // make sure the cache stays up to date with the collapsing
-                    Range visibleRowRange = getWidget().getEscalator()
-                            .getVisibleRowRange();
-                    getDataSource().ensureAvailability(
-                            visibleRowRange.getStart(),
-                            visibleRowRange.length());
                 }
+                // make sure the cache stays up to date
+                Range visibleRowRange = getWidget().getEscalator()
+                        .getVisibleRowRange();
+                getDataSource().ensureAvailability(visibleRowRange.getStart(),
+                        visibleRowRange.length());
                 checkExpand();
             }
 
@@ -221,13 +220,12 @@ public class TreeGridConnector extends GridConnector {
             public void dataAdded(int firstRowIndex, int numberOfRows) {
                 if (awaitingRowsState == AwaitingRowsState.EXPAND) {
                     awaitingRowsState = AwaitingRowsState.NONE;
-                    // make sure the cache stays up to date with the expanding
-                    Range visibleRowRange = getWidget().getEscalator()
-                            .getVisibleRowRange();
-                    getDataSource().ensureAvailability(
-                            visibleRowRange.getStart(),
-                            visibleRowRange.length());
                 }
+                // make sure the cache stays up to date
+                Range visibleRowRange = getWidget().getEscalator()
+                        .getVisibleRowRange();
+                getDataSource().ensureAvailability(visibleRowRange.getStart(),
+                        visibleRowRange.length());
                 checkExpand();
             }
 
@@ -252,7 +250,7 @@ public class TreeGridConnector extends GridConnector {
             GridEventHandler<?> eventHandler)
     /*-{
         var browserEventHandlers = grid.@com.vaadin.client.widgets.Grid::browserEventHandlers;
-
+    
         // FocusEventHandler is initially 5th in the list of browser event handlers
         browserEventHandlers.@java.util.List::set(*)(5, eventHandler);
     }-*/;

--- a/uitest/src/main/java/com/vaadin/tests/components/treegrid/TreeGridProgrammaticExpand.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/treegrid/TreeGridProgrammaticExpand.java
@@ -1,0 +1,45 @@
+package com.vaadin.tests.components.treegrid;
+
+import com.vaadin.data.TreeData;
+import com.vaadin.data.provider.TreeDataProvider;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.TreeGrid;
+
+public class TreeGridProgrammaticExpand extends AbstractTestUI {
+
+    @Override
+    protected void setup(VaadinRequest request) {
+        TreeData<String> data = new TreeData<>();
+        String root = "Root";
+        data.addItem(null, root);
+        for (int i = 0; i < 15; i++) {
+            String leaf = "Leaf " + i;
+            data.addItem(root, leaf);
+        }
+
+        TreeDataProvider<String> treeDataProvider = new TreeDataProvider<>(
+                data);
+        TreeGrid<String> treeGrid = new TreeGrid<>();
+        treeGrid.setDataProvider(treeDataProvider);
+        treeGrid.addColumn(String::toString).setCaption("String")
+                .setId("string");
+        treeGrid.addColumn(i -> "--").setCaption("Nothing");
+
+        Button button = new Button("Expand", e -> treeGrid.expand(root));
+
+        addComponents(button, treeGrid);
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "There should be no client-side exception when clicking Leaf 4 "
+                + "or lower before scrolling.";
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 12372;
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridProgrammaticExpandTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/treegrid/TreeGridProgrammaticExpandTest.java
@@ -1,0 +1,22 @@
+package com.vaadin.tests.components.treegrid;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.TreeGridElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class TreeGridProgrammaticExpandTest extends MultiBrowserTest {
+
+    @Test
+    public void expandAndClick() {
+        openTestURL("debug");
+        TreeGridElement treeGrid = $(TreeGridElement.class).first();
+        $(ButtonElement.class).first().click();
+        waitUntilLoadingIndicatorNotVisible();
+        treeGrid.getCell(5, 0).click();
+        waitUntilLoadingIndicatorNotVisible();
+        assertElementNotPresent(By.className("v-Notification-error"));
+    }
+}


### PR DESCRIPTION
- Always update the availability request range when more or less data
becomes available. Otherwise e.g. programmatically expanding a TreeGrid
row can lead to discarding a lot of the new data right after receiving
it.

Fixes #12372