### PR TITLE
Fix Grid column reorder with partially hidden joined cells

### DIFF
--- a/client/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/client/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -4621,11 +4621,14 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
                 }
                 final boolean isDraggedCellRow = row.equals(draggedCellRow);
                 for (int cellColumnIndex = frozenColumns; cellColumnIndex < getColumnCount(); cellColumnIndex++) {
-                    StaticCell cell = row.getCell(getColumn(cellColumnIndex));
-                    int colspan = cell.getColspan();
-                    if (colspan <= 1) {
+                    // some of the columns might be hidden, use cell groups
+                    // rather than cell spans to determine actual span
+                    Set<Column<?, ?>> cellGroup = row
+                            .getCellGroupForColumn(getColumn(cellColumnIndex));
+                    if (cellGroup == null) {
                         continue;
                     }
+                    int colspan = cellGroup.size();
                     final int cellColumnRightIndex = cellColumnIndex + colspan;
                     final Range cellRange = Range.between(cellColumnIndex,
                             cellColumnRightIndex);

--- a/uitest/src/main/java/com/vaadin/tests/components/grid/GridReorderMerged.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/grid/GridReorderMerged.java
@@ -1,0 +1,44 @@
+package com.vaadin.tests.components.grid;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.tests.components.AbstractTestUI;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.Grid.Column;
+import com.vaadin.ui.Grid.HeaderRow;
+
+public class GridReorderMerged extends AbstractTestUI {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected void setup(VaadinRequest request) {
+        Grid grid = new Grid();
+        HeaderRow headerRow = grid.prependHeaderRow();
+        for (int i = 1; i < 10; ++i) {
+            String propertyId = "" + i;
+            Column column = grid.addColumn(propertyId);
+            column.setHidable(true);
+            if (i == 5) {
+                column.setHidden(true);
+            }
+            // add one value per row for easier visualization
+            grid.getContainerDataSource().addItem(i).getItemProperty(propertyId)
+                    .setValue(propertyId);
+        }
+        headerRow.join("1", "2", "3").setText("1");
+        headerRow.join("4", "5", "6").setText("2"); // middle column hidden
+        headerRow.join("7", "8", "9").setText("3");
+        grid.setColumnReorderingAllowed(true);
+        addComponent(grid);
+    }
+
+    @Override
+    protected Integer getTicketNumber() {
+        return 12377;
+    }
+
+    @Override
+    protected String getTestDescription() {
+        return "Reordering columns should respect joined cells "
+                + "even when some columns are hidden.";
+    }
+}

--- a/uitest/src/test/java/com/vaadin/tests/components/grid/GridReorderMergedTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/grid/GridReorderMergedTest.java
@@ -1,0 +1,30 @@
+package com.vaadin.tests.components.grid;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.openqa.selenium.interactions.Actions;
+
+import com.vaadin.testbench.elements.GridElement;
+import com.vaadin.testbench.elements.GridElement.GridCellElement;
+import com.vaadin.tests.tb3.MultiBrowserTest;
+
+public class GridReorderMergedTest extends MultiBrowserTest {
+
+    @Test
+    public void dragMerged() {
+        openTestURL();
+        GridElement grid = $(GridElement.class).first();
+        GridCellElement headerCell0_0 = grid.getHeaderCell(0, 0);
+        GridCellElement headerCell0_4 = grid.getHeaderCell(0, 4);
+        new Actions(driver).clickAndHold(headerCell0_0)
+                .moveToElement(headerCell0_4,
+                        headerCell0_4.getSize().getWidth() / 3, 0)
+                .release().perform();
+
+        // ensure the first merged block got dragged over the entire second
+        // merged block
+        assertEquals("Unexpected column order,", "6",
+                grid.getHeaderCell(1, 1).getText());
+    }
+}


### PR DESCRIPTION
Modified cherry-pick of #12385