### PR TITLE
fix: Ensure that side effects of readBean does not set hasChanges true

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1891,7 +1891,6 @@ public class Binder<BEAN> implements Serializable {
         if (bean == null) {
             clearFields();
         } else {
-            changedBindings.clear();
             getBindings().forEach(binding -> {
                 // Some bindings may have been removed from binder
                 // during readBean. We should skip those bindings to
@@ -1902,6 +1901,7 @@ public class Binder<BEAN> implements Serializable {
                     binding.initFieldValue(bean, false);
                 }
             });
+            changedBindings.clear();
             getValidationStatusHandler().statusChange(
                     BinderValidationStatus.createUnresolvedStatus(this));
             fireStatusChangeEvent(false);

--- a/server/src/test/java/com/vaadin/data/BinderTest.java
+++ b/server/src/test/java/com/vaadin/data/BinderTest.java
@@ -1518,6 +1518,28 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         assertEquals(new Double(2000), item.getSalaryDouble());
     }
 
+    // See: https://github.com/vaadin/framework/issues/9581
+    @Test
+    public void withConverter_hasChangesFalse() {
+        TextField nameField = new TextField();
+        nameField.setValue("");
+        TextField rentField = new TextField();
+        rentField.setValue("");
+        rentField.addValueChangeListener(event -> {
+            nameField.setValue("Name");
+        });
+        item.setRent(BigDecimal.valueOf(10));
+        binder.forField(nameField).bind(Person::getFirstName, Person::setFirstName);
+        binder.forField(rentField).withConverter(new EuroConverter(""))
+                .withNullRepresentation(BigDecimal.valueOf(0d))
+                .bind(Person::getRent, Person::setRent);
+        binder.readBean(item);
+
+        assertFalse(binder.hasChanges());
+        assertEquals("€ 10.00", rentField.getValue());
+        assertEquals("Name", nameField.getValue());
+    }
+
     private TextField createNullAnd42RejectingFieldWithEmptyValue(
             String emptyValue) {
         return new TextField() {


### PR DESCRIPTION
JavaDoc of hasChanges says

"Check whether any of the bound fields' have uncommitted changes since last explicit call to {@link #readBean(Object)}, {@link #removeBean()}, * {@link #writeBean(Object)} or {@link #writeBeanIfValid(Object)}."

If readBean has converters, they will be run and field values updated accordingly. Furthermore if fields have value change listeners that will produce further changes in values, this should be considered according to above as part of readBean producedure and thus hasChanges still should return false. 

fixes: https://github.com/vaadin/framework/issues/9581