### PR TITLE
fix: Add MPR UI id request parameter

### DIFF
--- a/server/src/main/resources/VAADIN/vaadinBootstrap.js
+++ b/server/src/main/resources/VAADIN/vaadinBootstrap.js
@@ -368,7 +368,7 @@
             // This parameter is used in multiplatform-runtime as a key for
             // storing the MPR UI content in the session
             if (window.mprUiId) {
-                params += '&v-mui' + encodeURIComponent(window.mprUiId);
+                params += '&v-mui=' + encodeURIComponent(window.mprUiId);
             }
 
             // Detect touch device support

--- a/server/src/main/resources/VAADIN/vaadinBootstrap.js
+++ b/server/src/main/resources/VAADIN/vaadinBootstrap.js
@@ -365,6 +365,12 @@
                 params += '&v-wn=' + encodeURIComponent(window.name);
             }
 
+            // This parameter is used in multiplatform-runtime as a key for
+            // storing the MPR UI content in the session
+            if (window.vaadin && window.vaadin.mprUiId) {
+                params += '&v-mui' + encodeURIComponent(window.vaadin.mprUiId);
+            }
+
             // Detect touch device support
             var supportsTouch = false;
             try {

--- a/server/src/main/resources/VAADIN/vaadinBootstrap.js
+++ b/server/src/main/resources/VAADIN/vaadinBootstrap.js
@@ -367,8 +367,8 @@
 
             // This parameter is used in multiplatform-runtime as a key for
             // storing the MPR UI content in the session
-            if (window.vaadin && window.vaadin.mprUiId) {
-                params += '&v-mui' + encodeURIComponent(window.vaadin.mprUiId);
+            if (window.mprUiId) {
+                params += '&v-mui' + encodeURIComponent(window.mprUiId);
             }
 
             // Detect touch device support

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/UIInitBrowserDetails.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/UIInitBrowserDetails.java
@@ -13,13 +13,6 @@ import com.vaadin.ui.Label;
 
 public class UIInitBrowserDetails extends AbstractReindeerTestUI {
 
-    static final String EXPECTED_MPR_UI_ID_LABEL_ID =
-            "expected-mpr-ui-id-label-id";
-    static final String ACTUAL_MPR_UI_ID_LABEL_ID =
-            "actual-mpr-ui-id-label-id";
-    static final String POPULATE_MPR_UI_BUTTON_ID = "populate-mpr-ui-button-id";
-    static final String TRIGGER_MPR_UI_BUTTON_ID = "trigger-mpr-ui-button-id";
-
     private GridLayout l = new GridLayout(3, 1);
     private VaadinRequest r;
 

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/UIInitBrowserDetails.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/UIInitBrowserDetails.java
@@ -4,14 +4,24 @@
 
 package com.vaadin.tests.components.ui;
 
+import java.util.UUID;
+
 import com.vaadin.server.Page;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.WebBrowser;
 import com.vaadin.tests.components.AbstractReindeerTestUI;
+import com.vaadin.ui.Button;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Label;
 
 public class UIInitBrowserDetails extends AbstractReindeerTestUI {
+
+    static final String EXPECTED_MPR_UI_ID_LABEL_ID =
+            "expected-mpr-ui-id-label-id";
+    static final String ACTUAL_MPR_UI_ID_LABEL_ID =
+            "actual-mpr-ui-id-label-id";
+    static final String POPULATE_MPR_UI_BUTTON_ID = "populate-mpr-ui-button-id";
+    static final String TRIGGER_MPR_UI_BUTTON_ID = "trigger-mpr-ui-button-id";
 
     private GridLayout l = new GridLayout(3, 1);
     private VaadinRequest r;
@@ -37,6 +47,9 @@ public class UIInitBrowserDetails extends AbstractReindeerTestUI {
         addDetail("dst saving", "v-dstd", wb.getDSTSavings());
         addDetail("dst in effect", "v-dston", wb.isDSTInEffect());
         addDetail("current date", "v-curdate", wb.getCurrentDate());
+        addDetail("mpr ui id", "v-mui", "");
+
+        addMprUiIdTestButtons(p);
     }
 
     private void addDetail(String name, String param, Object value) {
@@ -55,5 +68,30 @@ public class UIInitBrowserDetails extends AbstractReindeerTestUI {
     @Override
     protected Integer getTicketNumber() {
         return Integer.valueOf(9037);
+    }
+
+    private void addMprUiIdTestButtons(Page p) {
+        Button populateMprUiId = new Button("Populate MPR UI id parameter",
+                click -> {
+                    String mprUiId = UUID.randomUUID().toString();
+                    Label mprUiLabel = new Label(mprUiId);
+                    mprUiLabel.setId(EXPECTED_MPR_UI_ID_LABEL_ID);
+                    addComponents(new Label("Expected MPR UI Id"), mprUiLabel);
+                    p.getJavaScript().execute(
+                            "window.vaadin.mprUiId = " + mprUiId + ";");
+                });
+        populateMprUiId.setId(POPULATE_MPR_UI_BUTTON_ID);
+
+        Button triggerMprUiId = new Button("Trigger request with MPR UI id",
+                click -> {
+                    VaadinRequest request = VaadinRequest.getCurrent();
+                    String mprUiId = request.getParameter("v-mui");
+                    Label mprUiLabel = new Label(mprUiId);
+                    mprUiLabel.setId(ACTUAL_MPR_UI_ID_LABEL_ID);
+                    addComponents(new Label("Actual MPR UI Id"), mprUiLabel);
+                });
+        triggerMprUiId.setId(TRIGGER_MPR_UI_BUTTON_ID);
+
+        addComponents(populateMprUiId, triggerMprUiId);
     }
 }

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/UIInitBrowserDetails.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/UIInitBrowserDetails.java
@@ -4,13 +4,10 @@
 
 package com.vaadin.tests.components.ui;
 
-import java.util.UUID;
-
 import com.vaadin.server.Page;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.WebBrowser;
 import com.vaadin.tests.components.AbstractReindeerTestUI;
-import com.vaadin.ui.Button;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Label;
 
@@ -48,8 +45,6 @@ public class UIInitBrowserDetails extends AbstractReindeerTestUI {
         addDetail("dst in effect", "v-dston", wb.isDSTInEffect());
         addDetail("current date", "v-curdate", wb.getCurrentDate());
         addDetail("mpr ui id", "v-mui", "");
-
-        addMprUiIdTestButtons(p);
     }
 
     private void addDetail(String name, String param, Object value) {
@@ -68,30 +63,5 @@ public class UIInitBrowserDetails extends AbstractReindeerTestUI {
     @Override
     protected Integer getTicketNumber() {
         return Integer.valueOf(9037);
-    }
-
-    private void addMprUiIdTestButtons(Page p) {
-        Button populateMprUiId = new Button("Populate MPR UI id parameter",
-                click -> {
-                    String mprUiId = UUID.randomUUID().toString();
-                    Label mprUiLabel = new Label(mprUiId);
-                    mprUiLabel.setId(EXPECTED_MPR_UI_ID_LABEL_ID);
-                    addComponents(new Label("Expected MPR UI Id"), mprUiLabel);
-                    p.getJavaScript().execute(
-                            "window.vaadin.mprUiId = " + mprUiId + ";");
-                });
-        populateMprUiId.setId(POPULATE_MPR_UI_BUTTON_ID);
-
-        Button triggerMprUiId = new Button("Trigger request with MPR UI id",
-                click -> {
-                    VaadinRequest request = VaadinRequest.getCurrent();
-                    String mprUiId = request.getParameter("v-mui");
-                    Label mprUiLabel = new Label(mprUiId);
-                    mprUiLabel.setId(ACTUAL_MPR_UI_ID_LABEL_ID);
-                    addComponents(new Label("Actual MPR UI Id"), mprUiLabel);
-                });
-        triggerMprUiId.setId(TRIGGER_MPR_UI_BUTTON_ID);
-
-        addComponents(populateMprUiId, triggerMprUiId);
     }
 }

--- a/uitest/src/test/java/com/vaadin/tests/components/ui/UIInitBrowserDetailsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ui/UIInitBrowserDetailsTest.java
@@ -3,10 +3,18 @@ package com.vaadin.tests.components.ui;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+import org.junit.Assert;
 import org.junit.Test;
+import org.openqa.selenium.By;
 
+import com.vaadin.testbench.elements.ButtonElement;
 import com.vaadin.testbench.elements.LabelElement;
 import com.vaadin.tests.tb3.MultiBrowserTest;
+
+import static com.vaadin.tests.components.ui.UIInitBrowserDetails.ACTUAL_MPR_UI_ID_LABEL_ID;
+import static com.vaadin.tests.components.ui.UIInitBrowserDetails.EXPECTED_MPR_UI_ID_LABEL_ID;
+import static com.vaadin.tests.components.ui.UIInitBrowserDetails.POPULATE_MPR_UI_BUTTON_ID;
+import static com.vaadin.tests.components.ui.UIInitBrowserDetails.TRIGGER_MPR_UI_BUTTON_ID;
 
 public class UIInitBrowserDetailsTest extends MultiBrowserTest {
 
@@ -23,6 +31,8 @@ public class UIInitBrowserDetailsTest extends MultiBrowserTest {
         compareRequestAndBrowserValue("v-sw", "screen width", "-1");
         /* screen height */
         compareRequestAndBrowserValue("v-sh", "screen height", "-1");
+        /* mpr ui id */
+        compareRequestAndBrowserValue("v-mui", "mpr ui id", "foo");
         /* timezone offset */
         assertTextNotNull("timezone offset");
         /* raw timezone offset */
@@ -34,6 +44,26 @@ public class UIInitBrowserDetailsTest extends MultiBrowserTest {
         /* current date */
         assertTextNotNull("v-curdate");
         assertTextNotNull("current date");
+    }
+
+    @Test
+    public void testMprUiIdRequestParameter() {
+        openTestURL();
+        waitForElementPresent(By.id(POPULATE_MPR_UI_BUTTON_ID));
+        $(ButtonElement.class).id(POPULATE_MPR_UI_BUTTON_ID).click();
+        waitUntil(driver -> getCommandExecutor().executeScript(
+                "return !!window.vaadin.mprUiId;"));
+        waitForElementPresent(By.id(EXPECTED_MPR_UI_ID_LABEL_ID));
+
+        $(ButtonElement.class).id(TRIGGER_MPR_UI_BUTTON_ID).click();
+        waitForElementPresent(By.id(ACTUAL_MPR_UI_ID_LABEL_ID));
+
+        String expectedMprUiId = $(LabelElement.class).id(
+                EXPECTED_MPR_UI_ID_LABEL_ID).getText();
+        String actualMprUiId =
+                $(LabelElement.class).id(ACTUAL_MPR_UI_ID_LABEL_ID).getText();
+        Assert.assertEquals("Unexpected mpr UI id request parameter",
+                expectedMprUiId, actualMprUiId);
     }
 
     private void compareRequestAndBrowserValue(String paramName,

--- a/uitest/src/test/java/com/vaadin/tests/components/ui/UIInitBrowserDetailsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ui/UIInitBrowserDetailsTest.java
@@ -3,23 +3,15 @@ package com.vaadin.tests.components.ui;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import org.junit.Assert;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
-import com.vaadin.testbench.elements.ButtonElement;
 import com.vaadin.testbench.elements.LabelElement;
 import com.vaadin.tests.tb3.MultiBrowserTest;
-
-import static com.vaadin.tests.components.ui.UIInitBrowserDetails.ACTUAL_MPR_UI_ID_LABEL_ID;
-import static com.vaadin.tests.components.ui.UIInitBrowserDetails.EXPECTED_MPR_UI_ID_LABEL_ID;
-import static com.vaadin.tests.components.ui.UIInitBrowserDetails.POPULATE_MPR_UI_BUTTON_ID;
-import static com.vaadin.tests.components.ui.UIInitBrowserDetails.TRIGGER_MPR_UI_BUTTON_ID;
 
 public class UIInitBrowserDetailsTest extends MultiBrowserTest {
 
     @Test
-    public void testBrowserDetails() throws Exception {
+    public void testBrowserDetails() {
         openTestURL();
         /* location */
         compareRequestAndBrowserValue("v-loc", "location", "null");
@@ -32,7 +24,8 @@ public class UIInitBrowserDetailsTest extends MultiBrowserTest {
         /* screen height */
         compareRequestAndBrowserValue("v-sh", "screen height", "-1");
         /* mpr ui id */
-        compareRequestAndBrowserValue("v-mui", "mpr ui id", "foo");
+        compareRequestAndBrowserValue("v-mui", "mpr ui id",
+                "any-non-empty-value");
         /* timezone offset */
         assertTextNotNull("timezone offset");
         /* raw timezone offset */
@@ -44,26 +37,6 @@ public class UIInitBrowserDetailsTest extends MultiBrowserTest {
         /* current date */
         assertTextNotNull("v-curdate");
         assertTextNotNull("current date");
-    }
-
-    @Test
-    public void testMprUiIdRequestParameter() {
-        openTestURL();
-        waitForElementPresent(By.id(POPULATE_MPR_UI_BUTTON_ID));
-        $(ButtonElement.class).id(POPULATE_MPR_UI_BUTTON_ID).click();
-        waitUntil(driver -> getCommandExecutor().executeScript(
-                "return !!window.vaadin.mprUiId;"));
-        waitForElementPresent(By.id(EXPECTED_MPR_UI_ID_LABEL_ID));
-
-        $(ButtonElement.class).id(TRIGGER_MPR_UI_BUTTON_ID).click();
-        waitForElementPresent(By.id(ACTUAL_MPR_UI_ID_LABEL_ID));
-
-        String expectedMprUiId = $(LabelElement.class).id(
-                EXPECTED_MPR_UI_ID_LABEL_ID).getText();
-        String actualMprUiId =
-                $(LabelElement.class).id(ACTUAL_MPR_UI_ID_LABEL_ID).getText();
-        Assert.assertEquals("Unexpected mpr UI id request parameter",
-                expectedMprUiId, actualMprUiId);
     }
 
     private void compareRequestAndBrowserValue(String paramName,


### PR DESCRIPTION
Includes the MPR UI Content id parameter to the vaadin request, if it exists.
Only MPR is supposed to include it for its needs.
If the plain Vaadin 7,8 is used, this parameter shouldn't exist and added.

Related-to https://github.com/vaadin/multiplatform-runtime/issues/85

**Check when you have completed**
[x] Valid tests for the pull request
[x] Contributing guidelines implemented
