### PR TITLE
chore: avoid repackaging of google elemental dep and use it directly

### DIFF
--- a/shared/bnd.bnd
+++ b/shared/bnd.bnd
@@ -3,7 +3,6 @@ Bundle-Activator: com.vaadin.osgi.resources.OsgiVaadinResources
 Bundle-Name: Vaadin Shared
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
-Import-Package: org.osgi*
+Import-Package: org.osgi*, elemental.json*
 Export-Package: com.vaadin.osgi.resources;-noimport:=true,\
-  com.vaadin.shared*;-noimport:=true,\
-  elemental.json*;-noimport:=true
+  com.vaadin.shared*;-noimport:=tru

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -33,6 +33,12 @@
             <groupId>org.osgi</groupId>
             <artifactId>osgi.cmpn</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.vaadin.external.gwt</groupId>
+            <artifactId>gwt-elemental</artifactId>
+            <version>2.8.2.vaadin2</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -47,57 +53,6 @@
                         <goals>
                             <goal>filter-sources</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- Copy needed GWT dependencies to package -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack-dependencies</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.google.gwt</groupId>
-                                    <artifactId>gwt-elemental</artifactId>
-                                    <includes>
-                                        elemental/json/**,
-                                        elemental/util/Array*,
-                                        elemental/util/Can*,
-                                        elemental/util/Map*
-                                    </includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- Unpacked Dependencies as source -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-
-                <!-- Needs extra source folder for unpacked dependencies -->
-                <executions>
-                    <execution>
-                        <id>add-source-path</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${dependency.unpack.directory}</source>
-                            </sources>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
The google elemental dependency is not OSGi compatible so it's repackaged
into shared module to use it directly from there. But there is a custom Vaadin version
of google elemental dep and it's OSGi compatible. Flow uses this version and to be able
to use FW in MPR the versions should match. So the Vaadin google elemental dep is added
instead of repackaging.

Thanks for submitting a pull request!
Please confirm that your pull request follows our guidelines found in CONTRIBUTING and that you provide enough information so that we can review your pull request.

<Description of pull request, e.g. "Fix Grid Column not sortable with backend data and sort property">

Fixes #<replace with an issue number>

**Check when you have completed**
[ ] Valid tests for the pull request
[ ] Contributing guidelines implemented
