### PR TITLE
Switched from java.io to  java.nio for safer temp file generation

### DIFF
--- a/client-compiler/src/test/java/com/vaadin/tools/CvalCheckerTest.java
+++ b/client-compiler/src/test/java/com/vaadin/tools/CvalCheckerTest.java
@@ -25,6 +25,7 @@ import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.prefs.Preferences;
@@ -288,7 +289,7 @@ public class CvalCheckerTest {
         testManifest.getMainAttributes().putValue(VAADIN_ADDON_VERSION, "2");
 
         // Create a temporary Jar
-        File testJarFile = File.createTempFile("vaadin." + productName, ".jar");
+        File testJarFile = Files.createTempFile("vaadin." + productName, ".jar").toFile();
         testJarFile.deleteOnExit();
         JarOutputStream target = new JarOutputStream(
                 new FileOutputStream(testJarFile), testManifest);
@@ -357,7 +358,7 @@ public class CvalCheckerTest {
 
     @Test
     public void testReadKeyFromFile_LicenseFileEmpty() throws Exception {
-        File tmpLicenseFile = File.createTempFile("license", "lic");
+        File tmpLicenseFile = Files.createTempFile("license", "lic").toFile();
 
         assertNull(licenseChecker
                 .readKeyFromFile(tmpLicenseFile.toURI().toURL(), 4));
@@ -368,7 +369,7 @@ public class CvalCheckerTest {
     @Test
     public void testReadKeyFromFile_LicenseFileHasSingleUnidentifiedKey()
             throws Exception {
-        File tmpLicenseFile = File.createTempFile("license", "lic");
+        File tmpLicenseFile = Files.createTempFile("license", "lic").toFile();
         PrintWriter out = new PrintWriter(tmpLicenseFile);
         out.println("this-is-a-license");
         out.close();
@@ -382,7 +383,7 @@ public class CvalCheckerTest {
     @Test
     public void testReadKeyFromFile_LicenseFileHasSingleIdentifiedKey()
             throws Exception {
-        File tmpLicenseFile = File.createTempFile("license", "lic");
+        File tmpLicenseFile = Files.createTempFile("license", "lic").toFile();
         PrintWriter out = new PrintWriter(tmpLicenseFile);
         out.println("4=this-is-a-license");
         out.close();
@@ -396,7 +397,7 @@ public class CvalCheckerTest {
     @Test
     public void testReadKeyFromFile_LicenseFileHasMultipleKeys()
             throws Exception {
-        File tmpLicenseFile = File.createTempFile("license", "lic");
+        File tmpLicenseFile = Files.createTempFile("license", "lic").toFile();
         PrintWriter out = new PrintWriter(tmpLicenseFile);
         out.println("4=this-is-a-license");
         out.println("5=this-is-another-license");
@@ -413,7 +414,7 @@ public class CvalCheckerTest {
     @Test
     public void testReadKeyFromFile_LicenseFileHasMultipleKeysWithWhitespace()
             throws Exception {
-        File tmpLicenseFile = File.createTempFile("license", "lic");
+        File tmpLicenseFile = Files.createTempFile("license", "lic").toFile();
         PrintWriter out = new PrintWriter(tmpLicenseFile);
         out.println("4 = this-is-a-license");
         out.println("5 = this-is-another-license");
@@ -429,7 +430,7 @@ public class CvalCheckerTest {
 
     @Test
     public void testReadKeyFromFile_RequestedVersionMissing() throws Exception {
-        File tmpLicenseFile = File.createTempFile("license", "lic");
+        File tmpLicenseFile = Files.createTempFile("license", "lic").toFile();
         PrintWriter out = new PrintWriter(tmpLicenseFile);
         out.println("4 = this-is-a-license");
         out.println("5 = this-is-another-license");
@@ -443,7 +444,7 @@ public class CvalCheckerTest {
 
     @Test
     public void testReadKeyFromFile_FallbackToDefaultKey() throws Exception {
-        File tmpLicenseFile = File.createTempFile("license", "lic");
+        File tmpLicenseFile = Files.createTempFile("license", "lic").toFile();
         PrintWriter out = new PrintWriter(tmpLicenseFile);
         out.println("this-is-a-license");
         out.println("5 = this-is-another-license");
@@ -462,7 +463,7 @@ public class CvalCheckerTest {
     @Test
     public void testReadKeyFromFile_FallbackToDefaultKeyReversed()
             throws Exception {
-        File tmpLicenseFile = File.createTempFile("license", "lic");
+        File tmpLicenseFile = Files.createTempFile("license", "lic").toFile();
         PrintWriter out = new PrintWriter(tmpLicenseFile);
         out.println("5 = this-is-another-license");
         out.println("this-is-a-license");

--- a/uitest/src/main/java/com/vaadin/tests/TestForStyledUpload.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForStyledUpload.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
+import java.nio.file.Files;
 
 import com.vaadin.server.LegacyApplication;
 import com.vaadin.server.StreamResource;
@@ -172,7 +173,7 @@ public class TestForStyledUpload extends LegacyApplication
             final String tempFileName = "upload_tmpfile_"
                     + System.currentTimeMillis();
             try {
-                file = File.createTempFile(tempFileName, null);
+                file = Files.createTempFile(tempFileName, null).toFile();
             } catch (final IOException e) {
                 e.printStackTrace();
             }

--- a/uitest/src/main/java/com/vaadin/tests/TestForUpload.java
+++ b/uitest/src/main/java/com/vaadin/tests/TestForUpload.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
+import java.nio.file.Files;
 
 import com.vaadin.server.StreamResource;
 import com.vaadin.shared.ui.ContentMode;
@@ -299,7 +300,7 @@ public class TestForUpload extends CustomComponent
             final String tempFileName = "upload_tmpfile_"
                     + System.currentTimeMillis();
             try {
-                file = File.createTempFile(tempFileName, null);
+                file = Files.createTempFile(tempFileName, null).toFile();
             } catch (final IOException e) {
                 e.printStackTrace();
             }

--- a/uitest/src/main/java/com/vaadin/tests/components/FileDownloaderUI.java
+++ b/uitest/src/main/java/com/vaadin/tests/components/FileDownloaderUI.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -62,7 +63,7 @@ public class FileDownloaderUI extends AbstractTestUIWithLog {
         }, "demo.png");
         addComponents("Dynamic image", resource, components);
         try {
-            File hugeFile = File.createTempFile("huge", ".txt");
+            File hugeFile = Files.createTempFile("huge", ".txt").toFile();
             hugeFile.deleteOnExit();
             BufferedOutputStream os = new BufferedOutputStream(
                     new FileOutputStream(hugeFile));

--- a/uitest/src/main/java/com/vaadin/tests/containers/filesystemcontainer/FileSystemContainerInTreeTable.java
+++ b/uitest/src/main/java/com/vaadin/tests/containers/filesystemcontainer/FileSystemContainerInTreeTable.java
@@ -2,6 +2,7 @@ package com.vaadin.tests.containers.filesystemcontainer;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,7 +27,7 @@ public class FileSystemContainerInTreeTable extends TestBase {
 
         final File folder;
         try {
-            File tempFile = File.createTempFile("fsc-tt", "");
+            File tempFile = Files.createTempFile("fsc-tt", "").toFile();
             tempFile.delete();
             folder = new File(tempFile.getParent(), tempFile.getName());
             folder.mkdir();

--- a/uitest/src/main/java/com/vaadin/tests/resources/DownloadLargeFileResource.java
+++ b/uitest/src/main/java/com/vaadin/tests/resources/DownloadLargeFileResource.java
@@ -4,6 +4,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import com.vaadin.server.FileResource;
 import com.vaadin.tests.components.TestBase;
@@ -32,7 +33,7 @@ public class DownloadLargeFileResource extends TestBase {
 
     private void createFile() {
         try {
-            File hugeFile = File.createTempFile("huge", ".txt");
+            File hugeFile = Files.createTempFile("huge", ".txt").toFile();
             hugeFile.deleteOnExit();
             BufferedOutputStream os = new BufferedOutputStream(
                     new FileOutputStream(hugeFile));

--- a/uitest/src/test/java/com/vaadin/tests/components/ui/MultiFileUploadTestTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/ui/MultiFileUploadTestTest.java
@@ -7,6 +7,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -54,7 +55,7 @@ public class MultiFileUploadTestTest extends MultiBrowserTest {
      * @throws IOException
      */
     private File createTempFile() throws IOException {
-        File tempFile = File.createTempFile("TestFileUpload", ".txt");
+        File tempFile = Files.createTempFile("TestFileUpload", ".txt").toFile();
         BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
         writer.write(getTempFileContents());
         writer.close();

--- a/uitest/src/test/java/com/vaadin/tests/components/upload/DisablingUploadTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/upload/DisablingUploadTest.java
@@ -4,6 +4,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.Test;
 import org.openqa.selenium.WebElement;
@@ -175,7 +176,7 @@ public class DisablingUploadTest extends SingleBrowserTest {
      * @throws IOException
      */
     private File createTempFile(boolean large) throws IOException {
-        File tempFile = File.createTempFile("TestFileUpload", ".txt");
+        File tempFile = Files.createTempFile("TestFileUpload", ".txt").toFile();
         BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
         if (large) {
             writer.write(getLargeTempFileContents());

--- a/uitest/src/test/java/com/vaadin/tests/components/upload/InterruptUploadTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/upload/InterruptUploadTest.java
@@ -4,6 +4,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -72,7 +73,7 @@ public class InterruptUploadTest extends MultiBrowserTest {
      * @throws IOException
      */
     private File createTempFile() throws IOException {
-        File tempFile = File.createTempFile("TestFileUpload", ".txt");
+        File tempFile = Files.createTempFile("TestFileUpload", ".txt").toFile();
         BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
         writer.write(getTempFileContents());
         writer.close();

--- a/uitest/src/test/java/com/vaadin/tests/components/upload/TestFileUploadTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/upload/TestFileUploadTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -54,7 +55,7 @@ public class TestFileUploadTest extends MultiBrowserTest {
      * @throws IOException
      */
     private File createTempFile() throws IOException {
-        File tempFile = File.createTempFile("TestFileUpload", ".txt");
+        File tempFile = Files.createTempFile("TestFileUpload", ".txt").toFile();
         BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
         writer.write(getTempFileContents());
         writer.close();

--- a/uitest/src/test/java/com/vaadin/tests/components/upload/TestUploadMIMETypeTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/upload/TestUploadMIMETypeTest.java
@@ -15,6 +15,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 
 import static com.vaadin.tests.components.upload.TestUploadMIMEType.TEST_MIME_TYPE;
@@ -52,7 +53,7 @@ public class TestUploadMIMETypeTest extends MultiBrowserTest {
      * @throws IOException
      */
     private File createTempFile() throws IOException {
-        File tempFile = File.createTempFile("TestFileUpload", ".pdf");
+        File tempFile = Files.createTempFile("TestFileUpload", ".pdf").toFile();
         BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
         writer.write(getTempFileContents());
         writer.close();

--- a/uitest/src/test/java/com/vaadin/tests/components/upload/UploadChangeListenerTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/upload/UploadChangeListenerTest.java
@@ -6,6 +6,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -46,7 +47,7 @@ public class UploadChangeListenerTest extends MultiBrowserTest {
      * @throws IOException
      */
     private File createTempFile() throws IOException {
-        File tempFile = File.createTempFile("TestFileUpload", ".txt");
+        File tempFile = Files.createTempFile("TestFileUpload", ".txt").toFile();
         BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
         writer.write(getTempFileContents());
         writer.close();

--- a/uitest/src/test/java/com/vaadin/tests/components/upload/UploadInTabsheetTest.java
+++ b/uitest/src/test/java/com/vaadin/tests/components/upload/UploadInTabsheetTest.java
@@ -4,6 +4,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -40,7 +41,7 @@ public class UploadInTabsheetTest extends MultiBrowserTest {
      * @throws IOException
      */
     private File createTempFile() throws IOException {
-        File tempFile = File.createTempFile("TestFileUpload", ".txt");
+        File tempFile = Files.createTempFile("TestFileUpload", ".txt").toFile();
         BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
         writer.write(getTempFileContents());
         writer.close();

--- a/uitest/src/test/java/com/vaadin/v7/tests/components/upload/TestFileUploadTest.java
+++ b/uitest/src/test/java/com/vaadin/v7/tests/components/upload/TestFileUploadTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -54,7 +55,7 @@ public class TestFileUploadTest extends MultiBrowserTest {
      * @throws IOException
      */
     private File createTempFile() throws IOException {
-        File tempFile = File.createTempFile("TestFileUpload", ".txt");
+        File tempFile = Files.createTempFile("TestFileUpload", ".txt").toFile();
         BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
         writer.write(getTempFileContents());
         writer.close();


### PR DESCRIPTION
Following our own best practices, we should no longer use the older java.io to create temporary files as it uses less safe defaults than java.nio's implementation.