### PR TITLE
Add MPR UI id request parameter

### DIFF
--- a/server/src/main/resources/VAADIN/vaadinBootstrap.js
+++ b/server/src/main/resources/VAADIN/vaadinBootstrap.js
@@ -354,6 +354,12 @@
 				params += '&v-wn=' + encodeURIComponent(window.name);
 			}
 
+			// This parameter is used in multiplatform-runtime as a key for
+			// storing the MPR UI content in the session
+			if (window.mprUiId) {
+				params += '&v-mui=' + encodeURIComponent(window.mprUiId);
+			}
+
 			// Detect touch device support
 			var supportsTouch = false;
 			try {

--- a/uitest/src/main/java/com/vaadin/tests/components/ui/UIInitBrowserDetails.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/ui/UIInitBrowserDetails.java
@@ -37,6 +37,7 @@ public class UIInitBrowserDetails extends AbstractTestUI {
         addDetail("dst saving", "v-dstd", wb.getDSTSavings());
         addDetail("dst in effect", "v-dston", wb.isDSTInEffect());
         addDetail("current date", "v-curdate", wb.getCurrentDate());
+        addDetail("mpr ui id", "v-mui", "");
     }
 
     private void addDetail(String name, String param, Object value) {

--- a/uitest/src/test/java/com/vaadin/tests/components/ui/UIInitBrowserDetailsTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ui/UIInitBrowserDetailsTest.java
@@ -21,6 +21,9 @@ public class UIInitBrowserDetailsTest extends MultiBrowserTest {
         compareRequestAndBrowserValue("v-sw", "screen width", "-1");
         /* screen height */
         compareRequestAndBrowserValue("v-sh", "screen height", "-1");
+        /* mpr ui id */
+        compareRequestAndBrowserValue("v-mui", "mpr ui id",
+                "any-non-empty-value");
         /* timezone offset */
         assertTextNotNull("timezone offset");
         /* raw timezone offset */


### PR DESCRIPTION
Includes the MPR UI Content id parameter to the vaadin request, if it exists.
Only MPR is supposed to include it for its needs.
If the plain Vaadin 7,8 is used, this parameter shouldn't exist and added.

Related-to vaadin/multiplatform-runtime#85
