### PR TITLE
chore: Add a very visible obsoletion message

### DIFF
--- a/server/src/main/java/com/vaadin/server/Constants.java
+++ b/server/src/main/java/com/vaadin/server/Constants.java
@@ -102,6 +102,26 @@ public interface Constants {
             + "VaadinService if you're not using custom class loader.\n"
             + "NullPointerExceptions will be thrown later."
             + "=================================================================";
+    
+    static final String UNMAINTAINED_VERSION_WARNING = "\n"
+            + " .:::::::::::::::::::::::  WARNING  :::::::::::::::::::::::. \n"
+            + "::'                                                       '::\n"
+            + "::                                                         ::\n"
+            + "::                  P L E A S E   N O T E                  ::\n"
+            + "::                                                         ::\n"
+            + "::                                                         ::\n"
+            + "::   This is an unmaintained version of Vaadin Framework   ::\n"
+            + "::               with known security issues.               ::\n"
+            + "::                                                         ::\n"
+            + "::        To upgrade to a maintained version, go to        ::\n"
+            + "::                                                         ::\n"
+            + "::     https://vaadin.com/vaadin-8-extended-maintenance    ::\n"
+            + "::                                                         ::\n"
+            + "::                                                         ::\n"
+            + "::.                                                       .::\n"
+            + " ':::::::::::::::::::::::  WARNING  :::::::::::::::::::::::' \n"
+            + "\n";
+
 
     static final String URL_PARAMETER_THEME = "theme";
 

--- a/server/src/main/java/com/vaadin/server/DefaultDeploymentConfiguration.java
+++ b/server/src/main/java/com/vaadin/server/DefaultDeploymentConfiguration.java
@@ -265,12 +265,15 @@ public class DefaultDeploymentConfiguration
 
     /**
      * Log a warning if Vaadin is not running in production mode.
+     *
+     * Also show a warning about unmaintained version.
      */
     private void checkProductionMode() {
         productionMode = getApplicationOrSystemProperty(
                 Constants.SERVLET_PARAMETER_PRODUCTION_MODE, "false")
                         .equals("true");
         if (!productionMode) {
+            getLogger().warning(Constants.UNMAINTAINED_VERSION_WARNING);
             getLogger().warning(Constants.NOT_PRODUCTION_MODE_INFO);
         }
     }


### PR DESCRIPTION
Adds a warning banner to the Vaadin startup when not in production mode, warning the user about known security vulnerabilities and encouraging them to upgrade to a supported version.