### PR TITLE
fix: improve iPad detection to check for maxTouchPoints

### DIFF
--- a/shared/src/main/java/com/vaadin/shared/VBrowserDetails.java
+++ b/shared/src/main/java/com/vaadin/shared/VBrowserDetails.java
@@ -222,7 +222,8 @@ public class VBrowserDetails implements Serializable {
         } else if (userAgent.contains("macintosh")
                 || userAgent.contains("mac osx")
                 || userAgent.contains("mac os x")) {
-            isIPad = userAgent.contains("ipad");
+            boolean isMultiTouch = getMaxTouchPoints() > 2;
+            isIPad = userAgent.contains("ipad") || isMultiTouch;
             isIPhone = userAgent.contains("iphone");
             if (isIPad || userAgent.contains("ipod") || isIPhone) {
                 os = OperatingSystem.IOS;
@@ -236,6 +237,10 @@ public class VBrowserDetails implements Serializable {
             parseChromeOSVersion(userAgent);
         }
     }
+
+    private native int getMaxTouchPoints() /*-{
+        return navigator.maxTouchPoints || 0;
+    }-*/;
 
     // (X11; CrOS armv7l 6946.63.0)
     private void parseChromeOSVersion(String userAgent) {


### PR DESCRIPTION
It's not enough to check if the UA string contains the word `ipad` to detect the user's device as in some cases, an iPad browser can report the UA as `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Safari/605.1.15`. In such cases, the client won't be able to correctly detect the user's device, which could lead to some features not being available. That's the case for [this issue reported in Spreadsheet](https://github.com/vaadin/flow-components/issues/8155), where the context menu does not work in iPad devices, since the Spreadsheet client tries to detect an iOS device to add a polyfill for the `contextmenu` event that is not present in iPhones/iPads.

To work around this issue, this proposal tries to check for the `navigator.maxTouchPoints` value when it detects that it is running in an Apple device. Since Apple desktop devices do not support multi-touching, it is safe to assume that any value greater than 1 (using 2 just to play safe) is from an iPad device.

Not sure how to add a test for this, but it can be manually tested using the Device Simulator in MacOS.

Fixes https://github.com/vaadin/flow-components/issues/8155