### PR TITLE
chore: Downgrade snapshot version for free version

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-all</artifactId>
     <name>vaadin-all</name>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -11,7 +11,7 @@
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-bom</artifactId>
     <packaging>pom</packaging>
-    <version>8.15-SNAPSHOT</version>
+    <version>8.14-SNAPSHOT</version>
     <name>Vaadin Framework (Bill of Materials)</name>
     <description>Vaadin Framework (Bill of Materials)</description>
     <url>http://vaadin.com</url>

--- a/client-compiled/pom.xml
+++ b/client-compiled/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <!-- Needed by a plugin in release build -->
     <groupId>com.vaadin</groupId>

--- a/client-compiler/pom.xml
+++ b/client-compiler/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-client-compiler</artifactId>
     <name>vaadin-client-compiler</name>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <!-- Needed by a plugin in release build -->
     <groupId>com.vaadin</groupId>

--- a/compatibility-client-compiled/pom.xml
+++ b/compatibility-client-compiled/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-compatibility-client-compiled</artifactId>
     <name>vaadin-compatibility-client-compiled</name>

--- a/compatibility-client/pom.xml
+++ b/compatibility-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-compatibility-client</artifactId>
     <name>vaadin-compatibility-client</name>

--- a/compatibility-server-gae/pom.xml
+++ b/compatibility-server-gae/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-compatibility-server-gae</artifactId>
     <name>vaadin-compatibility-server-gae</name>

--- a/compatibility-server/pom.xml
+++ b/compatibility-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-compatibility-server</artifactId>
     <name>vaadin-compatibility-server</name>

--- a/compatibility-shared/pom.xml
+++ b/compatibility-shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-compatibility-shared</artifactId>
     <name>vaadin-compatibility-shared</name>

--- a/compatibility-themes/pom.xml
+++ b/compatibility-themes/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-compatibility-themes</artifactId>
     <name>vaadin-compatibility-themes</name>

--- a/liferay-integration/pom.xml
+++ b/liferay-integration/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/liferay/pom.xml
+++ b/liferay/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-liferay</artifactId>
     <name>vaadin-liferay</name>

--- a/osgi-integration/pom.xml
+++ b/osgi-integration/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>vaadin-root</artifactId>
     <name>vaadin-root</name>
     <packaging>pom</packaging>
-    <version>8.15-SNAPSHOT</version>
+    <version>8.14-SNAPSHOT</version>
 
     <prerequisites>
         <maven>3.1.0</maven>

--- a/push/pom.xml
+++ b/push/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-push</artifactId>
     <name>vaadin-push</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-server</artifactId>
     <name>vaadin-server</name>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-shared</artifactId>
     <name>vaadin-shared</name>

--- a/test/addon-using-init-param-widget-set/pom.xml
+++ b/test/addon-using-init-param-widget-set/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-addon-using-init-param-widget-set</artifactId>
     <packaging>war</packaging>

--- a/test/addon-using-no-defined-widget-set/pom.xml
+++ b/test/addon-using-no-defined-widget-set/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-addon-using-no-defined-widget-set</artifactId>
     <packaging>war</packaging>

--- a/test/addon-using-own-widget-set/pom.xml
+++ b/test/addon-using-own-widget-set/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-addon-using-own-widget-set</artifactId>
     <packaging>war</packaging>

--- a/test/bean-api-validation/pom.xml
+++ b/test/bean-api-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-bean-api-validation</artifactId>
     <packaging>jar</packaging>

--- a/test/bean-impl-validation/pom.xml
+++ b/test/bean-impl-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-bean-impl-validation</artifactId>
     <packaging>jar</packaging>

--- a/test/cdi/pom.xml
+++ b/test/cdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-cdi</artifactId>
     <packaging>war</packaging>

--- a/test/default-widget-set/pom.xml
+++ b/test/default-widget-set/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-default-widget-set</artifactId>
     <packaging>war</packaging>

--- a/test/dependency-rewrite-addon/pom.xml
+++ b/test/dependency-rewrite-addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-dependency-rewrite-addon</artifactId>
     <packaging>jar</packaging>

--- a/test/dependency-rewrite/pom.xml
+++ b/test/dependency-rewrite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-dependency-rewrite</artifactId>
     <packaging>war</packaging>

--- a/test/own-widget-set/pom.xml
+++ b/test/own-widget-set/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-own-widget-set</artifactId>
     <packaging>war</packaging>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-test</artifactId>
     <name>vaadin-test</name>
-    <version>8.15-SNAPSHOT</version>
+    <version>8.14-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <properties>

--- a/test/servlet-containers/generic-tests/pom.xml
+++ b/test/servlet-containers/generic-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-server-tests</artifactId>
     <name>vaadin-test-server-tests</name>

--- a/test/servlet-containers/generic-ui/pom.xml
+++ b/test/servlet-containers/generic-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-server-ui</artifactId>
     <name>vaadin-test-server-ui</name>

--- a/test/servlet-containers/generic/pom.xml
+++ b/test/servlet-containers/generic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-generic-integration</artifactId>
     <name>vaadin-test-generic-integration</name>

--- a/test/servlet-containers/glassfish/pom.xml
+++ b/test/servlet-containers/glassfish/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-glassfish-server</artifactId>
     <name>Vaadin Glassfish Test</name>

--- a/test/servlet-containers/jetty8/pom.xml
+++ b/test/servlet-containers/jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-jetty8-server</artifactId>
     <name>Vaadin Jetty 8 Test</name>

--- a/test/servlet-containers/jetty9/pom.xml
+++ b/test/servlet-containers/jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-jetty9-server</artifactId>
     <name>Vaadin Jetty 9 Test</name>

--- a/test/servlet-containers/jsp-integration/pom.xml
+++ b/test/servlet-containers/jsp-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-jsp-integration</artifactId>
     <name>vaadin-test-jsp-integration</name>

--- a/test/servlet-containers/karaf/karaf-run/pom.xml
+++ b/test/servlet-containers/karaf/karaf-run/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vaadin-test-karaf</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test/servlet-containers/karaf/pom.xml
+++ b/test/servlet-containers/karaf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-karaf</artifactId>
     <packaging>pom</packaging>

--- a/test/servlet-containers/karaf/vaadin-karaf-bundle1/pom.xml
+++ b/test/servlet-containers/karaf/vaadin-karaf-bundle1/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test-karaf</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-karaf-bundle1</artifactId>
     <packaging>jar</packaging>

--- a/test/servlet-containers/karaf/vaadin-karaf-bundle2/pom.xml
+++ b/test/servlet-containers/karaf/vaadin-karaf-bundle2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>vaadin-test-karaf</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-karaf-bundle2</artifactId>
     <packaging>jar</packaging>

--- a/test/servlet-containers/liberty-javaee/pom.xml
+++ b/test/servlet-containers/liberty-javaee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-liberty-javaee-server</artifactId>
     <name>Vaadin Liberty JavaEE7 Test</name>

--- a/test/servlet-containers/liberty-microprofile/pom.xml
+++ b/test/servlet-containers/liberty-microprofile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-liberty-microprofile-server</artifactId>
     <name>Vaadin Liberty MicroProfile Test</name>

--- a/test/servlet-containers/liberty-webprofile/pom.xml
+++ b/test/servlet-containers/liberty-webprofile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-liberty-webprofile-server</artifactId>
     <name>Vaadin Liberty WebProfile Test</name>

--- a/test/servlet-containers/payara-micro/pom.xml
+++ b/test/servlet-containers/payara-micro/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-payara-micro-server</artifactId>
     <name>Vaadin Payara Micro Test</name>

--- a/test/servlet-containers/pom.xml
+++ b/test/servlet-containers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-servlet-containers-test</artifactId>
     <name>vaadin-servlet-containers-test</name>

--- a/test/servlet-containers/tomcat7/pom.xml
+++ b/test/servlet-containers/tomcat7/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-tomcat7-server</artifactId>
     <name>Vaadin Tomcat 7 Test</name>

--- a/test/servlet-containers/tomcat80/pom.xml
+++ b/test/servlet-containers/tomcat80/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-tomcat80-server</artifactId>
     <name>Vaadin Tomcat 8.0 Test</name>

--- a/test/servlet-containers/tomcat85/pom.xml
+++ b/test/servlet-containers/tomcat85/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-tomcat85-server</artifactId>
     <name>Vaadin Tomcat 8.5 Test</name>

--- a/test/servlet-containers/tomcat9/pom.xml
+++ b/test/servlet-containers/tomcat9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-tomcat9-server</artifactId>
     <name>Vaadin Tomcat 9 Test</name>

--- a/test/servlet-containers/wildfly-swarm/pom.xml
+++ b/test/servlet-containers/wildfly-swarm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-wildfly-swarm-server</artifactId>
     <name>Vaadin Wildfly Swarm Test</name>

--- a/test/servlet-containers/wildfly10/pom.xml
+++ b/test/servlet-containers/wildfly10/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-wildfly10-server</artifactId>
     <name>Vaadin Wildfly 10 Test</name>

--- a/test/servlet-containers/wildfly11/pom.xml
+++ b/test/servlet-containers/wildfly11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-wildfly11-server</artifactId>
     <name>Vaadin Wildfly 11 Test</name>

--- a/test/servlet-containers/wildfly12/pom.xml
+++ b/test/servlet-containers/wildfly12/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-wildfly12-server</artifactId>
     <name>Vaadin Wildfly 12 Test</name>

--- a/test/servlet-containers/wildfly13/pom.xml
+++ b/test/servlet-containers/wildfly13/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-wildfly13-server</artifactId>
     <name>Vaadin Wildfly 13 Test</name>

--- a/test/servlet-containers/wildfly8/pom.xml
+++ b/test/servlet-containers/wildfly8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-wildfly8-server</artifactId>
     <name>Vaadin Wildfly 8 Test</name>

--- a/test/servlet-containers/wildfly9/pom.xml
+++ b/test/servlet-containers/wildfly9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-servlet-containers-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-wildfly9-server</artifactId>
     <name>Vaadin Wildfly 9 Test</name>

--- a/test/space in directory/pom.xml
+++ b/test/space in directory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-space-in-directory</artifactId>
     <packaging>war</packaging>

--- a/test/spring-boot-subcontext/pom.xml
+++ b/test/spring-boot-subcontext/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-subcontext</artifactId>
     <packaging>jar</packaging>

--- a/test/spring-boot/pom.xml
+++ b/test/spring-boot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot</artifactId>
     <packaging>jar</packaging>

--- a/test/vaadin7-widget-set/pom.xml
+++ b/test/vaadin7-widget-set/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-vaadin7-widget-set</artifactId>
     <packaging>war</packaging>

--- a/test/vaadinservletconfiguration-widget-set/pom.xml
+++ b/test/vaadinservletconfiguration-widget-set/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-test</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-vaadinservletconfiguration-widget-set</artifactId>
     <packaging>war</packaging>

--- a/test/widget-set-testutil/pom.xml
+++ b/test/widget-set-testutil/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-test-widget-set-testutil</artifactId>
-    <version>8.15-SNAPSHOT</version>
+    <version>8.14-SNAPSHOT</version>
     <packaging>jar</packaging>
     <!-- 
         This module does not inherit the vaadin-test on purpose. It is done 

--- a/testbench-api/pom.xml
+++ b/testbench-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-api</artifactId>
     <name>vaadin-testbench-api</name>

--- a/themes/pom.xml
+++ b/themes/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-themes</artifactId>
     <name>vaadin-themes</name>

--- a/uitest/pom.xml
+++ b/uitest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-root</artifactId>
-        <version>8.15-SNAPSHOT</version>
+        <version>8.14-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-uitest</artifactId>
     <name>vaadin-uitest</name>


### PR DESCRIPTION
The free version of Vaadin 8 is going to stay on 8.14.x, therefore the snapshot version should be set to 8.14-SNAPSHOT.