### PR TITLE
chore: Remove obsolete comment and assert in Binder

### DIFF
--- a/server/src/main/java/com/vaadin/data/Binder.java
+++ b/server/src/main/java/com/vaadin/data/Binder.java
@@ -1239,8 +1239,7 @@ public class Binder<BEAN> implements Serializable {
 
         /**
          * Sets the field value by invoking the getter function on the given
-         * bean. The default listener attached to the field will be removed for
-         * the duration of this update.
+         * bean.
          *
          * @param bean
          *            the bean to fetch the property value from
@@ -1252,7 +1251,6 @@ public class Binder<BEAN> implements Serializable {
          */
         private void initFieldValue(BEAN bean, boolean writeBackChangedValues) {
             assert bean != null;
-            assert onValueChange != null;
             valueInit = true;
             try {
                 TARGET originalValue = getter.apply(bean);


### PR DESCRIPTION
The original fix #4205 removed the temporary removal of the value change listener. Thus the comment is no longer valid and assert is no longer needed.