### PR TITLE
Fix compatibility Grid column reorder of partially hidden joined cells.

### DIFF
--- a/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/widgets/Grid.java
@@ -4485,8 +4485,11 @@ public class Grid<T> extends ResizeComposite implements HasSelectionHandlers<T>,
         @Override
         public void onDrop() {
             final int draggedColumnIndex = eventCell.getColumnIndex();
-            final int colspan = header.getRow(eventCell.getRowIndex())
-                    .getCell(eventCell.getColumn()).getColspan();
+            final StaticRow<?> draggedCellRow = header
+                    .getRow(eventCell.getRowIndex());
+            Set<Column<?, ?>> cellGroup = draggedCellRow
+                    .getCellGroupForColumn(getColumn(draggedColumnIndex));
+            final int colspan = cellGroup == null ? 1 : cellGroup.size();
             if (latestColumnDropIndex != draggedColumnIndex
                     && latestColumnDropIndex != draggedColumnIndex + colspan) {
                 List<Column<?, T>> columns = getColumns();

--- a/uitest/src/test/java/com/vaadin/v7/tests/components/grid/GridReorderMergedTest.java
+++ b/uitest/src/test/java/com/vaadin/v7/tests/components/grid/GridReorderMergedTest.java
@@ -24,4 +24,21 @@ public class GridReorderMergedTest extends MultiBrowserTest {
         assertEquals("Unexpected column order,", "6",
                 grid.getHeaderCell(1, 1).getText());
     }
+
+    @Test
+    public void dragMergedReverse() {
+        openTestURL();
+        GridElement grid = $(GridElement.class).first();
+        GridCellElement headerCell0_0 = grid.getHeaderCell(0, 0);
+        GridCellElement headerCell0_4 = grid.getHeaderCell(0, 4);
+        new Actions(driver).clickAndHold(headerCell0_4)
+                .moveByOffset(-headerCell0_0.getSize().getWidth(),
+                        headerCell0_0.getSize().getHeight() / 2)
+                .release().perform();
+
+        // ensure the second merged block got dragged over the first merged
+        // block entirely
+        assertEquals("Unexpected column order,", "6",
+                grid.getHeaderCell(1, 1).getText());
+    }
 }


### PR DESCRIPTION
(#12427)

Adds the fix from #12386 to the drag source as well.

Fixes #12377