### PR TITLE
Fix for setting dataproviders when overriding getDataProvider

### DIFF
--- a/server/src/main/java/com/vaadin/ui/Grid.java
+++ b/server/src/main/java/com/vaadin/ui/Grid.java
@@ -4997,7 +4997,7 @@ public class Grid<T> extends AbstractListing<T> implements HasComponents,
 
     @Override
     protected void internalSetDataProvider(DataProvider<T, ?> dataProvider) {
-        boolean newProvider = getDataProvider() != dataProvider;
+        boolean newProvider = internalGetDataProvider() != dataProvider;
         super.internalSetDataProvider(dataProvider);
         if (newProvider) {
             Set<T> oldVisibleDetails = new HashSet<>(


### PR DESCRIPTION

Fixes #12394

Do not call an overridable method from the constructor.