### PR TITLE
Fix vaadin-uitest POM file errors

### DIFF
--- a/uitest/pom.xml
+++ b/uitest/pom.xml
@@ -175,7 +175,7 @@
             <!-- Jetty requires 3.1.0 -->
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.0</version> <!--$NO-MVN-MAN-VER$-->
             <scope>provided</scope>
         </dependency>
 
@@ -237,6 +237,11 @@
 
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-maven-plugin</artifactId>
@@ -430,6 +435,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
                         <skip>true</skip>


### PR DESCRIPTION
Fixed errors where Maven complains about the POM for uitest - "could not initialize class org.apache.maven.plugin.war.util.WebappStructureSerializer" and about the 'skip' option being incorrect for maven-javadoc-plugin (because it was missing a groupid declaration). Also silenced warning for explicitly set javax.servlet-api version.
