### PR TITLE
fix(sec): upgrade org.hibernate:hibernate-validator to 6.0.19.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>5.3.6.Final</version>
+                <version>6.0.19.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.hibernate:hibernate-validator 5.3.6.Final
- [CVE-2019-10219](https://www.oscs1024.com/hd/CVE-2019-10219)


### What did I do？
Upgrade org.hibernate:hibernate-validator from 5.3.6.Final to 6.0.19.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS